### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sms_api"
-version = "0.6.3"
+version = "0.7.0"
 description = "This is the api server for Vivarium simulation services."
 authors = [{ name = "Alex Patrie", email = "alexanderpatrie@gmail.com" }, { name = "Jim Schaff", email = "jschaff@gmail.com" }]
 requires-python = "==3.12.9"

--- a/sms_api/version.py
+++ b/sms_api/version.py
@@ -6,4 +6,5 @@
 # LATEST STABLE AFTER HACKATHON FOR AWS: 0.6.0
 # 0.6.2 — task-8 parallel S3 downloads + results-cache emptyDir volume
 # 0.6.3 — remove PCS/SLURM/FSx from stanford-test, backend guards on legacy endpoints
-__version__ = "0.6.3"
+# 0.7.0 — Atlantis CLI, AWS Batch backend, PCS/SLURM/FSx removal, ComputeBackend enum
+__version__ = "0.7.0"


### PR DESCRIPTION
## Summary

Version bump to 0.7.0 for release.

## Test plan

- [x] Version string updated in `sms_api/version.py` and `pyproject.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)