### PR TITLE
ci: group dependabot updates into single PR per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    groups:
+      all-pip:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    groups:
+      all-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Configure dependabot to group all pip updates into one PR and all GitHub Actions updates into one PR per weekly scan, instead of individual PRs per dependency.