### PR TITLE
call slurm commands from inside singularity container

### DIFF
--- a/sms_api/common/hpc/slurm_service.py
+++ b/sms_api/common/hpc/slurm_service.py
@@ -14,6 +14,17 @@ class SlurmService:
     def __init__(self, ssh_service: SSHService):
         self.ssh_service = ssh_service
 
+    async def get_job_status(self, job_ids: list[int] | None = None) -> list[SlurmJob]:
+        """
+        Get job status using squeue first, if no jobs are found and job_ids is not None,
+        then use sacct to get the job status.
+        """
+        slurm_jobs_from_squeue = await self.get_job_status_squeue(job_ids)
+        slurm_jobs_from_sacct = await self.get_job_status_sacct(job_ids)
+        slurm_job_map = {job.job_id: job for job in slurm_jobs_from_squeue}
+        slurm_job_map.update({job.job_id: job for job in slurm_jobs_from_sacct})
+        return list(slurm_job_map.values())
+
     async def get_job_status_squeue(self, job_ids: list[int] | None = None) -> list[SlurmJob]:
         command = f'squeue -u $USER --noheader --format="{SlurmJob.get_squeue_format_string()}"'
         if job_ids is not None:

--- a/tests/common/test_slurm_broker.py
+++ b/tests/common/test_slurm_broker.py
@@ -1,0 +1,70 @@
+from typing import Generator
+
+import pytest
+import subprocess
+import tempfile
+import os
+import socket
+import time
+import sys
+
+SOCKET_PATH = "/tmp/slurm_broker.sock"
+
+@pytest.fixture(scope="module")
+def broker_and_fake_sbatch() -> Generator[str, None, None]:
+    # Create a fake sbatch script for testing
+    tempdir = tempfile.TemporaryDirectory()
+    fake_sbatch = os.path.join(tempdir.name, "sbatch")
+    with open(fake_sbatch, "w") as f:
+        f.write("#!/bin/sh\necho FAKE_SBATCH_OK\n")
+    os.chmod(fake_sbatch, 0o755)
+
+    # Patch ALLOWED_COMMANDS in the broker to use our fake sbatch
+    broker_path = os.path.abspath("../fixtures/scripts/slurm_broker.py")
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.getcwd()
+    env["FAKE_SBATCH"] = fake_sbatch
+
+    # Start the broker as a subprocess
+    proc = subprocess.Popen(
+        [sys.executable, broker_path, SOCKET_PATH],
+        env=env,
+    )
+    # Wait for the socket to appear
+    for _ in range(20):
+        if os.path.exists(SOCKET_PATH):
+            break
+        time.sleep(0.1)
+    else:
+        proc.terminate()
+        tempdir.cleanup()
+        raise RuntimeError("Broker socket did not appear")
+
+    yield fake_sbatch
+
+    proc.terminate()
+    proc.wait(timeout=5)
+    tempdir.cleanup()
+    if os.path.exists(SOCKET_PATH):
+        os.remove(SOCKET_PATH)
+
+
+def test_sbatch(broker_and_fake_sbatch: str) -> None:
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+        client.connect(SOCKET_PATH)
+        client.sendall(b"sbatch --help\n")
+        data = b""
+        while True:
+            chunk = client.recv(4096)
+            if not chunk:
+                break
+            data += chunk
+    assert b"FAKE_SBATCH_OK" in data
+
+
+def test_invalid_command(broker_and_fake_sbatch: str) -> None:
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+        client.connect(SOCKET_PATH)
+        client.sendall(b"notallowed\n")
+        data = client.recv(4096)
+    assert b"ERROR: Command not allowed" in data

--- a/tests/common/test_slurm_broker.py
+++ b/tests/common/test_slurm_broker.py
@@ -1,14 +1,15 @@
-from typing import Generator
-
-import pytest
-import subprocess
-import tempfile
 import os
 import socket
-import time
+import subprocess
 import sys
+import tempfile
+import time
+from collections.abc import Generator
 
-SOCKET_PATH = "/tmp/slurm_broker.sock"
+import pytest
+
+SOCKET_PATH = "slurm_broker.sock"
+
 
 @pytest.fixture(scope="module")
 def broker_and_fake_sbatch() -> Generator[str, None, None]:
@@ -17,7 +18,7 @@ def broker_and_fake_sbatch() -> Generator[str, None, None]:
     fake_sbatch = os.path.join(tempdir.name, "sbatch")
     with open(fake_sbatch, "w") as f:
         f.write("#!/bin/sh\necho FAKE_SBATCH_OK\n")
-    os.chmod(fake_sbatch, 0o755)
+    os.chmod(fake_sbatch, 0o500)
 
     # Patch ALLOWED_COMMANDS in the broker to use our fake sbatch
     broker_path = os.path.abspath("../fixtures/scripts/slurm_broker.py")
@@ -26,7 +27,7 @@ def broker_and_fake_sbatch() -> Generator[str, None, None]:
     env["FAKE_SBATCH"] = fake_sbatch
 
     # Start the broker as a subprocess
-    proc = subprocess.Popen(
+    proc = subprocess.Popen(  # noqa: S603
         [sys.executable, broker_path, SOCKET_PATH],
         env=env,
     )

--- a/tests/common/test_slurm_singularity.py
+++ b/tests/common/test_slurm_singularity.py
@@ -1,0 +1,187 @@
+import tempfile
+import time
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from sms_api.common.hpc.models import SlurmJob
+from sms_api.common.hpc.slurm_service import SlurmService
+from sms_api.config import get_settings
+
+
+slurm_broker_py_contents = dedent(f"""
+import asyncio
+import os
+import socket
+import struct
+import sys
+from asyncio import StreamReader, StreamWriter
+
+ALLOWED_COMMANDS = {{
+    "/usr/bin/sbatch": ["sbatch"],
+    "/usr/bin/squeue": ["squeue"],
+    "/usr/bin/sacct": ["sacct"],
+}}
+
+async def handle_client(reader: StreamReader, writer: StreamWriter) -> None:
+
+    try:
+        sock = writer.get_extra_info("socket")
+        ucred = sock.getsockopt(socket.SOL_SOCKET, socket.SO_PEERCRED, struct.calcsize("3i"))
+        pid, peer_uid, gid = struct.unpack("3i", ucred)
+        if peer_uid != os.getuid():
+            writer.write(b"ERROR: UID mismatch\\n")
+            await writer.drain()
+            writer.close()
+            return
+
+        data = await reader.readline()
+        if not data:
+            writer.close()
+            return
+        parts = data.decode().strip().split()
+        if not parts or parts[0] not in ALLOWED_COMMANDS.keys():
+            writer.write(f"ERROR: Command '{{parts}}' not allowed\\n".encode())
+            await writer.drain()
+            writer.close()
+            return
+        cmd = list(ALLOWED_COMMANDS[parts[0]]) + parts[1:]
+        proc = await asyncio.create_subprocess_exec(
+            *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+        )
+        stdout, stderr = await proc.communicate()
+        writer.write(stdout)
+        if stderr:
+            writer.write(b"\\nERROR:\\n" + stderr)
+        await writer.drain()
+    except Exception as e:
+        writer.write(f"ERROR: {{e}}\\n".encode())
+        await writer.drain()
+    finally:
+        writer.close()
+
+async def main(socket_path: str) -> None:
+    if os.path.exists(socket_path):
+        os.remove(socket_path)
+    server = await asyncio.start_unix_server(handle_client, path=socket_path)
+    os.chmod(socket_path, 0o700)
+    async with server:
+        await server.serve_forever()
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2 or sys.argv[1] in ("-h", "--help"):
+        print(f"Usage: {{sys.argv[0]}} SOCKET_PATH")
+        sys.exit(1)
+    socket_path = sys.argv[1]
+    try:
+        asyncio.run(main(socket_path))
+    except KeyboardInterrupt:
+        print("Broker stopped.")
+""")
+
+
+singularity_def_contents = dedent(f"""
+    Bootstrap: docker
+    From: alpine:latest
+    
+    %post
+        apk add --no-cache socat bash
+    
+        cat <<'EOF' > /usr/bin/sbatch
+    #!/bin/sh
+    echo "$0 $@" | socat - UNIX-CONNECT:$UNIX_SOCKET_PATH
+    EOF
+        chmod +x /usr/bin/sbatch
+    
+        cat <<'EOF' > /usr/bin/squeue
+    #!/bin/sh
+    echo "$0 $@" | socat - UNIX-CONNECT:$UNIX_SOCKET_PATH
+    EOF
+        chmod +x /usr/bin/squeue
+     
+        cat <<'EOF' > /usr/bin/sacct
+    #!/bin/sh
+    echo "$0 $@" | socat - UNIX-CONNECT:$UNIX_SOCKET_PATH
+    EOF
+        chmod +x /usr/bin/sacct
+
+    """)
+
+
+sbatch_file_contents = dedent(f"""\
+#!/bin/bash
+#SBATCH --job-name=my_test_job        # Job name
+#SBATCH --output=slurm_test.out       # Standard output file (same)
+#SBATCH --error=slurm_test.out        # Standard error file (same)
+#SBATCH --partition={get_settings().slurm_partition}       # Partition or queue name
+#SBATCH --qos={get_settings().slurm_qos}                   # QOS level
+#SBATCH --nodelist={get_settings().slurm_node_list}  # List of nodes
+#SBATCH --nodes=1                     # Number of nodes
+#SBATCH --ntasks-per-node=1           # Number of tasks per node
+#SBATCH --cpus-per-task=2             # Number of CPU cores per task
+#SBATCH --time=0-00:01:00             # Maximum runtime (D-HH:MM:SS)
+
+# write contents of slurm_broker_py to slurm_test_broker.py
+cat <<'EOF' > slurm_test_broker.py
+{slurm_broker_py_contents}
+EOF
+
+# start the slurm_broker
+python3 slurm_test_broker.py /tmp/slurm.sock &
+sleep 2  # wait for the broker to start
+
+# run squeue command from the singularity container to test the broker
+echo $(singularity exec --env UNIX_SOCKET_PATH=/tmp/slurm.sock slurm_test.sif squeue --help)
+
+echo "Hello, world! to stdout"
+""")
+
+
+@pytest.mark.skipif(len(get_settings().slurm_submit_key_path) == 0, reason="slurm ssh key file not supplied")
+@pytest.mark.asyncio
+async def test_singularity_slurm(slurm_service: SlurmService) -> None:
+    with tempfile.TemporaryDirectory() as tmpdir_str:
+        tmpdir = Path(tmpdir_str)
+
+        # 1. Create a singularity definition file
+        singularity_def_file = tmpdir / "slurm_test.def"
+        with open(singularity_def_file, "w") as f:
+            f.write(singularity_def_contents)
+        # Build the singularity image remotely using ssh
+        await slurm_service.ssh_service.scp_upload(local_file=singularity_def_file, remote_path=Path("slurm_test.def"))
+        await slurm_service.ssh_service.run_command(command=f"ssh mantis-039 singularity build --ignore-fakeroot-command --force slurm_test.sif slurm_test.def")
+
+        # write the sbatch file to a temporary file
+        sbatch_file = tmpdir / "slurm_test.sbatch"
+        with open(sbatch_file, "w") as f:
+            f.write(sbatch_file_contents)
+
+        # 2. Submit the job
+        slurmjobid = await slurm_service.submit_job(local_sbatch_file=sbatch_file, remote_sbatch_file=Path("slurm_test.sbatch"))
+        # sleep for a few seconds to allow the job to be scheduled
+        # await asyncio.sleep(5)
+
+        # 5. Wait for the job to finish
+        slurm_jobs: list[SlurmJob] = []
+        for _ in range(60):
+            slurm_jobs = await slurm_service.get_job_status(job_ids=[slurmjobid])
+            print(slurm_jobs)
+            if not slurm_jobs or slurm_jobs[0].job_state in ("COMPLETED", "FAILED", "CANCELLED"):
+                break
+            time.sleep(1)
+
+        assert slurm_jobs
+        assert len(slurm_jobs) == 1
+        assert slurm_jobs[0].job_id == slurmjobid
+        assert slurm_jobs[0].job_state == "COMPLETED", f"Job {slurmjobid} did not complete successfully, state: {slurm_jobs[0].job_state}"
+
+        # 6. Check the output
+        output_file = tmpdir / "slurm_test.out"
+        await slurm_service.ssh_service.scp_download(local_file=output_file, remote_path=Path("slurm_test.out"))
+
+        assert output_file.exists()
+        with open(output_file, "r") as f:
+            output_content = f.read()
+
+        assert "Usage: squeue" in output_content, "Output file does not contain expected content"

--- a/tests/fixtures/scripts/slurm_broker.py
+++ b/tests/fixtures/scripts/slurm_broker.py
@@ -16,8 +16,8 @@ ALLOWED_COMMANDS = {
     "scancel": ["/usr/bin/scancel"],
 }
 
-async def handle_client(reader: StreamReader, writer: StreamWriter) -> None:
 
+async def handle_client(reader: StreamReader, writer: StreamWriter) -> None:
     try:
         if IS_LINUX:
             sock = writer.get_extra_info("socket")
@@ -57,6 +57,7 @@ async def handle_client(reader: StreamReader, writer: StreamWriter) -> None:
     finally:
         writer.close()
 
+
 async def main(socket_path: str) -> None:
     if os.path.exists(socket_path):
         os.remove(socket_path)
@@ -64,6 +65,7 @@ async def main(socket_path: str) -> None:
     os.chmod(socket_path, 0o700)
     async with server:
         await server.serve_forever()
+
 
 if __name__ == "__main__":
     if len(sys.argv) != 2 or sys.argv[1] in ("-h", "--help"):

--- a/tests/fixtures/scripts/slurm_broker.py
+++ b/tests/fixtures/scripts/slurm_broker.py
@@ -1,0 +1,76 @@
+import asyncio
+import os
+import socket
+import struct
+import sys
+from asyncio import StreamReader, StreamWriter
+
+IS_LINUX = sys.platform.startswith("linux")
+if IS_LINUX:
+    SO_PEERCRED = 17  # Linux only
+
+
+ALLOWED_COMMANDS = {
+    "sbatch": [os.environ.get("FAKE_SBATCH", "/usr/bin/sbatch")],
+    "squeue": ["/usr/bin/squeue"],
+    "scancel": ["/usr/bin/scancel"],
+}
+
+async def handle_client(reader: StreamReader, writer: StreamWriter) -> None:
+
+    try:
+        if IS_LINUX:
+            sock = writer.get_extra_info("socket")
+            ucred = sock.getsockopt(socket.SOL_SOCKET, SO_PEERCRED, struct.calcsize("3i"))
+            pid, peer_uid, gid = struct.unpack("3i", ucred)
+            if peer_uid != os.getuid():
+                writer.write(b"ERROR: UID mismatch\n")
+                await writer.drain()
+                writer.close()
+                return
+        else:
+            # On macOS, skip UID check (not secure!)
+            print("WARNING: UID check is skipped on non-Linux platforms.", file=sys.stderr)
+
+        data = await reader.readline()
+        if not data:
+            writer.close()
+            return
+        parts = data.decode().strip().split()
+        if not parts or parts[0] not in ALLOWED_COMMANDS:
+            writer.write(b"ERROR: Command not allowed\n")
+            await writer.drain()
+            writer.close()
+            return
+        cmd = ALLOWED_COMMANDS[parts[0]] + parts[1:]
+        proc = await asyncio.create_subprocess_exec(
+            *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+        )
+        stdout, stderr = await proc.communicate()
+        writer.write(stdout)
+        if stderr:
+            writer.write(b"\nERROR:\n" + stderr)
+        await writer.drain()
+    except Exception as e:
+        writer.write(f"ERROR: {e}\n".encode())
+        await writer.drain()
+    finally:
+        writer.close()
+
+async def main(socket_path: str) -> None:
+    if os.path.exists(socket_path):
+        os.remove(socket_path)
+    server = await asyncio.start_unix_server(handle_client, path=socket_path)
+    os.chmod(socket_path, 0o700)
+    async with server:
+        await server.serve_forever()
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2 or sys.argv[1] in ("-h", "--help"):
+        print(f"Usage: {sys.argv[0]} SOCKET_PATH")
+        sys.exit(1)
+    socket_path = sys.argv[1]
+    try:
+        asyncio.run(main(socket_path))
+    except KeyboardInterrupt:
+        print("Broker stopped.")


### PR DESCRIPTION
set up a python proxy process which is launched directly by sbatch which accepts slurm commands and executes them on the host.

add fake /usr/bin/sbatch, /usr/sbin/squeue, /usr/bin/sacct shell scripts into the singularity container - which proxies the slurm commands to the python proxy using the unix socket.

The unix socket is restricted to the current user, and does some input validation on the command. 