### PR TITLE
fix: deployment config fixes for stanford-test (v0.7.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,45 @@ async with get_ssh_session_service().session() as ssh:
 - **Package manager**: uv with hatchling build backend.
 
 
+## Release Protocol
+
+Follow this exact sequence to cut a release:
+
+1. **Merge all work to `main`** — ensure CI passes, all feature PRs merged
+2. **Create release branch** from `main`:
+   ```bash
+   git checkout main && git pull
+   git checkout -b release/vX.Y.Z
+   ```
+3. **Bump version** in exactly two files:
+   - `sms_api/version.py` — `__version__ = "X.Y.Z"`
+   - `pyproject.toml` — `version = "X.Y.Z"`
+4. **Single commit**: `chore: bump version to X.Y.Z`
+5. **PR to main**, merge (or fast-forward)
+6. **Tag the merge commit**:
+   ```bash
+   git checkout main && git pull
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+7. **Create GitHub Release** from the tag with release notes:
+   ```bash
+   gh release create vX.Y.Z --title "vX.Y.Z — <summary>" --notes-file <notes.md>
+   ```
+8. **Build + deploy** (if deploying):
+   ```bash
+   gh workflow run build-and-push.yml --ref main -f version=X.Y.Z
+   ```
+   Then bump `newTag` in all kustomize overlays and apply.
+
+**Version sync checklist** (when bumping version):
+- `sms_api/version.py`
+- `pyproject.toml`
+- `kustomize/overlays/sms-api-stanford-test/kustomization.yaml` (sms-api only — keep sms-ptools at 0.5.9)
+- `kustomize/overlays/sms-api-stanford/kustomization.yaml`
+- `kustomize/overlays/sms-api-rke/kustomization.yaml`
+- `kustomize/overlays/sms-api-rke-dev/kustomization.yaml`
+
 ## Notes
 
 ### Full end-user E2E workflow (E.U.T.E: End User Tooling Experience)

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,52 @@ clean-build: ## Clean build artifacts
 	@echo "🚀 Removing build artifacts"
 	@uv run python -c "import shutil; import os; shutil.rmtree('dist') if os.path.exists('dist') else None"
 
+# ----------------------------------------------------------------------------
+# PyPI publish — mirrors ../vecoli_deployment's publish workflow so that
+# `pip install sms-api` ships the full end-user bundle (app.cli, app.tui,
+# app.gui, app_data_service, etc.) to stakeholders.
+#
+# Usage:
+#   make publish                              # reads token from ~/.ssh/.pypi-sms-api
+#   make publish token=pypi-AgEN...           # explicit token
+#   make upload_package token=pypi-...        # upload already-built dist/
+# ----------------------------------------------------------------------------
+
+.PHONY: sync_publish
+sync_publish: ## Recreate uv.lock and sync all groups (no-cache) for a clean publish
+	@echo "🚀 Refreshing uv environment for publish"
+	@uv cache clean
+	@rm -f uv.lock
+	@uv lock --no-cache
+	@uv sync --no-cache --all-groups
+
+.PHONY: build_package
+build_package: clean-build ## Build sdist + wheel into dist/ using the standard PEP 517 builder
+	@echo "🚀 Building sms_api package (sdist + wheel)"
+	@uvx --from build pyproject-build --installer uv
+
+.PHONY: upload_package
+upload_package: ## Upload dist/* to PyPI (requires token=... and a pre-built dist/)
+	@if [ -z "$(token)" ]; then \
+		echo "❌ upload_package requires token=..."; exit 1; \
+	fi
+	@echo "🚀 Uploading sms_api package to PyPI"
+	@uv publish --no-cache --token $(token)
+
+.PHONY: publish
+publish: ## Publish sms_api to PyPI (sync → build → upload). Reads token from ~/.ssh/.pypi-sms-api unless token=... is set.
+	@TOKEN="$(token)"; \
+	if [ -z "$$TOKEN" ] && [ -f "$$HOME/.ssh/.pypi-sms-api" ]; then \
+		TOKEN=$$(cat "$$HOME/.ssh/.pypi-sms-api"); \
+	fi; \
+	if [ -z "$$TOKEN" ]; then \
+		echo "❌ No PyPI token. Set token=... or write one to ~/.ssh/.pypi-sms-api"; \
+		exit 1; \
+	fi; \
+	$(MAKE) sync_publish && \
+	$(MAKE) build_package && \
+	$(MAKE) upload_package token=$$TOKEN
+
 .PHONY: docs-test
 docs-test: ## Test if documentation can be built without warnings or errors
 	@cd docs && uv run make html SPHINXOPTS="-W"

--- a/kustomize/config/sms-api-stanford-test/shared.env
+++ b/kustomize/config/sms-api-stanford-test/shared.env
@@ -14,7 +14,7 @@ REDIS_EMITTER_MAGIC_WORD=redis-emitter-magic-word
 BUILD_ARM64_QUEUE=smsvpctest-vecoli-build-arm64
 BUILD_AMD64_QUEUE=smsvpctest-vecoli-build-amd64
 BUILD_JOB_DEFINITION=smsvpctest-vecoli-dind-build
-BUILD_GIT_SECRET_ARN=arn:aws-us-gov:secretsmanager:us-gov-west-1:476270107793:secret:vecoli-github-pat-5zxtT0
+BUILD_GIT_SECRET_ARN=arn:aws-us-gov:secretsmanager:us-gov-west-1:476270107793:secret:vecoli-github-pat-ytH7kL
 
 K8S_JOB_NAMESPACE=sms-api-stanford-test
 ECR_ACCOUNT_ID=476270107793

--- a/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
@@ -3,11 +3,11 @@ kind: Kustomization
 
 namespace: sms-api-stanford-test
 
-# STABLE: 0.5.9
+# STABLE: 0.5.9 | 0.6.2
 
 images:
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.6.3
+    newTag: 0.7.0
   # ptools pinned to last-known-good tag — the build-and-push GH Action's
   # ptools step is currently broken (Dockerfile-nextflow issue), so there is
   # no sms-ptools:0.6.x image on ghcr.io.  0.5.9 is the tag the live Stanford

--- a/sms_api/common/handlers/simulations.py
+++ b/sms_api/common/handlers/simulations.py
@@ -197,6 +197,15 @@ async def run_simulation_workflow(  # noqa: C901
 
     settings = get_settings()
 
+    # Batch backend requires parca to run: vEcoli's workflow.py resolves
+    # sim_data_path with os.path.abspath which mangles S3 URIs, and then
+    # passes the local kb_dir into Nextflow channels where Batch task
+    # containers can't access it.  Until vEcoli supports cloud-native
+    # sim_data_path, parca must run as part of the workflow on Batch.
+    if not run_parca and get_job_backend() == ComputeBackend.BATCH:
+        logger.warning("Forcing run_parca=True: --no-run-parca is not supported on the Batch backend")
+        run_parca = True
+
     # 1. Get the simulator (must exist)
     simulator = await database_service.get_simulator(simulator_id)
     if simulator is None:

--- a/sms_api/config.py
+++ b/sms_api/config.py
@@ -253,11 +253,13 @@ def get_job_backend() -> ComputeBackend:
 def get_public_mode() -> bool:
     """Return whether the deployment runs in public mode.
 
-    Raises ValueError if PUBLIC_MODE is not set.
+    Defaults to ``False`` when PUBLIC_MODE is not set so that the CLI and
+    other local tooling can import ``simulator_defaults`` without requiring
+    every server-side env var to be present.
     """
     value = get_settings().public_mode
     if not value:
-        raise ValueError("PUBLIC_MODE must be set explicitly to 'true' or 'false'")
+        return False
     return value.lower() == "true"
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -3092,7 +3092,7 @@ wheels = [
 
 [[package]]
 name = "sms-api"
-version = "0.6.3"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
## Summary

- **fix: public mode parser** — `get_public_mode()` no longer crashes when `PUBLIC_MODE` env var is unset (CLI/local tooling). Defaults to `False` instead of raising `ValueError`.
- **fix: stale BUILD_GIT_SECRET_ARN** — CDK recreated the Secrets Manager secret with a new suffix during PCS/FSx removal. Updated stanford-test `shared.env` to match (`vecoli-github-pat-ytH7kL`).
- **fix: enforce run_parca on Batch** — `--no-run-parca` is structurally broken on AWS Batch (vEcoli's `workflow.py` mangles S3 URIs with `os.path.abspath`). Handler now forces `run_parca=True` with a log warning when backend is Batch.
- **docs: release protocol** — Added release branch workflow to CLAUDE.md.
- **infra: bump stanford-test image tag** to 0.7.0, add PyPI publish targets to Makefile.

## Verified

- Full e2e workflow passed on `sms-api-stanford-test` (sim 46): build → parca → simulation → analysis → output download
- Build time: 315s dual-arch (AMD64 + ARM64)
- `atlantis --help` works locally without server env vars

## Test plan

- [x] `atlantis --help` no longer crashes without `PUBLIC_MODE` set
- [x] `atlantis simulator latest` → build succeeds with corrected secret ARN
- [x] `atlantis simulation run` → full EUTE passes on stanford-test
- [x] `atlantis simulation outputs` → download verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)