### PR TITLE
fix: handle vanilla vEcoli configs on SLURM backend

### DIFF
--- a/sms_api/common/handlers/simulations.py
+++ b/sms_api/common/handlers/simulations.py
@@ -277,9 +277,6 @@ async def run_simulation_workflow(  # noqa: C901
     if config_data.get("emitter_arg", {}).get("out_dir") in (None, "", "out"):
         config_data["emitter_arg"]["out_dir"] = str(settings.hpc_sim_base_path)
     config_data.setdefault("analysis_options", {"multiseed": {}})
-    # The fork repo's workflow.py expects analysis_options.memory_gb
-    if simulator.git_repo_url == RepoUrl.VECOLI_FORK_REPO_URL:
-        config_data["analysis_options"].setdefault("memory_gb", 3)
     config_data.setdefault("single_daughters", True)
     config_data.setdefault("suffix_time", False)
     # Ensure parca_options.outdir points to HPC path (vanilla configs use relative "out")
@@ -363,6 +360,9 @@ async def run_simulation_workflow(  # noqa: C901
         specified_analyses = {"multiseed": {}}
 
     config_data["analysis_options"] = specified_analyses
+    # The fork repo's workflow.py expects analysis_options.memory_gb
+    if simulator.git_repo_url == RepoUrl.VECOLI_FORK_REPO_URL:
+        config_data["analysis_options"].setdefault("memory_gb", 3)
     config = SimulationConfig(**config_data)
 
     # 5. Create placeholder parca dataset entry

--- a/sms_api/common/handlers/simulations.py
+++ b/sms_api/common/handlers/simulations.py
@@ -272,7 +272,10 @@ async def run_simulation_workflow(  # noqa: C901
     if config_data.get("experiment_id") is None:
         config_data["experiment_id"] = unique_experiment_id
     config_data.setdefault("emitter", "parquet")
-    config_data.setdefault("emitter_arg", {"out_dir": str(settings.hpc_sim_base_path)})
+    config_data.setdefault("emitter_arg", {})
+    # Always ensure emitter_arg.out_dir points to the HPC output path (vanilla configs use relative "out")
+    if config_data.get("emitter_arg", {}).get("out_dir") in (None, "", "out"):
+        config_data["emitter_arg"]["out_dir"] = str(settings.hpc_sim_base_path)
     config_data.setdefault("analysis_options", {"multiseed": {}})
     config_data.setdefault("single_daughters", True)
     config_data.setdefault("suffix_time", False)

--- a/sms_api/common/handlers/simulations.py
+++ b/sms_api/common/handlers/simulations.py
@@ -320,9 +320,22 @@ async def run_simulation_workflow(  # noqa: C901
             # from S3 to this path before workflow.py runs (vEcoli only accepts local paths)
             config_data["sim_data_path"] = "/tmp/simData.cPickle"  # noqa: S108
     else:
-        # SLURM path: replace K8s-specific sections with SLURM equivalents
+        # SLURM path: replace K8s-specific sections with SLURM equivalents.
+        # The ccam Nextflow profile only exists in the fork (api-support branch)
+        # and the private repo — not in the public CovertLab/vEcoli repo.
         config_data.pop("aws_cdk", None)
         config_data.pop("aws", None)
+        _ccam_repos = {RepoUrl.VECOLI_FORK_REPO_URL, RepoUrl.VECOLI_PRIVATE_REPO_URL}
+        if simulator.git_repo_url not in _ccam_repos:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Simulator {simulator.database_id} ({simulator.git_repo_url} @ {simulator.git_branch}) "
+                    f"cannot run on SLURM — the ccam Nextflow profile is only available in the fork "
+                    f"(vivarium-collective/vEcoli @ api-support) or the private repo. "
+                    f"Build a simulator from one of those repos, or use the stanford-test (K8s) backend."
+                ),
+            )
         image_path_str = str(get_settings().hpc_image_base_path / f"vecoli-{simulator.git_commit_hash}.sif")
         config_data["ccam"] = {"build_image": False, "container_image": image_path_str}
         if not run_parca:

--- a/sms_api/common/handlers/simulations.py
+++ b/sms_api/common/handlers/simulations.py
@@ -319,9 +319,14 @@ async def run_simulation_workflow(  # noqa: C901
             # Set local path for cached simData — the K8s job command will download
             # from S3 to this path before workflow.py runs (vEcoli only accepts local paths)
             config_data["sim_data_path"] = "/tmp/simData.cPickle"  # noqa: S108
-    elif not run_parca:
-        # SLURM: use cached simData from HPC filesystem
-        config_data["sim_data_path"] = DEFAULT_SIMDATA_PATH.__str__()
+    else:
+        # SLURM path: replace K8s-specific sections with SLURM equivalents
+        config_data.pop("aws_cdk", None)
+        config_data.pop("aws", None)
+        image_path_str = str(get_settings().hpc_image_base_path / f"vecoli-{simulator.git_commit_hash}.sif")
+        config_data["ccam"] = {"build_image": False, "container_image": image_path_str}
+        if not run_parca:
+            config_data["sim_data_path"] = DEFAULT_SIMDATA_PATH.__str__()
 
     # Default analysis modules depend on the simulator's source repo:
     # cd1_* modules only exist in the private vEcoli repo, so public-repo

--- a/sms_api/common/handlers/simulations.py
+++ b/sms_api/common/handlers/simulations.py
@@ -277,6 +277,9 @@ async def run_simulation_workflow(  # noqa: C901
     if config_data.get("emitter_arg", {}).get("out_dir") in (None, "", "out"):
         config_data["emitter_arg"]["out_dir"] = str(settings.hpc_sim_base_path)
     config_data.setdefault("analysis_options", {"multiseed": {}})
+    # The fork repo's workflow.py expects analysis_options.memory_gb
+    if simulator.git_repo_url == RepoUrl.VECOLI_FORK_REPO_URL:
+        config_data["analysis_options"].setdefault("memory_gb", 3)
     config_data.setdefault("single_daughters", True)
     config_data.setdefault("suffix_time", False)
     # Ensure parca_options.outdir points to HPC path (vanilla configs use relative "out")

--- a/sms_api/common/handlers/simulations.py
+++ b/sms_api/common/handlers/simulations.py
@@ -267,6 +267,16 @@ async def run_simulation_workflow(  # noqa: C901
     config_str = config_str.replace("SIMULATOR_IMAGE_PATH_PLACEHOLDER", str(image_path))
     config_data = json.loads(config_str)
 
+    # 3b. Ensure required fields exist (vanilla vEcoli configs may lack API placeholders)
+    config_data.setdefault("experiment_id", unique_experiment_id)
+    if config_data.get("experiment_id") is None:
+        config_data["experiment_id"] = unique_experiment_id
+    config_data.setdefault("emitter", "parquet")
+    config_data.setdefault("emitter_arg", {"out_dir": str(settings.hpc_sim_base_path)})
+    config_data.setdefault("analysis_options", {"multiseed": {}})
+    config_data.setdefault("single_daughters", True)
+    config_data.setdefault("suffix_time", False)
+
     # 4. Override config values if provided
     if num_generations is not None:
         config_data["generations"] = num_generations

--- a/sms_api/common/handlers/simulations.py
+++ b/sms_api/common/handlers/simulations.py
@@ -279,6 +279,13 @@ async def run_simulation_workflow(  # noqa: C901
     config_data.setdefault("analysis_options", {"multiseed": {}})
     config_data.setdefault("single_daughters", True)
     config_data.setdefault("suffix_time", False)
+    # Ensure parca_options.outdir points to HPC path (vanilla configs use relative "out")
+    if "parca_options" in config_data:
+        parca_outdir = config_data["parca_options"].get("outdir", "")
+        if not parca_outdir or parca_outdir == "out":
+            config_data["parca_options"]["outdir"] = str(settings.hpc_sim_base_path)
+    else:
+        config_data["parca_options"] = {"outdir": str(settings.hpc_sim_base_path), "cpus": 6}
 
     # 4. Override config values if provided
     if num_generations is not None:

--- a/sms_api/simulation/simulation_service.py
+++ b/sms_api/simulation/simulation_service.py
@@ -473,14 +473,23 @@ class SimulationServiceHpc(SimulationService):
         async with get_ssh_session_service(SSHTarget.SLURM).session() as ssh:
             returncode, stdout, stderr = await ssh.run_command(f"cat {remote_config_path}")
             if returncode != 0:
-                # Config not found in repo — fall back to embedded API template
-                # (same behavior as K8s backend for public repos without api_* configs)
                 logger.warning(
                     "Config %s not found at %s — using embedded default template",
                     config_filename,
                     remote_config_path,
                 )
                 return json.dumps(_DEFAULT_CONFIG_TEMPLATE)
+
+        # If the config is a vanilla vEcoli config (no API placeholders), use
+        # the embedded template instead — vanilla configs have internal relative
+        # paths that don't work in the API pipeline.
+        if "EXPERIMENT_ID_PLACEHOLDER" not in stdout:
+            logger.warning(
+                "Config %s is a vanilla vEcoli config (no API placeholders) — using embedded default template",
+                config_filename,
+            )
+            return json.dumps(_DEFAULT_CONFIG_TEMPLATE)
+
         return stdout
 
     @override

--- a/sms_api/simulation/simulation_service.py
+++ b/sms_api/simulation/simulation_service.py
@@ -460,6 +460,8 @@ class SimulationServiceHpc(SimulationService):
 
     @override
     async def read_config_template(self, simulator_version: SimulatorVersion, config_filename: str) -> str:
+        from sms_api.simulation.simulation_service_k8s import _DEFAULT_CONFIG_TEMPLATE
+
         settings = get_settings()
         remote_config_path = (
             settings.hpc_repo_base_path.remote_path
@@ -471,7 +473,14 @@ class SimulationServiceHpc(SimulationService):
         async with get_ssh_session_service(SSHTarget.SLURM).session() as ssh:
             returncode, stdout, stderr = await ssh.run_command(f"cat {remote_config_path}")
             if returncode != 0:
-                raise ValueError(f"Failed to read config file {remote_config_path}: {stderr}")
+                # Config not found in repo — fall back to embedded API template
+                # (same behavior as K8s backend for public repos without api_* configs)
+                logger.warning(
+                    "Config %s not found at %s — using embedded default template",
+                    config_filename,
+                    remote_config_path,
+                )
+                return json.dumps(_DEFAULT_CONFIG_TEMPLATE)
         return stdout
 
     @override

--- a/tests/integration/test_k8s_workflow_mock.py
+++ b/tests/integration/test_k8s_workflow_mock.py
@@ -255,13 +255,14 @@ async def test_analysis_options_default_public_repo(
     )
     simulation_service_k8s_mock.read_config_template = AsyncMock(return_value=CONFIG_TEMPLATE)  # type: ignore[method-assign]
 
-    await sim_handlers.run_simulation_workflow(
-        database_service=database_service,
-        simulation_service=simulation_service_k8s_mock,
-        simulator_id=simulator.database_id,
-        experiment_id="public-repo-analysis",
-        simulation_config_filename="api_simulation_default.json",
-    )
+    with patch("sms_api.common.handlers.simulations.get_job_backend", return_value=ComputeBackend.BATCH):
+        await sim_handlers.run_simulation_workflow(
+            database_service=database_service,
+            simulation_service=simulation_service_k8s_mock,
+            simulator_id=simulator.database_id,
+            experiment_id="public-repo-analysis",
+            simulation_config_filename="api_simulation_default.json",
+        )
 
     configmap = mock_k8s_job_service.create_configmap.call_args[0][0]
     config_data = json.loads(configmap.data["workflow.json"])
@@ -404,14 +405,15 @@ async def test_analysis_options_validation_accepts_valid_module(
     simulation_service_k8s_mock.discover_repo_contents = AsyncMock(return_value=discovery)  # type: ignore[method-assign]
 
     valid_analyses = AnalysisOptions.model_validate({"multiseed": {"ptools_rna": {"n_tp": 10}}})
-    simulation = await sim_handlers.run_simulation_workflow(
-        database_service=database_service,
-        simulation_service=simulation_service_k8s_mock,
-        simulator_id=simulator.database_id,
-        experiment_id="valid-module-test",
-        simulation_config_filename="api_simulation_default.json",
-        analysis_options=valid_analyses,
-    )
+    with patch("sms_api.common.handlers.simulations.get_job_backend", return_value=ComputeBackend.BATCH):
+        simulation = await sim_handlers.run_simulation_workflow(
+            database_service=database_service,
+            simulation_service=simulation_service_k8s_mock,
+            simulator_id=simulator.database_id,
+            experiment_id="valid-module-test",
+            simulation_config_filename="api_simulation_default.json",
+            analysis_options=valid_analyses,
+        )
     assert simulation.database_id is not None
 
 
@@ -434,13 +436,14 @@ async def test_discovery_failure_does_not_block_workflow(
     simulation_service_k8s_mock.discover_repo_contents = AsyncMock(side_effect=RuntimeError("GitHub API down"))  # type: ignore[method-assign]
 
     user_analyses = AnalysisOptions.model_validate({"multiseed": {"anything": {}}})
-    simulation = await sim_handlers.run_simulation_workflow(
-        database_service=database_service,
-        simulation_service=simulation_service_k8s_mock,
-        simulator_id=simulator.database_id,
-        experiment_id="discovery-fail-test",
-        simulation_config_filename="api_simulation_default.json",
-        analysis_options=user_analyses,
-    )
+    with patch("sms_api.common.handlers.simulations.get_job_backend", return_value=ComputeBackend.BATCH):
+        simulation = await sim_handlers.run_simulation_workflow(
+            database_service=database_service,
+            simulation_service=simulation_service_k8s_mock,
+            simulator_id=simulator.database_id,
+            experiment_id="discovery-fail-test",
+            simulation_config_filename="api_simulation_default.json",
+            analysis_options=user_analyses,
+        )
     # Should succeed despite discovery failure
     assert simulation.database_id is not None


### PR DESCRIPTION
## Summary

Enables SLURM backend to work with all three vEcoli repo types (fork, private, public).

- **Vanilla config detection**: Configs without `EXPERIMENT_ID_PLACEHOLDER` fall back to the embedded API template — vanilla vEcoli configs have relative paths that don't work in the API pipeline
- **SLURM template fallback**: Same fallback behavior as K8s backend when config file is missing from the repo
- **Required field injection**: `experiment_id`, `emitter`, `emitter_arg.out_dir`, `parca_options.outdir` — ensures API fields exist even if the config lacks them
- **`aws_cdk` → `ccam` replacement**: SLURM backend strips K8s-specific sections and injects the `ccam` Nextflow profile with the Singularity image path
- **Public repo guard**: Clear 400 error when a public repo simulator is used on SLURM (no `ccam` Nextflow profile available)
- **Fork repo `memory_gb`**: Injects `analysis_options.memory_gb` for `vivarium-collective/vEcoli` simulators (fork `workflow.py` requires it)
- **CI fix**: K8s mock tests now patch `get_job_backend` to BATCH so the SLURM ccam guard doesn't interfere

## Verified

- Sim 64: fork simulator 3 (`vivarium-collective/vEcoli @ api-support`) on RKE with `api_simulation_default_ccam.json` — **COMPLETED** (660s)
- Sim 39 (public repo) on SLURM → clear 400 error explaining ccam profile requirement
- All existing stanford-test (K8s) functionality unchanged
- 11 K8s mock tests pass locally (including patched backend tests)

## Test plan

- [x] `make check` passes
- [x] E2E on RKE: fork simulator, CCAM config, 1 gen / 1 seed — COMPLETED
- [x] Public repo simulator on SLURM returns clear 400 error
- [x] Stanford-test (K8s) path unaffected
- [x] CI: K8s mock tests patched for SLURM ccam guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)