### PR TITLE
fix: README image, CLI trailing help, docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Documentation](https://img.shields.io/badge/documentation-online-blue.svg)](https://sms-api.readthedocs.io/en/latest/)
 
 <p align="center">
-  <img src="https://github.com/vivarium-collective/sms-api/blob/main/documentation/source/_static/wholecellecoli.png?raw=true" width="400" />
+  <img src="https://github.com/vivarium-collective/sms-api/blob/main/docs/source/_static/wholecellecoli.png?raw=true" width="400" />
 </p>
 
 - **Github repository**: <https://github.com/vivarium-collective/sms-api/>
@@ -28,17 +28,24 @@ The vEcoli documentation is very well written and we highly recommend that users
 # Install
 uv sync
 
-# Build a simulator
-uv run atlantis simulator latest --repo-url https://github.com/CovertLabEcoli/vEcoli-private --branch master
+# Build a simulator (public vEcoli repo)
+uv run atlantis simulator latest --repo-url https://github.com/CovertLab/vEcoli --branch master
+
+# Discover available configs and analysis modules for your simulator
+uv run atlantis simulation configs 16
+uv run atlantis simulation analyses 16
 
 # Run a simulation (1 generation, 1 seed)
-uv run atlantis simulation run my-experiment 11 --generations 1 --seeds 1 --poll
+uv run atlantis simulation run my-experiment 16 --generations 1 --seeds 1 --poll
 
 # Check status (fast — shows log tail + status)
 uv run atlantis simulation status 37
 
 # Download outputs
 uv run atlantis simulation outputs 37 --dest ./results
+
+# Help works at any nesting level
+uv run atlantis simulation run help
 ```
 
 ## Three Client Interfaces

--- a/app/cli.py
+++ b/app/cli.py
@@ -67,6 +67,13 @@ cli.add_typer(tkapp_cli)
 
 
 def main() -> None:
+    import sys
+
+    # Allow "help" as a trailing word at any nesting level:
+    # e.g. "atlantis simulation run help" → "atlantis simulation run --help"
+    if len(sys.argv) > 1 and sys.argv[-1] == "help":
+        sys.argv[-1] = "--help"
+
     cli()
 
 

--- a/docs/source/guides/choosing-a-client.rst
+++ b/docs/source/guides/choosing-a-client.rst
@@ -44,13 +44,13 @@ the platform. It supports all workflow steps as subcommands:
    uv run atlantis simulation run ...     # Run
    uv run atlantis simulation outputs ... # Download
 
-Use ``--help`` on any command or subcommand for details:
+Use ``help`` as a trailing word on any command (equivalent to ``--help``):
 
 .. code-block:: bash
 
    uv run atlantis help
-   uv run atlantis help simulation
    uv run atlantis simulation help
+   uv run atlantis simulation run help
 
 See :doc:`cli-reference` for the full command reference.
 

--- a/docs/source/guides/cli-reference.rst
+++ b/docs/source/guides/cli-reference.rst
@@ -24,13 +24,15 @@ environment variable.
 help
 ----
 
-Show help for the top-level CLI or any command group:
+Show help for the top-level CLI or any command group. The word ``help`` works
+as a trailing argument at any nesting level:
 
 .. code-block:: bash
 
    uv run atlantis help
    uv run atlantis help simulator
-   uv run atlantis simulator help    # equivalent
+   uv run atlantis simulator help         # equivalent
+   uv run atlantis simulation run help    # same as --help
 
 simulator
 ---------
@@ -120,10 +122,12 @@ Submit a simulation workflow (parca -> simulation -> analysis).
        If omitted, uses the default baseline set (55 paths covering
        all analysis modules).
    * - ``--analysis-options``
-     - default ptools modules
-     - JSON string overriding which analysis modules run as part of the
-       workflow. E.g. ``'{"multiseed": {"ptools_rna": {"n_tp": 10}}}'``.
-       If omitted, uses the default set.
+     - repo-aware defaults
+     - JSON string specifying which analysis modules to run. Keys are
+       categories (``single``, ``multiseed``, ``multigeneration``, etc.);
+       values map module names to params. Defaults depend on the simulator's
+       repo — private vEcoli gets cd1_* modules, public gets none. Use
+       ``simulation analyses SIMULATOR_ID`` to discover available modules.
    * - ``--poll / --no-poll``
      - off
      - Poll until completion
@@ -175,6 +179,37 @@ List all simulations.
 .. code-block:: bash
 
    uv run atlantis simulation list
+
+simulation configs
+~~~~~~~~~~~~~~~~~~
+
+List available config filenames for a simulator's repo. The available configs
+depend on what exists in the simulator's vEcoli commit.
+
+.. code-block:: bash
+
+   uv run atlantis simulation configs SIMULATOR_ID
+
+simulation analyses
+~~~~~~~~~~~~~~~~~~~
+
+List available analysis modules for a simulator's repo, grouped by category
+(single, multiseed, multigeneration, etc.).
+
+.. code-block:: bash
+
+   uv run atlantis simulation analyses SIMULATOR_ID
+
+**Example:**
+
+.. code-block:: bash
+
+   # Discover what analyses are available before submitting
+   uv run atlantis simulation analyses 16 --base-url http://localhost:8080
+
+   # Then use a discovered module in a run
+   uv run atlantis simulation run my-exp 16 \
+     --analysis-options '{"multiseed": {"protein_counts_validation": {}}}'
 
 simulation status
 ~~~~~~~~~~~~~~~~~

--- a/docs/source/guides/end-to-end-workflow.rst
+++ b/docs/source/guides/end-to-end-workflow.rst
@@ -73,6 +73,23 @@ Managing simulators
    # Force a rebuild (e.g. after a code change on the same commit)
    uv run atlantis simulator latest --force
 
+Discover Available Configs and Analyses
+----------------------------------------
+
+Before running a simulation, you can discover what config files and analysis
+modules are available for your simulator:
+
+.. code-block:: bash
+
+   # List config files in the simulator's vEcoli repo
+   uv run atlantis simulation configs 11
+
+   # List available analysis modules by category
+   uv run atlantis simulation analyses 11
+
+This is especially useful when working with custom vEcoli branches where the
+available configs and analysis modules differ from the defaults.
+
 Step 4--5: Run a Simulation
 ----------------------------
 
@@ -117,7 +134,12 @@ Submit a simulation workflow using your simulator ID:
      - Wait and display status updates until completion
    * - ``--config-filename``
      - ``api_simulation_default.json``
-     - Simulation configuration preset
+     - Simulation config file. Use ``simulation configs SIMULATOR_ID`` to
+       discover available files for your simulator.
+   * - ``--analysis-options``
+     - repo-aware defaults
+     - JSON string of analysis modules to run. Use ``simulation analyses
+       SIMULATOR_ID`` to discover available modules.
    * - ``--observables``
      - baseline (55 paths)
      - Comma-separated dot-path observables to record.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,7 +7,7 @@ Atlantis
 
 **Atlantis** is a platform for designing, running, and analyzing whole-cell
 simulations of *E. coli* using the
-`vEcoli <https://github.com/CovertLabEcoli/vEcoli-private>`_ model.
+`vEcoli <https://github.com/CovertLab/vEcoli>`_ model.
 
 You interact with Atlantis through one of three client applications --- each
 exposes the same end-to-end workflow (build a simulator, run a simulation,

--- a/docs/source/reference/configuration.rst
+++ b/docs/source/reference/configuration.rst
@@ -41,22 +41,38 @@ to switch servers at any time.
 Simulation Configuration Presets
 --------------------------------
 
-When submitting a simulation, you choose a configuration preset via
-``--config-filename`` (CLI) or the config dropdown (GUI/TUI):
+Available config filenames are **discovered dynamically** from the simulator's
+vEcoli repository. Different simulators (different commits, repos, branches)
+may have different configs available. Use the discovery command to see what's
+available for a given simulator:
 
-.. list-table::
-   :header-rows: 1
+.. code-block:: bash
 
-   * - Preset
-     - Description
-   * - ``api_simulation_default.json``
-     - Standard configuration (default)
-   * - ``api_simulation_default_ccam.json``
-     - CCAM configuration
-   * - ``api_simulation_default_aws_cdk.json``
-     - AWS CDK / Batch configuration
-   * - ``api_simulation_ptools_ccam.json``
-     - PTools CCAM configuration
+   uv run atlantis simulation configs SIMULATOR_ID
+
+The default is ``api_simulation_default.json``. If the config file doesn't
+exist in the repo, the server falls back to an embedded default template.
+
+Analysis Module Discovery
+-------------------------
+
+Analysis modules available for ``--analysis-options`` depend on what exists in
+the simulator's vEcoli repo under ``ecoli/analysis/{category}/``. Discover
+available modules before submitting:
+
+.. code-block:: bash
+
+   uv run atlantis simulation analyses SIMULATOR_ID
+
+Or via the REST API:
+
+.. code-block:: bash
+
+   curl http://localhost:8080/api/v1/simulations/discovery?simulator_id=16
+
+Analysis defaults are **repo-aware**: private vEcoli repo simulators get cd1_*
+modules by default; public repo simulators get no default analyses. User-specified
+``--analysis-options`` always overrides the defaults.
 
 Environment Variables
 ---------------------


### PR DESCRIPTION
## Summary

- **README image fix**: Path updated from `documentation/` to `docs/` (image was not rendering)
- **CLI trailing help**: `help` works as a trailing word at any nesting level (e.g. `atlantis simulation run help`)
- **Docs updated** for v0.7.4 features:
  - New `simulation configs` and `simulation analyses` discovery commands documented
  - Repo-aware analysis_options defaults explained
  - Static config preset table replaced with dynamic discovery guidance
  - Index links public vEcoli repo
  - `choosing-a-client.rst` updated with trailing help examples

## Test plan

- [x] `make check` passes
- [x] `atlantis simulation run help` shows run command help
- [x] `atlantis simulator help` shows simulator group help
- [x] README image renders on GitHub (path points to `docs/source/_static/wholecellecoli.png`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)