### PR TITLE
chore: bump version to 0.7.5, sync kustomize tags

### DIFF
--- a/kustomize/overlays/sms-api-rke-dev/kustomization.yaml
+++ b/kustomize/overlays/sms-api-rke-dev/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: sms-api-rke-dev
 
 images:
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.7.4
+    newTag: 0.7.5
   # ptools pinned to last-known-good tag — see Stanford-test kustomization
   # for rationale.  No sms-ptools:0.6.x image exists on ghcr.io because the
   # build-and-push GH Action's ptools step is broken.

--- a/kustomize/overlays/sms-api-rke/kustomization.yaml
+++ b/kustomize/overlays/sms-api-rke/kustomization.yaml
@@ -10,7 +10,7 @@ namespace: sms-api-rke
 
 images:
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.7.4
+    newTag: 0.7.5
   # ptools pinned to last-known-good tag — see Stanford-test kustomization
   # for rationale.  No sms-ptools:0.6.x image exists on ghcr.io because the
   # build-and-push GH Action's ptools step is broken.

--- a/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: sms-api-stanford-test
 
 images:
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.7.4
+    newTag: 0.7.5
   # ptools pinned to last-known-good tag — the build-and-push GH Action's
   # ptools step is currently broken (Dockerfile-nextflow issue), so there is
   # no sms-ptools:0.6.x image on ghcr.io.  0.5.9 is the tag the live Stanford

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sms_api"
-version = "0.7.4"
+version = "0.7.5"
 description = "This is the api server for Vivarium simulation services."
 authors = [{ name = "Alex Patrie", email = "alexanderpatrie@gmail.com" }, { name = "Jim Schaff", email = "jschaff@gmail.com" }]
 requires-python = "==3.12.9"

--- a/sms_api/version.py
+++ b/sms_api/version.py
@@ -12,4 +12,5 @@
 # 0.7.3 — generation range and seed filtering for ptools analysis endpoint
 # 0.7.4 — top-level DuckDB filters, strip private analyses from embedded template,
 #          repo-aware analysis_options defaults (cd1_* only for private vEcoli repo)
-__version__ = "0.7.4"
+# 0.7.5 — S3 streaming download (fix 504), README image, CLI trailing help, docs update
+__version__ = "0.7.5"

--- a/uv.lock
+++ b/uv.lock
@@ -3092,7 +3092,7 @@ wheels = [
 
 [[package]]
 name = "sms-api"
-version = "0.7.4"
+version = "0.7.5"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
## Summary

- Bump `sms_api/version.py` and `pyproject.toml` to 0.7.5
- Sync kustomize overlay tags for sms-api-stanford-test, sms-api-rke, sms-api-rke-dev

## What's in v0.7.5 (since v0.7.4)

- **PR #82**: Stream S3 outputs directly into tar.gz response — fixes ALB 504 on large downloads
- **PR #83**: README image fix, CLI trailing `help` at any nesting level, docs update for discovery commands and repo-aware defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)