### PR TITLE
feat: config template fallback for public vEcoli repo (v0.7.2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,28 +211,21 @@ async with get_ssh_session_service().session() as ssh:
 
 Follow this exact sequence to cut a release:
 
-1. **Merge all work to `main`** — ensure CI passes, all feature PRs merged
-2. **Create release branch** from `main`:
-   ```bash
-   git checkout main && git pull
-   git checkout -b release/vX.Y.Z
-   ```
-3. **Bump version** in exactly two files:
+1. **Include the version bump in the feature/fix branch** before merging:
    - `sms_api/version.py` — `__version__ = "X.Y.Z"`
    - `pyproject.toml` — `version = "X.Y.Z"`
-4. **Single commit**: `chore: bump version to X.Y.Z`
-5. **PR to main**, merge (or fast-forward)
-6. **Tag the merge commit**:
+2. **Single PR to `main`** — contains all changes + version bump. Merge.
+3. **Tag the merge commit**:
    ```bash
    git checkout main && git pull
    git tag vX.Y.Z
    git push origin vX.Y.Z
    ```
-7. **Create GitHub Release** from the tag with release notes:
+4. **Create GitHub Release** from the tag with release notes:
    ```bash
    gh release create vX.Y.Z --title "vX.Y.Z — <summary>" --notes-file <notes.md>
    ```
-8. **Build + deploy** (if deploying):
+5. **Build + deploy** (if deploying):
    ```bash
    gh workflow run build-and-push.yml --ref main -f version=X.Y.Z
    ```

--- a/kustomize/overlays/sms-api-rke-dev/kustomization.yaml
+++ b/kustomize/overlays/sms-api-rke-dev/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: sms-api-rke-dev
 
 images:
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.6.3
+    newTag: 0.7.2
   # ptools pinned to last-known-good tag — see Stanford-test kustomization
   # for rationale.  No sms-ptools:0.6.x image exists on ghcr.io because the
   # build-and-push GH Action's ptools step is broken.

--- a/kustomize/overlays/sms-api-rke/kustomization.yaml
+++ b/kustomize/overlays/sms-api-rke/kustomization.yaml
@@ -10,7 +10,7 @@ namespace: sms-api-rke
 
 images:
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.6.3
+    newTag: 0.7.2
   # ptools pinned to last-known-good tag — see Stanford-test kustomization
   # for rationale.  No sms-ptools:0.6.x image exists on ghcr.io because the
   # build-and-push GH Action's ptools step is broken.

--- a/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: sms-api-stanford-test
 
 images:
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.7.0
+    newTag: 0.7.2
   # ptools pinned to last-known-good tag — the build-and-push GH Action's
   # ptools step is currently broken (Dockerfile-nextflow issue), so there is
   # no sms-ptools:0.6.x image on ghcr.io.  0.5.9 is the tag the live Stanford

--- a/kustomize/overlays/sms-api-stanford/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: sms-api-stanford
 
 images:
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.6.3
+    newTag: 0.7.2
   # ptools pinned to last-known-good tag — the build-and-push GH Action's
   # ptools step is currently broken (Dockerfile-nextflow issue), so there is
   # no sms-ptools:0.6.x image on ghcr.io.  0.5.9 is the tag the live Stanford

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sms_api"
-version = "0.7.1"
+version = "0.7.2"
 description = "This is the api server for Vivarium simulation services."
 authors = [{ name = "Alex Patrie", email = "alexanderpatrie@gmail.com" }, { name = "Jim Schaff", email = "jschaff@gmail.com" }]
 requires-python = "==3.12.9"

--- a/sms_api/simulation/simulation_service_k8s.py
+++ b/sms_api/simulation/simulation_service_k8s.py
@@ -25,6 +25,55 @@ from sms_api.simulation.simulation_service import SimulationService
 
 logger = logging.getLogger(__name__)
 
+# Embedded config template used when the target vEcoli repo does not ship
+# an api_simulation_default.json (e.g. the public CovertLab/vEcoli repo).
+# Mirrors vEcoli-private/configs/api_simulation_default.json with the same
+# placeholders that the handler's replacement logic expects.
+_DEFAULT_CONFIG_TEMPLATE: dict[str, object] = {
+    "experiment_id": "EXPERIMENT_ID_PLACEHOLDER",
+    "parca_options": {
+        "cpus": 6,
+        "outdir": "HPC_SIM_BASE_PATH_PLACEHOLDER",
+        "operons": True,
+        "ribosome_fitting": True,
+        "remove_rrna_operons": False,
+        "remove_rrff": False,
+        "stable_rrna": False,
+        "new_genes": "off",
+        "debug_parca": False,
+        "save_intermediates": False,
+        "intermediates_directory": "",
+        "variable_elongation_transcription": True,
+        "variable_elongation_translation": False,
+    },
+    "sim_data_path": None,
+    "suffix_time": False,
+    "generations": 8,
+    "n_init_sims": 3,
+    "max_duration": 10800.0,
+    "initial_global_time": 0.0,
+    "time_step": 1.0,
+    "single_daughters": True,
+    "emitter": "parquet",
+    "emitter_arg": {"out_dir": "HPC_SIM_BASE_PATH_PLACEHOLDER"},
+    "analysis_options": {
+        "multiseed": {
+            "cd1_higher_order_properties": {"generation_lower_bound": 5},
+            "cd1_transcriptomics": {"generation_lower_bound": 5},
+            "cd1_proteomics": {"generation_lower_bound": 5},
+            "cd1_metabolomics": {"generation_lower_bound": 5},
+            "cd1_fluxomics": {"generation_lower_bound": 5},
+            "ptools_rxns": {"n_tp": 10},
+            "ptools_rna": {"n_tp": 10},
+            "ptools_proteins": {"n_tp": 10},
+        }
+    },
+    "aws_cdk": {
+        "build_image": False,
+        "container_image": "SIMULATOR_IMAGE_PATH_PLACEHOLDER",
+    },
+}
+
 
 def _github_api_url(repo_url: str) -> str:
     """Convert a GitHub HTTPS URL to the API equivalent.
@@ -456,7 +505,12 @@ echo "Submit image pushed: $ECR_REGISTRY/{settings.ecr_repository}:{image_tag}-s
 
     @override
     async def read_config_template(self, simulator_version: SimulatorVersion, config_filename: str) -> str:
-        """Read a vEcoli config template from the GitHub repo via the Contents API."""
+        """Read a vEcoli config template from the GitHub repo via the Contents API.
+
+        Falls back to the embedded ``_DEFAULT_CONFIG_TEMPLATE`` when the
+        requested config file does not exist in the repo (e.g. the public
+        CovertLab/vEcoli repo does not ship ``api_simulation_default.json``).
+        """
         settings = get_settings()
         base = _github_api_url(simulator_version.git_repo_url)
         api_url = f"{base}/contents/configs/{config_filename}?ref={simulator_version.git_commit_hash}"
@@ -465,6 +519,14 @@ echo "Submit image pushed: $ECR_REGISTRY/{settings.ecr_repository}:{image_tag}-s
             headers["Authorization"] = f"token {settings.github_token}"
         async with httpx.AsyncClient() as client:
             response = await client.get(api_url, headers=headers)
+            if response.status_code == 404:
+                logger.warning(
+                    "Config %s not found in %s@%s — using embedded default template",
+                    config_filename,
+                    simulator_version.git_repo_url,
+                    simulator_version.git_commit_hash,
+                )
+                return json.dumps(_DEFAULT_CONFIG_TEMPLATE)
             response.raise_for_status()
             return response.text
 

--- a/sms_api/version.py
+++ b/sms_api/version.py
@@ -8,4 +8,5 @@
 # 0.6.3 — remove PCS/SLURM/FSx from stanford-test, backend guards on legacy endpoints
 # 0.7.0 — Atlantis CLI, AWS Batch backend, PCS/SLURM/FSx removal, ComputeBackend enum
 # 0.7.1 — fix public_mode default, stale secret ARN, enforce run_parca on Batch
-__version__ = "0.7.1"
+# 0.7.2 — config template fallback for public vEcoli repo, kustomize tag sync, RKE DB migration
+__version__ = "0.7.2"

--- a/tests/simulation/test_k8s_backend.py
+++ b/tests/simulation/test_k8s_backend.py
@@ -385,6 +385,41 @@ class TestSimulationServiceK8s:
         assert "api.github.com/repos/test/repo" in call_url
         assert "test.json" in call_url
 
+    async def test_read_config_template_fallback_on_404(
+        self,
+        simulation_service_k8s_mock: SimulationServiceK8s,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Verify read_config_template returns embedded default when GitHub returns 404."""
+        from sms_api.simulation.models import SimulatorVersion
+        from sms_api.simulation.simulation_service_k8s import _DEFAULT_CONFIG_TEMPLATE
+
+        simulator = SimulatorVersion(
+            database_id=1,
+            git_commit_hash="6f7e5b9",
+            git_repo_url="https://github.com/CovertLab/vEcoli",
+            git_branch="master",
+        )
+
+        mock_response = AsyncMock()
+        mock_response.status_code = 404
+        mock_response.raise_for_status = MagicMock(side_effect=Exception("should not be called"))
+
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        monkeypatch.setattr("sms_api.simulation.simulation_service_k8s.httpx.AsyncClient", lambda: mock_client)
+
+        result = await simulation_service_k8s_mock.read_config_template(simulator, "api_simulation_default.json")
+
+        parsed = json.loads(result)
+        assert parsed["experiment_id"] == "EXPERIMENT_ID_PLACEHOLDER"
+        assert parsed["parca_options"]["cpus"] == 6
+        assert "aws_cdk" in parsed
+        assert parsed == _DEFAULT_CONFIG_TEMPLATE
+
     async def test_build_command_generates_valid_script(
         self,
         simulation_service_k8s_mock: SimulationServiceK8s,


### PR DESCRIPTION
## Summary

- **Config template fallback** — When the target vEcoli repo doesn't ship `api_simulation_default.json` (e.g. public `CovertLab/vEcoli`), the K8s backend falls back to an embedded default template instead of returning a 500. Enables running simulations on stanford-test with the public repo.
- **Simplified release protocol** — One PR instead of two (version bump included in feature branch).
- **Kustomize tags synced to 0.7.2** across all four overlays.
- **RKE DB migration** — `job_id_ext`, `job_backend`, `error_message` columns added to hpcrun table (run manually on RKE pod).

## Test plan

- [x] `make check` passes
- [x] New test: `test_read_config_template_fallback_on_404` verifies embedded template returned on 404
- [x] All 31 K8s backend tests pass
- [x] Existing GitHub API path unchanged (private repo still fetches from repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)