### PR TITLE
chore: bump version to 0.7.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sms_api"
-version = "0.7.0"
+version = "0.7.1"
 description = "This is the api server for Vivarium simulation services."
 authors = [{ name = "Alex Patrie", email = "alexanderpatrie@gmail.com" }, { name = "Jim Schaff", email = "jschaff@gmail.com" }]
 requires-python = "==3.12.9"

--- a/sms_api/version.py
+++ b/sms_api/version.py
@@ -7,4 +7,5 @@
 # 0.6.2 — task-8 parallel S3 downloads + results-cache emptyDir volume
 # 0.6.3 — remove PCS/SLURM/FSx from stanford-test, backend guards on legacy endpoints
 # 0.7.0 — Atlantis CLI, AWS Batch backend, PCS/SLURM/FSx removal, ComputeBackend enum
-__version__ = "0.7.0"
+# 0.7.1 — fix public_mode default, stale secret ARN, enforce run_parca on Batch
+__version__ = "0.7.1"


### PR DESCRIPTION
## Summary

Patch release v0.7.1 — version bump per release protocol.

### Changes since v0.7.0

- **fix:** `get_public_mode()` defaults to `False` when `PUBLIC_MODE` unset (CLI/local tooling no longer crashes)
- **fix:** stale `BUILD_GIT_SECRET_ARN` in stanford-test config (CDK recreated secret during PCS/FSx removal)
- **fix:** enforce `run_parca=True` on Batch backend (vEcoli's `workflow.py` mangles S3 URIs)
- **docs:** release protocol added to CLAUDE.md
- **infra:** bump stanford-test image tag to 0.7.0, add PyPI publish targets to Makefile

### Verified

Full E2E workflow on `sms-api-stanford-test` (sim 46): build → parca → sim → analysis → output download

🤖 Generated with [Claude Code](https://claude.com/claude-code)