### PR TITLE
Fix analysis script

### DIFF
--- a/app/client_wrapper.py
+++ b/app/client_wrapper.py
@@ -1,14 +1,29 @@
+import asyncio
+import io
+from pathlib import Path
+
 import httpx
+import polars
 
 from sms_api.api.client import Client
+from sms_api.api.client.api.analyses.fetch_experiment_analysis import (
+    asyncio_detailed as fetch_experiment_analysis_async,
+)
+from sms_api.api.client.api.analyses.get_analysis_status import asyncio_detailed as get_analysis_status_async
+from sms_api.api.client.api.analyses.get_analysis_tsv import asyncio_detailed as get_analysis_tsv_async
+from sms_api.api.client.api.analyses.run_experiment_analysis import asyncio_detailed as run_analysis_async
 from sms_api.api.client.api.simulations.run_ecoli_simulation import asyncio_detailed as run_simulation_async
 from sms_api.api.client.models import (
     BodyRunEcoliSimulation,
+    EcoliSimulationDTO,
+    ExperimentAnalysisDTO,
+    ExperimentAnalysisRequest,
+    ExperimentRequest,
     HTTPValidationError,
-    experiment_request,
+    OutputFile,
+    SimulationRun,
 )
 from sms_api.api.client.types import Response
-from sms_api.simulation.models import EcoliSimulationDTO
 
 
 class ClientWrapper:
@@ -30,13 +45,92 @@ class ClientWrapper:
             self.api_client.set_httpx_client(self.httpx_client)
         return self.api_client
 
-    async def run_simulation(self) -> EcoliSimulationDTO:
+    async def run_simulation(self, request: ExperimentRequest) -> EcoliSimulationDTO:
         api_client = self._get_api_client()
-        response: Response[EcoliSimulationDTO | HTTPValidationError] = await run_simulation_async(  # type: ignore[assignment]
-            client=api_client,
-            body=BodyRunEcoliSimulation(request=experiment_request.ExperimentRequest(experiment_id="test")),
+        response: Response[EcoliSimulationDTO | HTTPValidationError] = await run_simulation_async(
+            client=api_client, body=BodyRunEcoliSimulation(request=request)
         )
         if response.status_code == 200 and isinstance(response.parsed, EcoliSimulationDTO):
             return response.parsed
         else:
             raise TypeError(f"Unexpected response status: {response.status_code}, content: {type(response.content)}")
+
+    async def run_analysis(self, request: ExperimentAnalysisRequest) -> ExperimentAnalysisDTO:
+        api_client = self._get_api_client()
+        response: Response[ExperimentAnalysisDTO | HTTPValidationError] = await run_analysis_async(
+            client=api_client, body=request
+        )
+        if response.status_code == 200 and isinstance(response.parsed, ExperimentAnalysisDTO):
+            return response.parsed
+        else:
+            raise TypeError(f"Unexpected response status: {response.status_code}, content: {type(response.content)}")
+
+    async def get_analysis(self, database_id: int) -> ExperimentAnalysisDTO:
+        api_client = self._get_api_client()
+        response: Response[ExperimentAnalysisDTO | HTTPValidationError] = await fetch_experiment_analysis_async(
+            client=api_client, id=database_id
+        )
+        if response.status_code == 200 and isinstance(response.parsed, ExperimentAnalysisDTO):
+            return response.parsed
+        else:
+            raise TypeError(f"Unexpected response status: {response.status_code}, content: {type(response.content)}")
+
+    async def get_analysis_status(self, analysis: ExperimentAnalysisDTO) -> SimulationRun:
+        api_client = self._get_api_client()
+        response: Response[SimulationRun | HTTPValidationError] = await get_analysis_status_async(
+            client=api_client, id=analysis.database_id
+        )
+        if response.status_code == 200 and isinstance(response.parsed, SimulationRun):
+            return response.parsed
+        else:
+            raise TypeError(f"Unexpected response status: {response.status_code}, content: {type(response.content)}")
+
+    async def get_tsv_outputs(self, analysis: ExperimentAnalysisDTO, outfile: Path | None = None) -> list[OutputFile]:
+        api_client = self._get_api_client()
+        response: Response[list[OutputFile] | HTTPValidationError] = await get_analysis_tsv_async(
+            client=api_client, id=analysis.database_id
+        )
+        if response.status_code == 200 and isinstance(response.parsed, list):
+            outputs = response.parsed
+            if outfile is not None:
+                lines = ["".join(output.content).split("\n") for output in outputs]
+                if outfile is not None:
+                    with open(outfile, "w") as f:
+                        for item in lines:
+                            f.write(f"{item}\n")
+
+            return outputs
+
+        else:
+            raise TypeError(f"Unexpected response status: {response.status_code}, content: {type(response.content)}")
+
+
+def format_tsv_string(output: OutputFile) -> str:
+    """
+    Convert a raw string containing escaped \\t and \\n into a proper TSV text.
+    """
+    raw_string = output.content
+    return raw_string.encode("utf-8").decode("unicode_escape")
+
+
+def tsv_string_to_polars_df(output: OutputFile) -> polars.DataFrame:
+    """
+    Parse a TSV-formatted string into a Polars DataFrame.
+    """
+    formatted = format_tsv_string(output)
+    return polars.read_csv(io.StringIO(formatted), separator="\t")
+
+
+async def test_client_get_tsv_outputs() -> None:
+    base_url = "https://sms.cam.uchc.edu"
+    dbid = 1
+    client = ClientWrapper(base_url=base_url)
+    analysis = await client.get_analysis(database_id=dbid)
+    outputs: list[OutputFile] = await client.get_tsv_outputs(analysis=analysis)
+    output_i = outputs[0]
+    df = tsv_string_to_polars_df(output_i)
+    print(df)
+
+
+if __name__ == "__main__":
+    asyncio.run(test_client_get_tsv_outputs())

--- a/clients/js/ptools_tsv.html
+++ b/clients/js/ptools_tsv.html
@@ -1,0 +1,146 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Ptools TSV Stream Viewer</title>
+  <style>
+    body { font-family: system-ui, sans-serif; padding: 20px; }
+    button { padding: 4px 8px; margin-left:6px; }
+    .part { margin: 12px 0; border: 1px solid #ddd; border-radius: 6px; background:#fafafa; padding:8px; }
+    .header { font-weight: 600; color:#333; margin-bottom:6px; display:flex; align-items:center; justify-content:space-between; }
+    pre { white-space: pre-wrap; margin:0; font-family: monospace; }
+    .error { color: #b91c1c; }
+  </style>
+</head>
+<body>
+  <h1>Ptools TSV Stream Viewer</h1>
+  <div>
+    <label>Analysis ID: <input id="analysisId" value="1" /></label>
+    <button id="startBtn">Load TSV parts</button>
+    <span id="status"></span>
+  </div>
+
+  <div id="output"></div>
+
+<script>
+function parseBoundary(contentType) {
+  const m = /boundary=(?:"([^"]+)"|([^;]+))/i.exec(contentType || '');
+  return m ? (m[1] || m[2]).trim() : null;
+}
+
+async function streamAndParse(endpoint) {
+  const statusEl = document.getElementById('status');
+  const output = document.getElementById('output');
+  output.innerHTML = '';
+  statusEl.textContent = 'Fetching…';
+
+  let res;
+  try {
+    res = await fetch(endpoint);
+  } catch (err) {
+    statusEl.textContent = 'Fetch failed';
+    const e = document.createElement('div');
+    e.className = 'error';
+    e.textContent = err.message;
+    output.appendChild(e);
+    return;
+  }
+
+  if (!res.ok) {
+    statusEl.textContent = `HTTP ${res.status}`;
+    const errText = await res.text().catch(()=>'(no body)');
+    const e = document.createElement('div');
+    e.className = 'error';
+    e.textContent = errText;
+    output.appendChild(e);
+    return;
+  }
+
+  const boundary = parseBoundary(res.headers.get('content-type'));
+  if (!boundary) {
+    // fallback to plain text
+    const txt = await res.text();
+    const wrap = document.createElement('div'); wrap.className='part';
+    const h = document.createElement('div'); h.className='header'; h.textContent='Single text';
+    const p = document.createElement('pre'); p.textContent=txt;
+    wrap.appendChild(h); wrap.appendChild(p);
+    output.appendChild(wrap);
+    statusEl.textContent = 'Done';
+    return;
+  }
+
+  statusEl.textContent = `Streaming multipart (boundary=${boundary})`;
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let partIndex = 0;
+
+  function handlePart(rawPart) {
+    rawPart = rawPart.trim();
+    if (!rawPart || rawPart === '--') return;
+    let sep = rawPart.indexOf('\r\n\r\n');
+    if (sep === -1) sep = rawPart.indexOf('\n\n');
+
+    let headers='', body=rawPart;
+    if (sep !== -1) {
+      headers = rawPart.slice(0,sep).trim();
+      body = rawPart.slice(sep + (rawPart.includes('\r\n\r\n')?4:2));
+    }
+
+    partIndex++;
+    const wrap = document.createElement('div'); wrap.className='part';
+
+    // header row with filename + button
+    const h = document.createElement('div'); h.className='header';
+    const cdMatch = headers.match(/Content-Disposition:[^\r\n]*filename="?([^"\r\n;]+)"?/i);
+    let filename = `part${partIndex}.txt`;
+    // if (cdMatch) filename = cdMatch[1];
+      if (cdMatch) {
+        const baseName = cdMatch[1].replace(/\.tsv$/i, '');
+        filename = baseName + '.txt';
+    }
+    const title = document.createElement('span');
+    title.textContent = `Part ${partIndex} — ${filename}`;
+    const downloadBtn = document.createElement('button');
+    downloadBtn.textContent = 'Download TSV';
+    downloadBtn.addEventListener('click', () => {
+      const blob = new Blob([body], {type:'text/plain'});  // tab-separated-values
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    });
+    h.appendChild(title);
+    h.appendChild(downloadBtn);
+
+    const pre = document.createElement('pre'); pre.textContent=body.trim();
+    wrap.appendChild(h);
+    wrap.appendChild(pre);
+    output.appendChild(wrap);
+  }
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value,{stream:true});
+    const parts = buffer.split(`--${boundary}`);
+    buffer = parts.pop(); // keep last incomplete
+    for (const part of parts) handlePart(part);
+  }
+  if (buffer && buffer.trim()) handlePart(buffer);
+  statusEl.textContent = 'Stream complete';
+}
+
+document.getElementById('startBtn').addEventListener('click', () => {
+  const id = document.getElementById('analysisId').value.trim();
+  const endpoint = `http://localhost:8888/v1/ecoli/analyses/${encodeURIComponent(id)}/ptools/formatted`; // adjust base path if needed
+  streamAndParse(endpoint);
+});
+</script>
+</body>
+</html>

--- a/kustomize/base/api.yaml
+++ b/kustomize/base/api.yaml
@@ -22,8 +22,8 @@ spec:
         fsGroup: 10000
       containers:
         - name: api
-          image: ghcr.io/vivarium-collective/sms-api:0.2.13-dev
-          # image: ghcr.io/biosimulations/sms-api:0.2.11-dev
+          image: ghcr.io/vivarium-collective/sms-api:0.2.24-dev  # 0.2.23-dev
+          # STABLE SRI WORKING VERSION: image: ghcr.io/biosimulations/sms-api:0.2.15-dev
           imagePullPolicy: Always
           ports:
             - containerPort: 8000

--- a/kustomize/config/sms-api-rke/shared.env
+++ b/kustomize/config/sms-api-rke/shared.env
@@ -7,7 +7,7 @@ SLURM_NODE_LIST=mantis-039
 SLURM_QOS=vivarium
 SLURM_LOG_BASE_PATH=/home/FCAM/svc_vivarium/prod/htclogs
 SLURM_BASE_PATH=/home/FCAM/svc_vivarium
-SIMULATION_OUTDIR=/home/FCAM/svc_vivarium/workspace/outputs
+SIMULATION_OUTDIR=/home/FCAM/svc_vivarium/workspace/api_outputs
 VECOLI_CONFIG_DIR=/home/FCAM/svc_vivarium/workspace/vEcoli/configs
 
 HPC_IMAGE_BASE_PATH=/home/FCAM/svc_vivarium/prod/images

--- a/kustomize/overlays/sms-api-rke/kustomization.yaml
+++ b/kustomize/overlays/sms-api-rke/kustomization.yaml
@@ -1,14 +1,15 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+# STABLE SRI WORKING VERSION:
+# - name: ghcr.io/vivarium-collective/sms-api
+#   newTag: 0.2.15-dev
+
 namespace: sms-api-rke
 
 images:
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.2.13-dev
-  # - name: ghcr.io/biosimulations/sms-api
-  #   newTag: 0.2.11-dev
-    # STABLE: newTag: 0.2.10-dev
+    newTag: 0.2.24-dev
   - name: docker.io/library/mongo
     newTag: 8.0.4
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sms_api"
-version = "0.2.12-dev"
+version = "0.2.24-dev"
 description = "This is the api server for Vivarium simulation services."
 authors = [{ name = "Alex Patrie", email = "alexanderpatrie@gmail.com" }, { name = "Jim Schaff", email = "jschaff@gmail.com" }]
 requires-python = ">=3.12,<4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "orjson>=3.11.1",
     "pandas-stubs>=2.3.0.250703",
     "xmltodict>=0.14.2",
+    "polars>=1.33.1",
 ]
 
 [project.urls]

--- a/sms_api/api/client/api/analyses/download_tsv_zip.py
+++ b/sms_api/api/client/api/analyses/download_tsv_zip.py
@@ -8,9 +8,7 @@ from ...types import Response, UNSET
 from ... import errors
 
 from ...models.http_validation_error import HTTPValidationError
-from ...models.output_file import OutputFile
 from typing import cast
-from typing import cast, Union
 
 
 def _get_kwargs(
@@ -18,7 +16,7 @@ def _get_kwargs(
 ) -> dict[str, Any]:
     _kwargs: dict[str, Any] = {
         "method": "get",
-        "url": "/v1/ecoli/analyses/{id}/plots".format(
+        "url": "/v1/ecoli/analyses/{id}/ptools/download".format(
             id=id,
         ),
     }
@@ -28,31 +26,9 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[HTTPValidationError, Union[list["OutputFile"], list[str]]]]:
+) -> Optional[Union[Any, HTTPValidationError]]:
     if response.status_code == 200:
-
-        def _parse_response_200(data: object) -> Union[list["OutputFile"], list[str]]:
-            try:
-                if not isinstance(data, list):
-                    raise TypeError()
-                response_200_type_0 = []
-                _response_200_type_0 = data
-                for response_200_type_0_item_data in _response_200_type_0:
-                    response_200_type_0_item = OutputFile.from_dict(response_200_type_0_item_data)
-
-                    response_200_type_0.append(response_200_type_0_item)
-
-                return response_200_type_0
-            except:  # noqa: E722
-                pass
-            if not isinstance(data, list):
-                raise TypeError()
-            response_200_type_1 = cast(list[str], data)
-
-            return response_200_type_1
-
-        response_200 = _parse_response_200(response.json())
-
+        response_200 = response.json()
         return response_200
     if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
@@ -66,7 +42,7 @@ def _parse_response(
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[HTTPValidationError, Union[list["OutputFile"], list[str]]]]:
+) -> Response[Union[Any, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -79,8 +55,8 @@ def sync_detailed(
     id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[Union[HTTPValidationError, Union[list["OutputFile"], list[str]]]]:
-    """Get an array of HTML files representing all plot outputs of a given analysis.
+) -> Response[Union[Any, HTTPValidationError]]:
+    """Download zip file of TSV outputs formatted for ptools.
 
     Args:
         id (int): Database ID of the analysis
@@ -90,7 +66,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[HTTPValidationError, Union[list['OutputFile'], list[str]]]]
+        Response[Union[Any, HTTPValidationError]]
     """
 
     kwargs = _get_kwargs(
@@ -108,8 +84,8 @@ def sync(
     id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[Union[HTTPValidationError, Union[list["OutputFile"], list[str]]]]:
-    """Get an array of HTML files representing all plot outputs of a given analysis.
+) -> Optional[Union[Any, HTTPValidationError]]:
+    """Download zip file of TSV outputs formatted for ptools.
 
     Args:
         id (int): Database ID of the analysis
@@ -119,7 +95,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[HTTPValidationError, Union[list['OutputFile'], list[str]]]
+        Union[Any, HTTPValidationError]
     """
 
     return sync_detailed(
@@ -132,8 +108,8 @@ async def asyncio_detailed(
     id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[Union[HTTPValidationError, Union[list["OutputFile"], list[str]]]]:
-    """Get an array of HTML files representing all plot outputs of a given analysis.
+) -> Response[Union[Any, HTTPValidationError]]:
+    """Download zip file of TSV outputs formatted for ptools.
 
     Args:
         id (int): Database ID of the analysis
@@ -143,7 +119,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[HTTPValidationError, Union[list['OutputFile'], list[str]]]]
+        Response[Union[Any, HTTPValidationError]]
     """
 
     kwargs = _get_kwargs(
@@ -159,8 +135,8 @@ async def asyncio(
     id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[Union[HTTPValidationError, Union[list["OutputFile"], list[str]]]]:
-    """Get an array of HTML files representing all plot outputs of a given analysis.
+) -> Optional[Union[Any, HTTPValidationError]]:
+    """Download zip file of TSV outputs formatted for ptools.
 
     Args:
         id (int): Database ID of the analysis
@@ -170,7 +146,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[HTTPValidationError, Union[list['OutputFile'], list[str]]]
+        Union[Any, HTTPValidationError]
     """
 
     return (

--- a/sms_api/api/client/api/analyses/get_analysis_tsv.py
+++ b/sms_api/api/client/api/analyses/get_analysis_tsv.py
@@ -16,7 +16,7 @@ def _get_kwargs(
 ) -> dict[str, Any]:
     _kwargs: dict[str, Any] = {
         "method": "get",
-        "url": "/v1/ecoli/analyses/{id}/ptools".format(
+        "url": "/v1/ecoli/analyses/{id}/ptools/formatted".format(
             id=id,
         ),
     }
@@ -26,10 +26,9 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[HTTPValidationError, list[str]]]:
+) -> Optional[Union[Any, HTTPValidationError]]:
     if response.status_code == 200:
-        response_200 = cast(list[str], response.json())
-
+        response_200 = response.json()
         return response_200
     if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
@@ -43,7 +42,7 @@ def _parse_response(
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[HTTPValidationError, list[str]]]:
+) -> Response[Union[Any, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -56,8 +55,8 @@ def sync_detailed(
     id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[Union[HTTPValidationError, list[str]]]:
-    """Get an array tsv files formatted for ptools.
+) -> Response[Union[Any, HTTPValidationError]]:
+    """Get a stream of multiple tsv file contents formatted for ptools.
 
     Args:
         id (int): Database ID of the analysis
@@ -67,7 +66,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[HTTPValidationError, list[str]]]
+        Response[Union[Any, HTTPValidationError]]
     """
 
     kwargs = _get_kwargs(
@@ -85,8 +84,8 @@ def sync(
     id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[Union[HTTPValidationError, list[str]]]:
-    """Get an array tsv files formatted for ptools.
+) -> Optional[Union[Any, HTTPValidationError]]:
+    """Get a stream of multiple tsv file contents formatted for ptools.
 
     Args:
         id (int): Database ID of the analysis
@@ -96,7 +95,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[HTTPValidationError, list[str]]
+        Union[Any, HTTPValidationError]
     """
 
     return sync_detailed(
@@ -109,8 +108,8 @@ async def asyncio_detailed(
     id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[Union[HTTPValidationError, list[str]]]:
-    """Get an array tsv files formatted for ptools.
+) -> Response[Union[Any, HTTPValidationError]]:
+    """Get a stream of multiple tsv file contents formatted for ptools.
 
     Args:
         id (int): Database ID of the analysis
@@ -120,7 +119,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[HTTPValidationError, list[str]]]
+        Response[Union[Any, HTTPValidationError]]
     """
 
     kwargs = _get_kwargs(
@@ -136,8 +135,8 @@ async def asyncio(
     id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[Union[HTTPValidationError, list[str]]]:
-    """Get an array tsv files formatted for ptools.
+) -> Optional[Union[Any, HTTPValidationError]]:
+    """Get a stream of multiple tsv file contents formatted for ptools.
 
     Args:
         id (int): Database ID of the analysis
@@ -147,7 +146,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[HTTPValidationError, list[str]]
+        Union[Any, HTTPValidationError]
     """
 
     return (

--- a/sms_api/api/client/models/__init__.py
+++ b/sms_api/api/client/models/__init__.py
@@ -62,6 +62,7 @@ from .hpc_run import HpcRun
 from .http_validation_error import HTTPValidationError
 from .job_status import JobStatus
 from .job_type import JobType
+from .output_file import OutputFile
 from .parca_dataset import ParcaDataset
 from .parca_dataset_request import ParcaDatasetRequest
 from .parca_dataset_request_parca_config import ParcaDatasetRequestParcaConfig
@@ -138,6 +139,7 @@ __all__ = (
     "HTTPValidationError",
     "JobStatus",
     "JobType",
+    "OutputFile",
     "ParcaDataset",
     "ParcaDatasetRequest",
     "ParcaDatasetRequestParcaConfig",

--- a/sms_api/api/client/models/analysis_config.py
+++ b/sms_api/api/client/models/analysis_config.py
@@ -11,8 +11,8 @@ from typing import cast
 from typing import Union
 
 if TYPE_CHECKING:
-    from ..models.analysis_config_emitter_arg import AnalysisConfigEmitterArg
     from ..models.analysis_config_options import AnalysisConfigOptions
+    from ..models.analysis_config_emitter_arg import AnalysisConfigEmitterArg
 
 
 T = TypeVar("T", bound="AnalysisConfig")
@@ -31,8 +31,8 @@ class AnalysisConfig:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        from ..models.analysis_config_emitter_arg import AnalysisConfigEmitterArg
         from ..models.analysis_config_options import AnalysisConfigOptions
+        from ..models.analysis_config_emitter_arg import AnalysisConfigEmitterArg
 
         analysis_options = self.analysis_options.to_dict()
 
@@ -52,8 +52,8 @@ class AnalysisConfig:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.analysis_config_emitter_arg import AnalysisConfigEmitterArg
         from ..models.analysis_config_options import AnalysisConfigOptions
+        from ..models.analysis_config_emitter_arg import AnalysisConfigEmitterArg
 
         d = dict(src_dict)
         analysis_options = AnalysisConfigOptions.from_dict(d.pop("analysis_options"))

--- a/sms_api/api/client/models/analysis_config_options.py
+++ b/sms_api/api/client/models/analysis_config_options.py
@@ -12,12 +12,12 @@ from typing import cast, Union
 from typing import Union
 
 if TYPE_CHECKING:
-    from ..models.analysis_config_options_multiseed import AnalysisConfigOptionsMultiseed
-    from ..models.analysis_config_options_multidaughter import AnalysisConfigOptionsMultidaughter
-    from ..models.analysis_config_options_multigeneration import AnalysisConfigOptionsMultigeneration
-    from ..models.analysis_config_options_single import AnalysisConfigOptionsSingle
-    from ..models.analysis_config_options_multiexperiment import AnalysisConfigOptionsMultiexperiment
     from ..models.analysis_config_options_multivariant import AnalysisConfigOptionsMultivariant
+    from ..models.analysis_config_options_multiexperiment import AnalysisConfigOptionsMultiexperiment
+    from ..models.analysis_config_options_multigeneration import AnalysisConfigOptionsMultigeneration
+    from ..models.analysis_config_options_multidaughter import AnalysisConfigOptionsMultidaughter
+    from ..models.analysis_config_options_multiseed import AnalysisConfigOptionsMultiseed
+    from ..models.analysis_config_options_single import AnalysisConfigOptionsSingle
 
 
 T = TypeVar("T", bound="AnalysisConfigOptions")
@@ -54,12 +54,12 @@ class AnalysisConfigOptions:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        from ..models.analysis_config_options_multiseed import AnalysisConfigOptionsMultiseed
-        from ..models.analysis_config_options_multidaughter import AnalysisConfigOptionsMultidaughter
-        from ..models.analysis_config_options_multigeneration import AnalysisConfigOptionsMultigeneration
-        from ..models.analysis_config_options_single import AnalysisConfigOptionsSingle
-        from ..models.analysis_config_options_multiexperiment import AnalysisConfigOptionsMultiexperiment
         from ..models.analysis_config_options_multivariant import AnalysisConfigOptionsMultivariant
+        from ..models.analysis_config_options_multiexperiment import AnalysisConfigOptionsMultiexperiment
+        from ..models.analysis_config_options_multigeneration import AnalysisConfigOptionsMultigeneration
+        from ..models.analysis_config_options_multidaughter import AnalysisConfigOptionsMultidaughter
+        from ..models.analysis_config_options_multiseed import AnalysisConfigOptionsMultiseed
+        from ..models.analysis_config_options_single import AnalysisConfigOptionsSingle
 
         experiment_id = self.experiment_id
 
@@ -143,12 +143,12 @@ class AnalysisConfigOptions:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.analysis_config_options_multiseed import AnalysisConfigOptionsMultiseed
-        from ..models.analysis_config_options_multidaughter import AnalysisConfigOptionsMultidaughter
-        from ..models.analysis_config_options_multigeneration import AnalysisConfigOptionsMultigeneration
-        from ..models.analysis_config_options_single import AnalysisConfigOptionsSingle
-        from ..models.analysis_config_options_multiexperiment import AnalysisConfigOptionsMultiexperiment
         from ..models.analysis_config_options_multivariant import AnalysisConfigOptionsMultivariant
+        from ..models.analysis_config_options_multiexperiment import AnalysisConfigOptionsMultiexperiment
+        from ..models.analysis_config_options_multigeneration import AnalysisConfigOptionsMultigeneration
+        from ..models.analysis_config_options_multidaughter import AnalysisConfigOptionsMultidaughter
+        from ..models.analysis_config_options_multiseed import AnalysisConfigOptionsMultiseed
+        from ..models.analysis_config_options_single import AnalysisConfigOptionsSingle
 
         d = dict(src_dict)
         experiment_id = cast(list[str], d.pop("experiment_id"))

--- a/sms_api/api/client/models/body_run_ecoli_simulation.py
+++ b/sms_api/api/client/models/body_run_ecoli_simulation.py
@@ -12,8 +12,8 @@ from typing import cast, Union
 from typing import Union
 
 if TYPE_CHECKING:
-    from ..models.experiment_metadata import ExperimentMetadata
     from ..models.experiment_request import ExperimentRequest
+    from ..models.experiment_metadata import ExperimentMetadata
 
 
 T = TypeVar("T", bound="BodyRunEcoliSimulation")
@@ -32,8 +32,8 @@ class BodyRunEcoliSimulation:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        from ..models.experiment_metadata import ExperimentMetadata
         from ..models.experiment_request import ExperimentRequest
+        from ..models.experiment_metadata import ExperimentMetadata
 
         request: Union[Unset, dict[str, Any]] = UNSET
         if not isinstance(self.request, Unset):
@@ -59,8 +59,8 @@ class BodyRunEcoliSimulation:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.experiment_metadata import ExperimentMetadata
         from ..models.experiment_request import ExperimentRequest
+        from ..models.experiment_metadata import ExperimentMetadata
 
         d = dict(src_dict)
         _request = d.pop("request", UNSET)

--- a/sms_api/api/client/models/ecoli_simulation_request.py
+++ b/sms_api/api/client/models/ecoli_simulation_request.py
@@ -11,8 +11,8 @@ from typing import cast
 from typing import Union
 
 if TYPE_CHECKING:
-    from ..models.simulator_version import SimulatorVersion
     from ..models.ecoli_simulation_request_variant_config import EcoliSimulationRequestVariantConfig
+    from ..models.simulator_version import SimulatorVersion
 
 
 T = TypeVar("T", bound="EcoliSimulationRequest")
@@ -34,8 +34,8 @@ class EcoliSimulationRequest:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        from ..models.simulator_version import SimulatorVersion
         from ..models.ecoli_simulation_request_variant_config import EcoliSimulationRequestVariantConfig
+        from ..models.simulator_version import SimulatorVersion
 
         simulator = self.simulator.to_dict()
 
@@ -58,8 +58,8 @@ class EcoliSimulationRequest:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.simulator_version import SimulatorVersion
         from ..models.ecoli_simulation_request_variant_config import EcoliSimulationRequestVariantConfig
+        from ..models.simulator_version import SimulatorVersion
 
         d = dict(src_dict)
         simulator = SimulatorVersion.from_dict(d.pop("simulator"))

--- a/sms_api/api/client/models/experiment_analysis_request.py
+++ b/sms_api/api/client/models/experiment_analysis_request.py
@@ -11,12 +11,12 @@ from typing import cast
 from typing import Union
 
 if TYPE_CHECKING:
-    from ..models.experiment_analysis_request_multiseed import ExperimentAnalysisRequestMultiseed
-    from ..models.experiment_analysis_request_multidaughter import ExperimentAnalysisRequestMultidaughter
     from ..models.experiment_analysis_request_multiexperiment import ExperimentAnalysisRequestMultiexperiment
     from ..models.experiment_analysis_request_multigeneration import ExperimentAnalysisRequestMultigeneration
     from ..models.experiment_analysis_request_single import ExperimentAnalysisRequestSingle
     from ..models.experiment_analysis_request_multivariant import ExperimentAnalysisRequestMultivariant
+    from ..models.experiment_analysis_request_multidaughter import ExperimentAnalysisRequestMultidaughter
+    from ..models.experiment_analysis_request_multiseed import ExperimentAnalysisRequestMultiseed
 
 
 T = TypeVar("T", bound="ExperimentAnalysisRequest")
@@ -27,7 +27,7 @@ class ExperimentAnalysisRequest:
     """
     Attributes:
         experiment_id (str):
-        analysis_name (Union[Unset, str]):  Default: 'analysis_smsapi-75f3365df39383d1_1758834636157'.
+        analysis_name (Union[Unset, str]):  Default: 'analysis_smsapi-60355055c281c9d9_1758906407363'.
         single (Union[Unset, ExperimentAnalysisRequestSingle]):
         multidaughter (Union[Unset, ExperimentAnalysisRequestMultidaughter]):
         multigeneration (Union[Unset, ExperimentAnalysisRequestMultigeneration]):
@@ -37,7 +37,7 @@ class ExperimentAnalysisRequest:
     """
 
     experiment_id: str
-    analysis_name: Union[Unset, str] = "analysis_smsapi-75f3365df39383d1_1758834636157"
+    analysis_name: Union[Unset, str] = "analysis_smsapi-60355055c281c9d9_1758906407363"
     single: Union[Unset, "ExperimentAnalysisRequestSingle"] = UNSET
     multidaughter: Union[Unset, "ExperimentAnalysisRequestMultidaughter"] = UNSET
     multigeneration: Union[Unset, "ExperimentAnalysisRequestMultigeneration"] = UNSET
@@ -47,12 +47,12 @@ class ExperimentAnalysisRequest:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        from ..models.experiment_analysis_request_multiseed import ExperimentAnalysisRequestMultiseed
-        from ..models.experiment_analysis_request_multidaughter import ExperimentAnalysisRequestMultidaughter
         from ..models.experiment_analysis_request_multiexperiment import ExperimentAnalysisRequestMultiexperiment
         from ..models.experiment_analysis_request_multigeneration import ExperimentAnalysisRequestMultigeneration
         from ..models.experiment_analysis_request_single import ExperimentAnalysisRequestSingle
         from ..models.experiment_analysis_request_multivariant import ExperimentAnalysisRequestMultivariant
+        from ..models.experiment_analysis_request_multidaughter import ExperimentAnalysisRequestMultidaughter
+        from ..models.experiment_analysis_request_multiseed import ExperimentAnalysisRequestMultiseed
 
         experiment_id = self.experiment_id
 
@@ -106,12 +106,12 @@ class ExperimentAnalysisRequest:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.experiment_analysis_request_multiseed import ExperimentAnalysisRequestMultiseed
-        from ..models.experiment_analysis_request_multidaughter import ExperimentAnalysisRequestMultidaughter
         from ..models.experiment_analysis_request_multiexperiment import ExperimentAnalysisRequestMultiexperiment
         from ..models.experiment_analysis_request_multigeneration import ExperimentAnalysisRequestMultigeneration
         from ..models.experiment_analysis_request_single import ExperimentAnalysisRequestSingle
         from ..models.experiment_analysis_request_multivariant import ExperimentAnalysisRequestMultivariant
+        from ..models.experiment_analysis_request_multidaughter import ExperimentAnalysisRequestMultidaughter
+        from ..models.experiment_analysis_request_multiseed import ExperimentAnalysisRequestMultiseed
 
         d = dict(src_dict)
         experiment_id = d.pop("experiment_id")

--- a/sms_api/api/client/models/experiment_request.py
+++ b/sms_api/api/client/models/experiment_request.py
@@ -12,15 +12,15 @@ from typing import cast, Union
 from typing import Union
 
 if TYPE_CHECKING:
-    from ..models.experiment_request_flow import ExperimentRequestFlow
-    from ..models.experiment_request_swap_processes import ExperimentRequestSwapProcesses
-    from ..models.experiment_request_process_configs import ExperimentRequestProcessConfigs
-    from ..models.experiment_request_topology import ExperimentRequestTopology
-    from ..models.experiment_request_metadata import ExperimentRequestMetadata
     from ..models.experiment_request_initial_state import ExperimentRequestInitialState
-    from ..models.experiment_request_analysis_options import ExperimentRequestAnalysisOptions
     from ..models.experiment_request_variants import ExperimentRequestVariants
+    from ..models.experiment_request_flow import ExperimentRequestFlow
+    from ..models.experiment_request_metadata import ExperimentRequestMetadata
+    from ..models.experiment_request_topology import ExperimentRequestTopology
     from ..models.experiment_request_spatial_environment_config import ExperimentRequestSpatialEnvironmentConfig
+    from ..models.experiment_request_analysis_options import ExperimentRequestAnalysisOptions
+    from ..models.experiment_request_process_configs import ExperimentRequestProcessConfigs
+    from ..models.experiment_request_swap_processes import ExperimentRequestSwapProcesses
 
 
 T = TypeVar("T", bound="ExperimentRequest")
@@ -32,7 +32,7 @@ class ExperimentRequest:
 
     Attributes:
         experiment_id (str):
-        simulation_name (Union[Unset, str]):  Default: 'sim_smsapi-aa6c65991c507fbe_1758834636180'.
+        simulation_name (Union[Unset, str]):  Default: 'sim_smsapi-70b0e43ad54d1d29_1758906407386'.
         metadata (Union[Unset, ExperimentRequestMetadata]):
         run_parca (Union[Unset, bool]):  Default: True.
         generations (Union[Unset, int]):  Default: 1.
@@ -84,7 +84,7 @@ class ExperimentRequest:
     """
 
     experiment_id: str
-    simulation_name: Union[Unset, str] = "sim_smsapi-aa6c65991c507fbe_1758834636180"
+    simulation_name: Union[Unset, str] = "sim_smsapi-70b0e43ad54d1d29_1758906407386"
     metadata: Union[Unset, "ExperimentRequestMetadata"] = UNSET
     run_parca: Union[Unset, bool] = True
     generations: Union[Unset, int] = 1
@@ -136,15 +136,15 @@ class ExperimentRequest:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        from ..models.experiment_request_flow import ExperimentRequestFlow
-        from ..models.experiment_request_swap_processes import ExperimentRequestSwapProcesses
-        from ..models.experiment_request_process_configs import ExperimentRequestProcessConfigs
-        from ..models.experiment_request_topology import ExperimentRequestTopology
-        from ..models.experiment_request_metadata import ExperimentRequestMetadata
         from ..models.experiment_request_initial_state import ExperimentRequestInitialState
-        from ..models.experiment_request_analysis_options import ExperimentRequestAnalysisOptions
         from ..models.experiment_request_variants import ExperimentRequestVariants
+        from ..models.experiment_request_flow import ExperimentRequestFlow
+        from ..models.experiment_request_metadata import ExperimentRequestMetadata
+        from ..models.experiment_request_topology import ExperimentRequestTopology
         from ..models.experiment_request_spatial_environment_config import ExperimentRequestSpatialEnvironmentConfig
+        from ..models.experiment_request_analysis_options import ExperimentRequestAnalysisOptions
+        from ..models.experiment_request_process_configs import ExperimentRequestProcessConfigs
+        from ..models.experiment_request_swap_processes import ExperimentRequestSwapProcesses
 
         experiment_id = self.experiment_id
 
@@ -495,15 +495,15 @@ class ExperimentRequest:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.experiment_request_flow import ExperimentRequestFlow
-        from ..models.experiment_request_swap_processes import ExperimentRequestSwapProcesses
-        from ..models.experiment_request_process_configs import ExperimentRequestProcessConfigs
-        from ..models.experiment_request_topology import ExperimentRequestTopology
-        from ..models.experiment_request_metadata import ExperimentRequestMetadata
         from ..models.experiment_request_initial_state import ExperimentRequestInitialState
-        from ..models.experiment_request_analysis_options import ExperimentRequestAnalysisOptions
         from ..models.experiment_request_variants import ExperimentRequestVariants
+        from ..models.experiment_request_flow import ExperimentRequestFlow
+        from ..models.experiment_request_metadata import ExperimentRequestMetadata
+        from ..models.experiment_request_topology import ExperimentRequestTopology
         from ..models.experiment_request_spatial_environment_config import ExperimentRequestSpatialEnvironmentConfig
+        from ..models.experiment_request_analysis_options import ExperimentRequestAnalysisOptions
+        from ..models.experiment_request_process_configs import ExperimentRequestProcessConfigs
+        from ..models.experiment_request_swap_processes import ExperimentRequestSwapProcesses
 
         d = dict(src_dict)
         experiment_id = d.pop("experiment_id")

--- a/sms_api/api/client/models/output_file.py
+++ b/sms_api/api/client/models/output_file.py
@@ -1,0 +1,68 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+
+T = TypeVar("T", bound="OutputFile")
+
+
+@_attrs_define
+class OutputFile:
+    """
+    Attributes:
+        name (str):
+        content (str):
+    """
+
+    name: str
+    content: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        name = self.name
+
+        content = self.content
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "name": name,
+            "content": content,
+        })
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        name = d.pop("name")
+
+        content = d.pop("content")
+
+        output_file = cls(
+            name=name,
+            content=content,
+        )
+
+        output_file.additional_properties = d
+        return output_file
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sms_api/api/client/models/simulation_config.py
+++ b/sms_api/api/client/models/simulation_config.py
@@ -12,16 +12,16 @@ from typing import cast, Union
 from typing import Union
 
 if TYPE_CHECKING:
-    from ..models.simulation_config_emitter_arg import SimulationConfigEmitterArg
-    from ..models.simulation_config_swap_processes import SimulationConfigSwapProcesses
-    from ..models.simulation_config_analysis_options import SimulationConfigAnalysisOptions
-    from ..models.simulation_config_parca_options import SimulationConfigParcaOptions
-    from ..models.simulation_config_variants import SimulationConfigVariants
-    from ..models.simulation_config_topology import SimulationConfigTopology
     from ..models.simulation_config_flow import SimulationConfigFlow
-    from ..models.simulation_config_spatial_environment_config import SimulationConfigSpatialEnvironmentConfig
-    from ..models.simulation_config_initial_state import SimulationConfigInitialState
+    from ..models.simulation_config_analysis_options import SimulationConfigAnalysisOptions
+    from ..models.simulation_config_topology import SimulationConfigTopology
+    from ..models.simulation_config_variants import SimulationConfigVariants
     from ..models.simulation_config_process_configs import SimulationConfigProcessConfigs
+    from ..models.simulation_config_parca_options import SimulationConfigParcaOptions
+    from ..models.simulation_config_emitter_arg import SimulationConfigEmitterArg
+    from ..models.simulation_config_spatial_environment_config import SimulationConfigSpatialEnvironmentConfig
+    from ..models.simulation_config_swap_processes import SimulationConfigSwapProcesses
+    from ..models.simulation_config_initial_state import SimulationConfigInitialState
 
 
 T = TypeVar("T", bound="SimulationConfig")
@@ -150,16 +150,16 @@ class SimulationConfig:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        from ..models.simulation_config_emitter_arg import SimulationConfigEmitterArg
-        from ..models.simulation_config_swap_processes import SimulationConfigSwapProcesses
-        from ..models.simulation_config_analysis_options import SimulationConfigAnalysisOptions
-        from ..models.simulation_config_parca_options import SimulationConfigParcaOptions
-        from ..models.simulation_config_variants import SimulationConfigVariants
-        from ..models.simulation_config_topology import SimulationConfigTopology
         from ..models.simulation_config_flow import SimulationConfigFlow
-        from ..models.simulation_config_spatial_environment_config import SimulationConfigSpatialEnvironmentConfig
-        from ..models.simulation_config_initial_state import SimulationConfigInitialState
+        from ..models.simulation_config_analysis_options import SimulationConfigAnalysisOptions
+        from ..models.simulation_config_topology import SimulationConfigTopology
+        from ..models.simulation_config_variants import SimulationConfigVariants
         from ..models.simulation_config_process_configs import SimulationConfigProcessConfigs
+        from ..models.simulation_config_parca_options import SimulationConfigParcaOptions
+        from ..models.simulation_config_emitter_arg import SimulationConfigEmitterArg
+        from ..models.simulation_config_spatial_environment_config import SimulationConfigSpatialEnvironmentConfig
+        from ..models.simulation_config_swap_processes import SimulationConfigSwapProcesses
+        from ..models.simulation_config_initial_state import SimulationConfigInitialState
 
         experiment_id = self.experiment_id
 
@@ -562,16 +562,16 @@ class SimulationConfig:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.simulation_config_emitter_arg import SimulationConfigEmitterArg
-        from ..models.simulation_config_swap_processes import SimulationConfigSwapProcesses
-        from ..models.simulation_config_analysis_options import SimulationConfigAnalysisOptions
-        from ..models.simulation_config_parca_options import SimulationConfigParcaOptions
-        from ..models.simulation_config_variants import SimulationConfigVariants
-        from ..models.simulation_config_topology import SimulationConfigTopology
         from ..models.simulation_config_flow import SimulationConfigFlow
-        from ..models.simulation_config_spatial_environment_config import SimulationConfigSpatialEnvironmentConfig
-        from ..models.simulation_config_initial_state import SimulationConfigInitialState
+        from ..models.simulation_config_analysis_options import SimulationConfigAnalysisOptions
+        from ..models.simulation_config_topology import SimulationConfigTopology
+        from ..models.simulation_config_variants import SimulationConfigVariants
         from ..models.simulation_config_process_configs import SimulationConfigProcessConfigs
+        from ..models.simulation_config_parca_options import SimulationConfigParcaOptions
+        from ..models.simulation_config_emitter_arg import SimulationConfigEmitterArg
+        from ..models.simulation_config_spatial_environment_config import SimulationConfigSpatialEnvironmentConfig
+        from ..models.simulation_config_swap_processes import SimulationConfigSwapProcesses
+        from ..models.simulation_config_initial_state import SimulationConfigInitialState
 
         d = dict(src_dict)
         experiment_id = d.pop("experiment_id")

--- a/sms_api/api/spec/openapi_3_1_0_generated.yaml
+++ b/sms_api/api/spec/openapi_3_1_0_generated.yaml
@@ -16,7 +16,7 @@ paths:
               $ref: '#/components/schemas/ExperimentAnalysisRequest'
               default:
                 experiment_id: sms_multigeneration
-                analysis_name: ptools_analysis-f244d98e1fafb16f_1758834636240
+                analysis_name: ptools_analysis-77e9fedb26bd3bb2_1758906442941
                 single:
                   ptools_rxns:
                     n_tp: 8
@@ -210,9 +210,13 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: string
+                anyOf:
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/OutputFile'
+                - type: array
+                  items:
+                    type: string
                 title: Response Get-Analysis-Plots
         '422':
           description: Validation Error
@@ -224,7 +228,7 @@ paths:
     get:
       tags:
       - Analyses
-      summary: Get an array tsv files formatted for ptools.
+      summary: Get an array of tsv files formatted for ptools.
       operationId: get-analysis-tsv
       parameters:
       - name: id
@@ -243,8 +247,62 @@ paths:
               schema:
                 type: array
                 items:
-                  type: string
+                  $ref: '#/components/schemas/OutputFile'
                 title: Response Get-Analysis-Tsv
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/ecoli/analyses/{id}/ptools/formatted:
+    get:
+      tags:
+      - Analyses
+      summary: Get a stream of multiple tsv file contents formatted for ptools.
+      operationId: get-analysis-tsv
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          description: Database ID of the analysis
+          title: Id
+        description: Database ID of the analysis
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/ecoli/analyses/{id}/ptools/download:
+    get:
+      tags:
+      - Analyses
+      summary: Download zip file of TSV outputs formatted for ptools.
+      operationId: download-tsv-zip
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          description: Database ID of the analysis
+          title: Id
+        description: Database ID of the analysis
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
         '422':
           description: Validation Error
           content:
@@ -981,8 +1039,8 @@ components:
         request:
           $ref: '#/components/schemas/ExperimentRequest'
           default:
-            experiment_id: sms_single-c6930bc3c659aef2_1758834636240-d8cdb806f7ad275e_1758834636240
-            simulation_name: sms_single-c6930bc3c659aef2_1758834636240
+            experiment_id: sms_single-344362e258bbd348_1758906442941-353798b398f195ef_1758906442941
+            simulation_name: sms_single-344362e258bbd348_1758906442941
             metadata: {}
             run_parca: true
             generations: 1
@@ -1137,7 +1195,7 @@ components:
         analysis_name:
           type: string
           title: Analysis Name
-          default: analysis_smsapi-75f3365df39383d1_1758834636157
+          default: analysis_smsapi-96196d02c5dc4f92_1758906442855
         single:
           additionalProperties: true
           type: object
@@ -1205,7 +1263,7 @@ components:
         simulation_name:
           type: string
           title: Simulation Name
-          default: sim_smsapi-aa6c65991c507fbe_1758834636180
+          default: sim_smsapi-63c15023a3b7a1c7_1758906442879
         metadata:
           additionalProperties: true
           type: object
@@ -1535,6 +1593,19 @@ components:
       - parca
       - build_image
       title: JobType
+    OutputFile:
+      properties:
+        name:
+          type: string
+          title: Name
+        content:
+          type: string
+          title: Content
+      type: object
+      required:
+      - name
+      - content
+      title: OutputFile
     ParcaDataset:
       properties:
         database_id:

--- a/sms_api/data/services/analysis.py
+++ b/sms_api/data/services/analysis.py
@@ -1,3 +1,4 @@
+import abc
 import json
 import logging
 import tempfile
@@ -6,7 +7,7 @@ from collections.abc import Generator
 from io import BytesIO
 from pathlib import Path
 from textwrap import dedent
-from typing import Any
+from typing import Any, override
 from zipfile import ZIP_DEFLATED, ZipFile
 
 from sms_api.common.hpc.slurm_service import SlurmService
@@ -14,6 +15,7 @@ from sms_api.common.ssh.ssh_service import SSHService, get_ssh_service
 from sms_api.config import Settings, get_settings
 from sms_api.data.models import AnalysisConfig
 from sms_api.simulation.hpc_utils import get_slurm_submit_file, get_slurmjob_name
+from sms_api.simulation.models import BaseModel
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -204,43 +206,79 @@ def unzip_archive(zip_path: Path, dest_dir: Path) -> str:
     return str(dest_dir)
 
 
-def get_html_output_paths(outdir_root: Path, experiment_id: str) -> list[Path]:
-    outdir = outdir_root / experiment_id
-    filepaths = []
-    for root, _, files in outdir.walk():
-        for f in files:
-            fp = root / f
-            if fp.exists() and fp.is_file():
-                filepaths.append(fp)
-    return list(filter(lambda _file: _file.name.endswith(".html"), filepaths))
+class OutputFile(BaseModel):
+    name: str
+    content: str
 
 
-def get_tsv_output_paths(outdir_root: Path, experiment_id: str) -> list[Path]:
-    outdir = outdir_root / experiment_id
-    filepaths = []
-    for root, _, files in outdir.walk():
-        for f in files:
-            fp = root / f
-            if fp.exists() and fp.is_file():
-                filepaths.append(fp)
-    return list(filter(lambda _file: _file.name.endswith(".tsv"), filepaths))
+class FileService(abc.ABC):
+    @abc.abstractmethod
+    def _get_output_paths(self, outdir_root: Path, experiment_id: str) -> list[Path]:
+        pass
+
+    @abc.abstractmethod
+    def _read_file(self, file_path: Path) -> str:
+        pass
+
+    def get_outputs(self, output_id: str = "analysis_multigen") -> list[OutputFile]:
+        outdir_root = Path("/home/FCAM/svc_vivarium/workspace/api_outputs")
+        filepaths = self._get_output_paths(outdir_root, output_id)
+        # return [read_tsv_file(path) for path in filepaths]
+        # return {path.name: self._read_file(path) for path in filepaths}
+        return [OutputFile(name=path.name, content=self._read_file(path)) for path in filepaths]
 
 
-def read_html_file(file_path: Path) -> str:
-    """Read an HTML file and return its contents as a single string."""
-    with open(str(file_path), encoding="utf-8") as f:
-        return f.read()
+class FileServiceTsv(FileService):
+    @override
+    def _get_output_paths(self, outdir_root: Path, experiment_id: str) -> list[Path]:
+        outdir = outdir_root / experiment_id
+        filepaths = []
+        for root, _, files in outdir.walk():
+            for f in files:
+                fp = root / f
+                if fp.exists() and fp.is_file():
+                    filepaths.append(fp)
+        return list(filter(lambda _file: _file.name.endswith(".txt"), filepaths))
+
+    @override
+    def _read_file(self, file_path: Path) -> str:
+        with open(str(file_path), encoding="utf-8") as f:
+            return f.read()
 
 
-def read_tsv_file(file_path: Path) -> str:
-    return read_html_file(file_path)
+class FileServiceHtml(FileService):
+    @override
+    def _get_output_paths(self, outdir_root: Path, experiment_id: str) -> list[Path]:
+        outdir = outdir_root / experiment_id
+        filepaths = []
+        for root, _, files in outdir.walk():
+            for f in files:
+                fp = root / f
+                if fp.exists() and fp.is_file():
+                    filepaths.append(fp)
+        return list(filter(lambda _file: _file.name.endswith(".html"), filepaths))
+
+    @override
+    def _read_file(self, file_path: Path) -> str:
+        """Read an HTML file and return its contents as a single string."""
+        with open(str(file_path), encoding="utf-8") as f:
+            return f.read()
 
 
-def get_analysis_html_outputs(outdir_root: Path, expid: str = "analysis_multigen") -> list[str]:
-    filepaths = get_html_output_paths(outdir_root, expid)
-    return [read_html_file(path) for path in filepaths]
+async def get_tsv_outputs_local(output_id: str, ssh_service: SSHService) -> list[OutputFile]:
+    # output_id = 'ptools_multigen_analysis_alex'
+    # outdir = Path("/home/FCAM/svc_vivarium/workspace/api_outputs")
+    remote_uv_executable = "/home/FCAM/svc_vivarium/.local/bin/uv"
+    ret, stdin, stdout = await ssh_service.run_command(
+        dedent(f"""
+                cd /home/FCAM/svc_vivarium/workspace \
+                    && {remote_uv_executable} run scripts/ptools_outputs.py --output_id {output_id}
+            """)
+    )
 
-
-def get_analysis_tsv_outputs(outdir_root: Path, expid: str = "analysis_multigen") -> list[str]:
-    filepaths = get_tsv_output_paths(outdir_root, expid)
-    return [read_tsv_file(path) for path in filepaths]
+    deserialized = json.loads(stdin.replace("'", '"'))
+    outputs = []
+    for spec in deserialized:
+        for name, content in spec.items():
+            outputs.append(OutputFile(name=name, content=content))
+    return outputs

--- a/sms_api/version.py
+++ b/sms_api/version.py
@@ -1,4 +1,4 @@
 # NEWEST(FIRST NEXTFLOW): "0.2.11-dev"
 # LATEST STABLE: "0.2.10-dev"
 # PREVIOUS STABLE: "0.2.8"
-__version__ = "0.2.20-dev"
+__version__ = "0.2.24-dev"

--- a/tests/data/test_analysis_service.py
+++ b/tests/data/test_analysis_service.py
@@ -1,0 +1,15 @@
+import logging
+
+import pytest
+
+from sms_api.common.ssh.ssh_service import SSHService
+from sms_api.config import get_settings
+from sms_api.data.services.analysis import OutputFile, get_tsv_outputs_local
+
+
+@pytest.mark.skipif(len(get_settings().slurm_submit_key_path) == 0, reason="slurm ssh key file not supplied")
+@pytest.mark.asyncio
+async def test_get_tsv_outputs_local(ssh_service: SSHService, logger: logging.Logger) -> None:
+    output_id = "ptools_multigen_analysis_alex"
+    outputs = await get_tsv_outputs_local(ssh_service=ssh_service, output_id=output_id)
+    assert all(isinstance(output, OutputFile) for output in outputs)

--- a/uv.lock
+++ b/uv.lock
@@ -1827,6 +1827,20 @@ wheels = [
 ]
 
 [[package]]
+name = "polars"
+version = "1.33.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/da/8246f1d69d7e49f96f0c5529057a19af1536621748ef214bbd4112c83b8e/polars-1.33.1.tar.gz", hash = "sha256:fa3fdc34eab52a71498264d6ff9b0aa6955eb4b0ae8add5d3cb43e4b84644007", size = 4822485 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/79/c51e7e1d707d8359bcb76e543a8315b7ae14069ecf5e75262a0ecb32e044/polars-1.33.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:3881c444b0f14778ba94232f077a709d435977879c1b7d7bd566b55bd1830bb5", size = 39132875 },
+    { url = "https://files.pythonhosted.org/packages/f8/15/1094099a1b9cb4fbff58cd8ed3af8964f4d22a5b682ea0b7bb72bf4bc3d9/polars-1.33.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:29200b89c9a461e6f06fc1660bc9c848407640ee30fe0e5ef4947cfd49d55337", size = 35638783 },
+    { url = "https://files.pythonhosted.org/packages/8d/b9/9ac769e4d8e8f22b0f2e974914a63dd14dec1340cd23093de40f0d67d73b/polars-1.33.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:444940646e76342abaa47f126c70e3e40b56e8e02a9e89e5c5d1c24b086db58a", size = 39742297 },
+    { url = "https://files.pythonhosted.org/packages/7a/26/4c5da9f42fa067b2302fe62bcbf91faac5506c6513d910fae9548fc78d65/polars-1.33.1-cp39-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:094a37d06789286649f654f229ec4efb9376630645ba8963b70cb9c0b008b3e1", size = 36684940 },
+    { url = "https://files.pythonhosted.org/packages/06/a6/dc535da476c93b2efac619e04ab81081e004e4b4553352cd10e0d33a015d/polars-1.33.1-cp39-abi3-win_amd64.whl", hash = "sha256:c9781c704432a2276a185ee25898aa427f39a904fbe8fde4ae779596cdbd7a9e", size = 39456676 },
+    { url = "https://files.pythonhosted.org/packages/cb/4e/a4300d52dd81b58130ccadf3873f11b3c6de54836ad4a8f32bac2bd2ba17/polars-1.33.1-cp39-abi3-win_arm64.whl", hash = "sha256:c3cfddb3b78eae01a218222bdba8048529fef7e14889a71e33a5198644427642", size = 35445171 },
+]
+
+[[package]]
 name = "polars-lts-cpu"
 version = "1.33.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2508,6 +2522,7 @@ dependencies = [
     { name = "numpy" },
     { name = "orjson" },
     { name = "pandas-stubs" },
+    { name = "polars" },
     { name = "polars-lts-cpu", extra = ["pyarrow"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -2571,6 +2586,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.3.1,<3" },
     { name = "orjson", specifier = ">=3.11.1" },
     { name = "pandas-stubs", specifier = ">=2.3.0.250703" },
+    { name = "polars", specifier = ">=1.33.1" },
     { name = "polars-lts-cpu", extras = ["pyarrow"], specifier = ">=1.31.0,<2" },
     { name = "pydantic", specifier = ">=2.11.5,<3" },
     { name = "pydantic-settings", specifier = ">=2.9.1,<3" },

--- a/uv.lock
+++ b/uv.lock
@@ -2504,7 +2504,7 @@ wheels = [
 
 [[package]]
 name = "sms-api"
-version = "0.2.12.dev0"
+version = "0.2.24.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
_What does this PR do?_:
- Fixes an issue in which the improper file extension was defined for the function that fetches all ptools-compliant tsv analysis output files.
- Adds new `/ecoli` router endpoints allowing for multiple was to ingest the tsv files required by Ptools that are generated by an analysis run.
- Adds a python `ClientWrapper` acting as a high level representation of the auto-generated client library (**For use with the Marimo apps/notebooks**)
- Adds a simple javascript client example for tsv outputs.