### PR TITLE
fix: explicit config validation, diagnostics, CLI error handling

### DIFF
--- a/.github/workflows/live-integration.yml
+++ b/.github/workflows/live-integration.yml
@@ -1,0 +1,48 @@
+name: Live Integration Tests
+
+# Manual-only trigger — never runs automatically.
+# These tests hit live infrastructure (RKE prod) and must only be run
+# when the target server is known to be healthy and the test payloads
+# are appropriate for the current data state.
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "API base URL to test against"
+        required: true
+        default: "https://sms.cam.uchc.edu"
+        type: choice
+        options:
+          - "https://sms.cam.uchc.edu"
+          - "https://sms-dev.cam.uchc.edu"
+      experiment_id:
+        description: "Experiment ID for analysis tests"
+        required: true
+        default: "sim3-test-5062"
+
+jobs:
+  analysis-integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Run analysis single test
+        env:
+          BASE_URL: ${{ inputs.base_url }}
+          EXPERIMENT_ID: ${{ inputs.experiment_id }}
+        run: |
+          # Substitute the base URL and experiment ID into the test scripts
+          sed -i "s|https://sms.cam.uchc.edu|${BASE_URL}|g" tests/clients/test_analyses_single.mjs
+          sed -i "s|sim3-test-5062|${EXPERIMENT_ID}|g" tests/clients/test_analyses_single.mjs
+          node tests/clients/test_analyses_single.mjs
+
+      - name: Run analysis compare test
+        env:
+          BASE_URL: ${{ inputs.base_url }}
+          EXPERIMENT_ID: ${{ inputs.experiment_id }}
+        run: |
+          sed -i "s|https://sms.cam.uchc.edu|${BASE_URL}|g" tests/clients/test_analyses_compare.mjs
+          sed -i "s|sim3-test-5062|${EXPERIMENT_ID}|g" tests/clients/test_analyses_compare.mjs
+          node tests/clients/test_analyses_compare.mjs

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ uv sync
 # Build a simulator (public vEcoli repo)
 uv run atlantis simulator latest --repo-url https://github.com/CovertLab/vEcoli --branch master
 
+# List resources (--n slices: positive = first N, negative = last N by ID)
+uv run atlantis simulation list --n -1       # most recent simulation
+uv run atlantis simulator list --n 3         # first 3 simulators
+
 # Discover available configs and analysis modules for your simulator
 uv run atlantis simulation configs 16
 uv run atlantis simulation analyses 16

--- a/app/app_data_service.py
+++ b/app/app_data_service.py
@@ -251,10 +251,12 @@ class E2EDataService:
         try:
             simulators = self.client.get(url="/core/v1/simulator/versions")
             if simulators.status_code != 200:
-                raise httpx.HTTPError("Error!")  # noqa: TRY301
+                raise httpx.HTTPError(f"Server returned {simulators.status_code}: {simulators.text}")  # noqa: TRY301
             return [SimulatorVersion(**sim) for sim in simulators.json()["versions"]]
+        except httpx.HTTPError:
+            raise
         except Exception as e:
-            raise httpx.HTTPError("Could not load simulators") from e
+            raise httpx.HTTPError(f"Could not list simulators: {e}") from e
 
     def submit_get_simulator_build_status(self, simulator: SimulatorVersion) -> str:
         try:
@@ -262,10 +264,14 @@ class E2EDataService:
                 url="/core/v1/simulator/status", params={"simulator_id": simulator.database_id}
             )
             if status_update_response.status_code != 200:
-                raise httpx.HTTPError("Error!")  # noqa: TRY301
+                raise httpx.HTTPError(  # noqa: TRY301
+                    f"Server returned {status_update_response.status_code}: {status_update_response.text}"
+                )
             return status_update_response.json().get("status", "")  # type: ignore[no-any-return]
+        except httpx.HTTPError:
+            raise
         except Exception as e:
-            raise httpx.HTTPError(f"Could not fetch build status for simulator: {simulator.model_dump()}") from e
+            raise httpx.HTTPError(f"Could not fetch build status for simulator {simulator.database_id}: {e}") from e
 
     def submit_get_simulator_build_status_full(self, simulator_id: int) -> HpcRun:
         try:
@@ -284,10 +290,14 @@ class E2EDataService:
                 url="/core/v1/simulator/status", params={"simulator_id": simulator_id}
             )
             if status_update_response.status_code != 200:
-                raise httpx.HTTPError("Error!")  # noqa: TRY301
+                raise httpx.HTTPError(  # noqa: TRY301
+                    f"Server returned {status_update_response.status_code}: {status_update_response.text}"
+                )
             return status_update_response.json().get("status", "")  # type: ignore[no-any-return]
+        except httpx.HTTPError:
+            raise
         except Exception as e:
-            raise httpx.HTTPError(f"Could not fetch build status for simulator with id: {simulator_id}") from e
+            raise httpx.HTTPError(f"Could not fetch build status for simulator {simulator_id}: {e}") from e
 
     # -- Low-level HTTP methods: Simulation --
 
@@ -343,10 +353,14 @@ class E2EDataService:
         try:
             status_update_response = self.client.get(url=f"/api/v1/simulations/{simulation_id}/status")
             if status_update_response.status_code != 200:
-                raise httpx.HTTPError("Error!")  # noqa: TRY301
+                raise httpx.HTTPError(  # noqa: TRY301
+                    f"Server returned {status_update_response.status_code}: {status_update_response.text}"
+                )
             return SimulationRun(**status_update_response.json())
+        except httpx.HTTPError:
+            raise
         except Exception as e:
-            raise httpx.HTTPError(f"Could not load status for simulation {simulation_id}") from e
+            raise httpx.HTTPError(f"Could not load status for simulation {simulation_id}: {e}") from e
 
     def submit_cancel_workflow(self, simulation_id: int) -> SimulationRun:
         try:
@@ -363,28 +377,34 @@ class E2EDataService:
         try:
             data_response = self.client.post(url=f"/api/v1/simulations/{simulation_id}/data")
             if data_response.status_code != 200:
-                raise httpx.HTTPError("Error!")  # noqa: TRY301
+                raise httpx.HTTPError(f"Server returned {data_response.status_code}: {data_response.text}")  # noqa: TRY301
             return [TsvOutputFile(**output) for output in data_response.json()]
+        except httpx.HTTPError:
+            raise
         except Exception as e:
-            raise httpx.HTTPError("Could not load simulation data") from e
+            raise httpx.HTTPError(f"Could not load output data for simulation {simulation_id}: {e}") from e
 
     def submit_get_workflow(self, simulation_id: int) -> Simulation:
         try:
             simulation = self.client.get(url=f"/api/v1/simulations/{simulation_id}")
             if simulation.status_code != 200:
-                raise httpx.HTTPError("Error!")  # noqa: TRY301
+                raise httpx.HTTPError(f"Server returned {simulation.status_code}: {simulation.text}")  # noqa: TRY301
             return Simulation(**simulation.json())
+        except httpx.HTTPError:
+            raise
         except Exception as e:
-            raise httpx.HTTPError("Could not load simulation data") from e
+            raise httpx.HTTPError(f"Could not load simulation {simulation_id}: {e}") from e
 
     def submit_list_workflows(self) -> list[Simulation]:
         try:
             simulations = self.client.get(url="/api/v1/simulations")
             if simulations.status_code != 200:
-                raise httpx.HTTPError("Error!")  # noqa: TRY301
+                raise httpx.HTTPError(f"Server returned {simulations.status_code}: {simulations.text}")  # noqa: TRY301
             return [Simulation(**sim) for sim in simulations.json()]
+        except httpx.HTTPError:
+            raise
         except Exception as e:
-            raise httpx.HTTPError("Could not load simulation data") from e
+            raise httpx.HTTPError(f"Could not list simulations: {e}") from e
 
     def submit_get_workflow_log(self, simulation_id: int, truncate: bool = True) -> str:
         try:
@@ -393,10 +413,12 @@ class E2EDataService:
                 params={"truncate": str(truncate).lower()},
             )
             if structured_log.status_code != 200:
-                raise httpx.HTTPError("Error!")  # noqa: TRY301
+                raise httpx.HTTPError(f"Server returned {structured_log.status_code}: {structured_log.text}")  # noqa: TRY301
             return structured_log.text
+        except httpx.HTTPError:
+            raise
         except Exception as e:
-            raise httpx.HTTPError("Could not load simulation log") from e
+            raise httpx.HTTPError(f"Could not load log for simulation {simulation_id}: {e}") from e
 
     # -- Low-level HTTP methods: Parca --
 

--- a/app/cli.py
+++ b/app/cli.py
@@ -128,6 +128,24 @@ def cli_error_handler(fn: Callable[..., Any]) -> Callable[..., Any]:
     return wrapper
 
 
+def _slice_by_id(items: list[Any], n: int | None) -> list[Any]:
+    """Slice a list of model objects by database_id order.
+
+    Args:
+        items: List of pydantic models with a ``database_id`` attribute.
+        n: If positive, return the first N (lowest IDs). If negative, return
+           the last |N| (highest IDs). If None or 0, return all.
+    """
+    if not n or not items:
+        return items
+    has_id = hasattr(items[0], "database_id")
+    if has_id:
+        items = sorted(items, key=lambda x: x.database_id)
+    if n > 0:
+        return items[:n]
+    return items[n:]
+
+
 class CliType(StrEnumBase):
     SIMULATOR = "simulator"
     SIMULATION = "simulation"
@@ -322,13 +340,17 @@ def simulator_latest(
     display_json(uploaded.model_dump(), console)
 
 
-@simulator_cli.command("list", help="List all registered simulator versions.")
+@simulator_cli.command("list", help="List registered simulator versions.")
 def simulator_list(
+    n: int | None = Option(
+        default=None, help="Number of entries to show. Positive = first N, negative = last N (by ID)."
+    ),
     base_url: ApiBaseUrl = Option(default=API_BASE_URL, help="API server base URL."),
 ) -> None:
     console = get_console()
     data_service = get_data_service(base_url=base_url)
     simulators = data_service.show_simulators()
+    simulators = _slice_by_id(simulators, n)
     for sim in simulators:
         display_json(sim.model_dump(), console)
 
@@ -462,13 +484,17 @@ def simulation_get(
     display_json(simulation.model_dump(), console)
 
 
-@simulation_cli.command("list", help="List all simulations.")
+@simulation_cli.command("list", help="List simulations.")
 def simulation_list(
+    n: int | None = Option(
+        default=None, help="Number of entries to show. Positive = first N, negative = last N (by ID)."
+    ),
     base_url: ApiBaseUrl = Option(default=API_BASE_URL, help="API server base URL."),
 ) -> None:
     console = get_console()
     data_service = get_data_service(base_url=base_url)
     simulations = data_service.show_workflows()
+    simulations = _slice_by_id(simulations, n)
     for sim in simulations:
         display_json(sim.model_dump(), console)
 
@@ -607,13 +633,17 @@ def simulation_analysis(
 # -- Parca commands --
 
 
-@parca_cli.command("list", help="List all parca datasets.")
+@parca_cli.command("list", help="List parca datasets.")
 def parca_list(
+    n: int | None = Option(
+        default=None, help="Number of entries to show. Positive = first N, negative = last N (by ID)."
+    ),
     base_url: ApiBaseUrl = Option(default=API_BASE_URL, help="API server base URL."),
 ) -> None:
     console = get_console()
     data_service = get_data_service(base_url=base_url)
     datasets = data_service.get_parca_datasets()
+    datasets = _slice_by_id(datasets, n)
     for ds in datasets:
         display_json(ds.model_dump(), console)
 

--- a/app/cli.py
+++ b/app/cli.py
@@ -1,24 +1,131 @@
 from __future__ import annotations
 
 import asyncio
+import functools
+import json as _json_mod
 import os
 import subprocess
+import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from sms_api.common import StrEnumBase
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from rich.console import Console
 
     from sms_api.common.storage.file_service_s3 import FileServiceS3
 
+import httpx
 import typer
 from typer import Argument, Option
 
 from app.app_data_service import get_data_service
 from app.cli_theme import display_json, get_console, print_banner, status_border, status_style
 from app.tui import AtlantisTUI
+
+
+def _format_server_detail(body: str) -> str:
+    """Extract the 'detail' field from a JSON error body, or return the body as-is."""
+    try:
+        parsed = _json_mod.loads(body)
+        if isinstance(parsed, dict) and "detail" in parsed:
+            return str(parsed["detail"])
+    except (ValueError, TypeError):
+        pass
+    return body.strip()
+
+
+def _handle_cli_error(e: Exception, console: Console | None = None) -> None:
+    """Render a user-friendly error panel for common exception types."""
+    from rich.panel import Panel
+
+    if console is None:
+        console = get_console()
+
+    if isinstance(e, httpx.ConnectError | ConnectionError | OSError) or _is_connection_error(e):
+        console.print(
+            Panel(
+                "[memphis.error]Could not connect to the API server.[/]\n\n"
+                "Check that the server is running and the --base-url is correct.\n"
+                f"Detail: {e}",
+                title="Connection Error",
+                border_style="memphis.border.error",
+            )
+        )
+    elif isinstance(e, httpx.HTTPStatusError):
+        detail = _format_server_detail(e.response.text)
+        code = e.response.status_code
+        console.print(
+            Panel(
+                f"[memphis.error]Server returned {code}[/]\n\n{detail}",
+                title="API Error",
+                border_style="memphis.border.error",
+            )
+        )
+    elif isinstance(e, httpx.HTTPError):
+        msg = str(e)
+        # Extract JSON detail from messages like "Server returned 400: {"detail":"..."}"
+        json_start = msg.find("{")
+        if json_start >= 0:
+            prefix = msg[:json_start].strip().rstrip(":")
+            detail = _format_server_detail(msg[json_start:])
+            label = prefix if prefix else "HTTP Error"
+        else:
+            detail = msg
+            label = "HTTP Error"
+        console.print(
+            Panel(
+                f"[memphis.error]{label}[/]\n\n{detail}",
+                title="API Error",
+                border_style="memphis.border.error",
+            )
+        )
+    elif isinstance(e, _json_mod.JSONDecodeError):
+        console.print(
+            Panel(
+                f"[memphis.error]Invalid JSON input.[/]\n\n{e.msg}\n  at position {e.pos}",
+                title="Input Error",
+                border_style="memphis.border.error",
+            )
+        )
+    elif isinstance(e, KeyboardInterrupt):
+        console.print("\n[memphis.warning]Cancelled.[/]")
+    else:
+        console.print(
+            Panel(
+                f"[memphis.error]{type(e).__name__}[/]: {e}",
+                title="Error",
+                border_style="memphis.border.error",
+            )
+        )
+
+    if os.environ.get("ATLANTIS_DEBUG"):
+        console.print_exception(show_locals=True)
+
+
+def _is_connection_error(e: Exception) -> bool:
+    """Check if an exception is a connection-related error."""
+    err_str = str(e).lower()
+    return any(s in err_str for s in ("connect", "refused", "unreachable", "timed out", "no route"))
+
+
+def cli_error_handler(fn: Callable[..., Any]) -> Callable[..., Any]:
+    """Decorator that catches exceptions and renders user-friendly error messages."""
+
+    @functools.wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        try:
+            return fn(*args, **kwargs)
+        except (SystemExit, KeyboardInterrupt):
+            raise
+        except Exception as e:
+            _handle_cli_error(e)
+            raise typer.Exit(1) from None
+
+    return wrapper
 
 
 class CliType(StrEnumBase):
@@ -67,14 +174,21 @@ cli.add_typer(tkapp_cli)
 
 
 def main() -> None:
-    import sys
-
     # Allow "help" as a trailing word at any nesting level:
     # e.g. "atlantis simulation run help" → "atlantis simulation run --help"
     if len(sys.argv) > 1 and sys.argv[-1] == "help":
         sys.argv[-1] = "--help"
 
-    cli()
+    try:
+        cli()
+    except SystemExit:
+        raise
+    except KeyboardInterrupt:
+        get_console().print("\n[memphis.warning]Cancelled.[/]")
+        raise SystemExit(130) from None
+    except Exception as e:
+        _handle_cli_error(e)
+        raise SystemExit(1) from None
 
 
 # -- Info/Help --

--- a/app/cli_theme.py
+++ b/app/cli_theme.py
@@ -85,8 +85,18 @@ def get_console() -> Console:
 
 
 def display_json(content: dict[str, object] | list[object] | str, console: Console | None = None) -> None:
-    """Display JSON data using the 256-color-safe native Pygments theme."""
+    """Display JSON data using the 256-color-safe native Pygments theme.
+
+    When stdout is not a TTY (i.e. piped to jq, grep, etc.), outputs raw JSON
+    without ANSI codes so downstream tools can parse it.
+    """
     import json
+    import sys
+
+    if not sys.stdout.isatty():
+        raw = content if isinstance(content, str) else json.dumps(content, indent=2, default=str)
+        print(raw)
+        return
 
     from rich.syntax import Syntax
 

--- a/docs/source/guides/cli-reference.rst
+++ b/docs/source/guides/cli-reference.rst
@@ -64,11 +64,21 @@ Fetch the latest commit, upload, and build a simulator image.
 simulator list
 ~~~~~~~~~~~~~~
 
-List all registered simulator versions.
+List registered simulator versions.
 
 .. code-block:: bash
 
    uv run atlantis simulator list
+   uv run atlantis simulator list --n 3     # first 3 (by ID)
+   uv run atlantis simulator list --n -1    # most recent
+
+.. list-table::
+   :widths: 30 70
+
+   * - Option
+     - Description
+   * - ``--n INTEGER``
+     - Number of entries. Positive = first N, negative = last N (by ID).
 
 simulator status
 ~~~~~~~~~~~~~~~~
@@ -174,11 +184,21 @@ Get a simulation by its database ID.
 simulation list
 ~~~~~~~~~~~~~~~
 
-List all simulations.
+List simulations.
 
 .. code-block:: bash
 
    uv run atlantis simulation list
+   uv run atlantis simulation list --n -1    # most recent simulation
+   uv run atlantis simulation list --n 5     # first 5 (by ID)
+
+.. list-table::
+   :widths: 30 70
+
+   * - Option
+     - Description
+   * - ``--n INTEGER``
+     - Number of entries. Positive = first N, negative = last N (by ID).
 
 simulation configs
 ~~~~~~~~~~~~~~~~~~
@@ -297,6 +317,15 @@ parca list
 .. code-block:: bash
 
    uv run atlantis parca list
+   uv run atlantis parca list --n -3    # last 3 parca datasets
+
+.. list-table::
+   :widths: 30 70
+
+   * - Option
+     - Description
+   * - ``--n INTEGER``
+     - Number of entries. Positive = first N, negative = last N (by ID).
 
 parca status
 ~~~~~~~~~~~~

--- a/kustomize/overlays/sms-api-rke-dev/kustomization.yaml
+++ b/kustomize/overlays/sms-api-rke-dev/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: sms-api-rke-dev
 
 images:
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.7.7
+    newTag: 0.7.8
   # ptools pinned to last-known-good tag — see Stanford-test kustomization
   # for rationale.  No sms-ptools:0.6.x image exists on ghcr.io because the
   # build-and-push GH Action's ptools step is broken.

--- a/kustomize/overlays/sms-api-rke/kustomization.yaml
+++ b/kustomize/overlays/sms-api-rke/kustomization.yaml
@@ -10,7 +10,7 @@ namespace: sms-api-rke
 
 images:
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.7.7
+    newTag: 0.7.8
   # ptools pinned to last-known-good tag — see Stanford-test kustomization
   # for rationale.  No sms-ptools:0.6.x image exists on ghcr.io because the
   # build-and-push GH Action's ptools step is broken.

--- a/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: sms-api-stanford-test
 
 images:
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.7.7
+    newTag: 0.7.8
   # ptools pinned to last-known-good tag — the build-and-push GH Action's
   # ptools step is currently broken (Dockerfile-nextflow issue), so there is
   # no sms-ptools:0.6.x image on ghcr.io.  0.5.9 is the tag the live Stanford

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sms_api"
-version = "0.7.7"
+version = "0.7.8"
 description = "This is the api server for Vivarium simulation services."
 authors = [{ name = "Alex Patrie", email = "alexanderpatrie@gmail.com" }, { name = "Jim Schaff", email = "jschaff@gmail.com" }]
 requires-python = "==3.12.9"

--- a/scripts/diagnose_sim.py
+++ b/scripts/diagnose_sim.py
@@ -1,0 +1,590 @@
+"""
+diagnose_sim.py — one-shot diagnostic for a failed atlantis simulation.
+
+Pulls the Nextflow workflow log via the sms-api data service, parses it for
+task status, then fetches each failing (or silently-empty) task's
+``.command.err`` / ``.command.out`` / ``.command.sh`` directly from S3 so
+the user can see the actual Python traceback, stderr, and argv the
+container received.
+
+Usage
+-----
+::
+
+    uv run python scripts/diagnose_sim.py <SIM_ID>
+
+    # Optional overrides:
+    uv run python scripts/diagnose_sim.py <SIM_ID> \\
+        --base-url https://sms.cam.uchc.edu \\
+        --bucket smsvpctest-shared-sharedbucket60d199d6-abfvwv0day91 \\
+        --tail 40                    # how many lines of each file to show
+
+The bucket is auto-detected from ``Settings.storage_s3_bucket`` /
+``Settings.s3_work_bucket`` when available; ``--bucket`` only needs to be
+passed if those aren't configured locally.
+
+What it reports
+---------------
+1. Sim header: status, experiment_id, simulator commit, Batch job id.
+2. Nextflow log tail (last ~30 lines) for context.
+3. Per-task breakdown: status (✓ / FAILED / IGNORED / running / pending),
+   hash, process name, and — for tasks that failed or that completed but
+   produced no downstream work — the ``.command.err`` tail.
+4. A parca_out check: lists the contents of the expected kb output
+   locations to catch "success-but-empty-output" bugs (e.g. parca wrote
+   somewhere different from what template.nf published).
+
+This script makes no changes; it is read-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+
+try:
+    import boto3
+    from botocore.exceptions import ClientError
+except ImportError:
+    print("boto3 is required. Install with `uv sync` (it's a project dep).")
+    sys.exit(1)
+
+# Make the sms-api package importable when running this script directly
+import os
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from app.app_data_service import get_data_service  # noqa: E402
+from sms_api.config import get_settings  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Log-parsing utilities
+# ---------------------------------------------------------------------------
+
+# Nextflow status-table lines, e.g.:
+#   [78/9f57e8] runParca (1)        | 1 of 1 ✔
+#   [00/d563ca] createVariants (1)  | 1 of 1, ignored: 1 ✔
+#   [-        ] sim_gen_1           -
+_PROC_LINE = re.compile(
+    r"\[(?P<hash>[a-f0-9]{2}/[a-f0-9]{6}|-\s*)\]\s+"
+    r"(?P<process>\S+(?:\s*\(\d+\))?)\s+"
+    r"(?:\|\s+)?(?P<status>.*?)$"
+)
+
+# Explicit "Process X failed" / NOTE / Caused-by blocks
+_FAIL_NOTE = re.compile(
+    r"\[(?P<hash>[a-f0-9]{2}/[a-f0-9]{6})\]\s+NOTE:\s+Process\s+"
+    r"`(?P<process>[^`]+)`\s+failed"
+)
+
+# Explicit work dir URIs that sometimes appear on caused-by blocks
+_WORK_DIR_URI = re.compile(r"s3://\S+/nextflow_workdirs/[a-f0-9]{2}/[a-f0-9]+")
+
+
+@dataclass
+class TaskRecord:
+    hash_prefix: str  # e.g. "78/9f57e8"
+    process: str  # e.g. "runParca (1)"
+    status_raw: str  # the tail of the progress line
+    failed: bool
+    ignored: bool
+    completed: bool
+    work_uri: str | None = None  # filled in by S3 search
+
+    @property
+    def label(self) -> str:
+        if self.failed and self.ignored:
+            return "FAILED (ignored)"
+        if self.failed:
+            return "FAILED"
+        if self.ignored:
+            return "ignored"
+        if self.completed:
+            return "OK"
+        return "running / pending"
+
+
+def parse_log(log: str) -> list[TaskRecord]:
+    """
+    Walk the workflow log and return one TaskRecord per distinct task hash.
+    Later status lines for the same hash overwrite earlier ones so we end
+    up with the final state.
+    """
+    by_hash: dict[str, TaskRecord] = {}
+    failed_processes: dict[str, str] = {}  # hash -> process (from NOTE line)
+
+    # First pass: collect explicit failure notes (Nextflow emits these even
+    # when errorStrategy='ignore' hides the failure from the progress table).
+    for line in log.splitlines():
+        m = _FAIL_NOTE.search(line)
+        if m:
+            failed_processes[m.group("hash")] = m.group("process")
+
+    for line in log.splitlines():
+        # Skip NOTE lines entirely — _PROC_LINE would otherwise match them
+        # with "NOTE:" as the process name.
+        if "NOTE:" in line or "WARN:" in line:
+            continue
+        m = _PROC_LINE.search(line)
+        if not m:
+            continue
+        h = m.group("hash").strip()
+        if h == "-":
+            continue  # pending task with no hash yet
+        process = m.group("process").strip()
+        status = m.group("status").strip()
+        # Reject false-positive "processes" like a bare "NOTE:" that slipped
+        # through (defense in depth).
+        if process.endswith(":"):
+            continue
+
+        failed = h in failed_processes or "FAILED" in status.upper() or "error" in status.lower()
+        ignored = "ignored" in status.lower()
+        completed = "✔" in status
+
+        by_hash[h] = TaskRecord(
+            hash_prefix=h,
+            process=process,
+            status_raw=status,
+            failed=failed,
+            ignored=ignored,
+            completed=completed and not failed,
+        )
+
+    # If we know about a failed hash but missed its status line (rare), still
+    # register it so the S3 fetch runs.
+    for h, proc in failed_processes.items():
+        if h not in by_hash:
+            by_hash[h] = TaskRecord(
+                hash_prefix=h,
+                process=proc,
+                status_raw="(no progress line seen)",
+                failed=True,
+                ignored=True,
+                completed=False,
+            )
+
+    return list(by_hash.values())
+
+
+# ---------------------------------------------------------------------------
+# S3 helpers
+# ---------------------------------------------------------------------------
+
+
+def _candidate_workroots(bucket: str, experiment_id: str) -> list[str]:
+    """
+    Known / observed work-dir layouts. We try each in turn — the first one
+    that resolves a given hash is the winner. The doubled ``<exp>/<exp>``
+    case reflects the current sms-api path composition; the single-``<exp>``
+    case is there for forward-compat if that gets fixed.
+    """
+    return [
+        f"s3://{bucket}/vecoli-output/{experiment_id}/{experiment_id}/nextflow/nextflow_workdirs",
+        f"s3://{bucket}/vecoli-output/{experiment_id}/nextflow/nextflow_workdirs",
+        f"s3://{bucket}/nextflow/work",
+    ]
+
+
+_s3_errors_seen: set[str] = set()
+
+
+def _list_subdirs(s3, bucket: str, prefix: str, max_keys: int = 1000) -> list[str]:
+    """Return the set of keys directly under ``prefix`` (using Delimiter='/').
+
+    Returns full keys with trailing ``/`` for subdirectories. Surfaces S3
+    client errors exactly once per error code (so repeated credential
+    failures don't flood the output) by printing a warning on first sight.
+    """
+    out: list[str] = []
+    try:
+        paginator = s3.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=bucket, Prefix=prefix, Delimiter="/", MaxKeys=max_keys):
+            for cp in page.get("CommonPrefixes", []) or []:
+                out.append(cp["Prefix"])
+            for obj in page.get("Contents", []) or []:
+                out.append(obj["Key"])
+    except ClientError as e:
+        code = e.response["Error"]["Code"]
+        if code not in _s3_errors_seen:
+            _s3_errors_seen.add(code)
+            print(f"\n  ⚠  S3 listing failed: {code} — {e.response['Error'].get('Message', '')}")
+            if code in (
+                "InvalidToken",
+                "ExpiredToken",
+                "TokenRefreshRequired",
+                "UnrecognizedClientException",
+                "AuthFailure",
+            ):
+                print("  ⚠  Your AWS credentials are expired / invalid.")
+                print("     Run `aws sso login` (or `aws configure sso`) and retry.")
+            elif code == "AccessDenied":
+                print("  ⚠  Current IAM role lacks ListObjects on this bucket.")
+        return []
+    return out
+
+
+def find_work_uri(s3, bucket: str, experiment_id: str, hash_prefix: str) -> str | None:
+    """
+    Resolve ``hh/xxxxxx`` (6-char short) to a full
+    ``s3://bucket/.../hh/xxxxxx...`` URI by probing candidate work roots.
+
+    Nextflow's short hash is actually the first 6 characters of a longer
+    hash, and the directory on S3 is named with the FULL hash — so we can't
+    just concat ``{root}/{hh}/{short}``; we have to list ``{root}/{hh}/``
+    and pick the entry that starts with ``short``.
+    """
+    hh, short = hash_prefix.split("/")
+    for root in _candidate_workroots(bucket, experiment_id):
+        no_scheme = root[len("s3://") :]
+        bkt, _, root_key = no_scheme.partition("/")
+        if bkt != bucket:
+            continue
+        # List everything under {root}/{hh}/ — subdirs are the candidate tasks.
+        entries = _list_subdirs(s3, bucket, f"{root_key}/{hh}/")
+        for entry in entries:
+            # entry is a subdir like "...nextflow_workdirs/78/9f57e8abcdef.../"
+            basename = entry.rstrip("/").split("/")[-1]
+            if basename.startswith(short):
+                return f"s3://{bucket}/{entry.rstrip('/')}"
+    return None
+
+
+def show_experiment_tree(s3, bucket: str, experiment_id: str, max_entries: int = 50) -> None:
+    """
+    Last-resort diagnostic: dump the top few levels of what actually exists
+    under each candidate path, so the user can see the real layout when
+    auto-resolution fails.
+    """
+    tried: set[str] = set()
+    for root in _candidate_workroots(bucket, experiment_id):
+        no_scheme = root[len("s3://") :]
+        bkt, _, root_key = no_scheme.partition("/")
+        if bkt != bucket or root_key in tried:
+            continue
+        tried.add(root_key)
+        entries = _list_subdirs(s3, bucket, f"{root_key}/")
+        if not entries:
+            print(f"  (empty) s3://{bucket}/{root_key}/")
+            continue
+        print(f"  s3://{bucket}/{root_key}/")
+        for e in entries[:max_entries]:
+            short = e[len(root_key) + 1 :]  # drop the root prefix
+            print(f"      {short}")
+        if len(entries) > max_entries:
+            print(f"      ... (+{len(entries) - max_entries} more)")
+
+
+def _fetch_s3_text(s3, s3_uri: str, tail: int) -> str:
+    """Download a text object from S3 and return last ``tail`` lines (or all)."""
+    if not s3_uri.startswith("s3://"):
+        return f"<invalid URI: {s3_uri}>"
+    no_scheme = s3_uri[len("s3://") :]
+    bucket, _, key = no_scheme.partition("/")
+    try:
+        body = s3.get_object(Bucket=bucket, Key=key)["Body"].read().decode("utf-8", "replace")
+    except ClientError as e:
+        return f"<unreachable: {e.response['Error']['Code']}>"
+    lines = body.splitlines()
+    if tail and len(lines) > tail:
+        return "\n".join([f"… ({len(lines) - tail} earlier lines elided)", *lines[-tail:]])
+    return body
+
+
+def list_kb_outputs(s3, bucket: str, experiment_id: str) -> list[tuple[str, int]]:
+    """List files under each candidate parca_N/kb/ path, returning (uri, size) pairs."""
+    results: list[tuple[str, int]] = []
+    candidates = (
+        [
+            f"vecoli-output/{experiment_id}/{experiment_id}/parca_{i}/kb/"
+            for i in range(16)  # more than anyone would realistically run
+        ]
+        + [f"vecoli-output/{experiment_id}/parca_{i}/kb/" for i in range(16)]
+        + [
+            f"vecoli-output/{experiment_id}/{experiment_id}/parca/kb/",
+            f"vecoli-output/{experiment_id}/parca/kb/",
+        ]
+    )
+    for prefix in candidates:
+        try:
+            r = s3.list_objects_v2(Bucket=bucket, Prefix=prefix, MaxKeys=20)
+        except ClientError:
+            continue
+        for obj in r.get("Contents", []) or []:
+            results.append((f"s3://{bucket}/{obj['Key']}", obj["Size"]))
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Report rendering
+# ---------------------------------------------------------------------------
+
+
+def _hr(title: str) -> str:
+    line = "─" * max(8, 74 - len(title))
+    return f"\n── {title} {line}"
+
+
+def _resolve_bucket(cli_bucket: str | None) -> str:
+    if cli_bucket:
+        return cli_bucket
+    settings = get_settings()
+    for attr in ("s3_work_bucket", "storage_s3_bucket"):
+        v = getattr(settings, attr, "") or ""
+        if v:
+            return v
+    env = os.environ.get("STORAGE_S3_BUCKET") or os.environ.get("S3_WORK_BUCKET")
+    if env:
+        return env
+    raise SystemExit(
+        "Could not auto-detect bucket name. Pass --bucket explicitly or set "
+        "STORAGE_S3_BUCKET / S3_WORK_BUCKET in the environment."
+    )
+
+
+def _make_s3_client(region: str | None, profile: str | None):
+    """
+    Build an S3 client, explicitly taking ``profile`` so we don't silently
+    fall back on (possibly stale) env-var credentials or the wrong named
+    profile. Also dumps what boto3 actually picked up so we can debug
+    credential-source mismatches with the AWS CLI.
+    """
+    # Default region for Stanford GovCloud is us-gov-west-1.
+    session = boto3.Session(profile_name=profile) if profile else boto3.Session()
+    creds = session.get_credentials()
+    if creds is None:
+        print("  ⚠  boto3 found no credentials. Run `aws sso login` (or export AWS_PROFILE) and retry.")
+    else:
+        frozen = creds.get_frozen_credentials()
+        # Redact the secret; we only care about identity + token presence.
+        ak = frozen.access_key or ""
+        print(
+            f"  boto3 credentials: access_key={ak[:4]}…{ak[-4:] if len(ak) >= 8 else ''}"
+            f"  profile={profile or session.profile_name or 'default'}"
+            f"  session_token={'set' if frozen.token else 'unset'}"
+            f"  region={region or session.region_name or 'unset'}"
+        )
+    return session.client("s3", region_name=region or session.region_name or "us-gov-west-1")
+
+
+def _inspect_interesting_tasks(s3, bucket: str, experiment_id: str, interesting: list[TaskRecord], tail: int) -> bool:
+    """Fetch and display S3 work-dir contents for failed/interesting tasks. Returns True if any resolved."""
+    any_resolved = False
+    for t in interesting:
+        print(_hr(f"Task {t.hash_prefix} · {t.process}  [{t.label}]"))
+        work_uri = find_work_uri(s3, bucket, experiment_id, t.hash_prefix)
+        if not work_uri:
+            print("  <could not locate work directory on S3>")
+            continue
+        any_resolved = True
+        print(f"  work dir: {work_uri}")
+        no_scheme = work_uri[len("s3://") :]
+        _, _, work_key = no_scheme.partition("/")
+        entries = _list_subdirs(s3, bucket, f"{work_key}/")
+        if entries:
+            print("  contents:")
+            for e in entries[:30]:
+                print(f"    {e[len(work_key) + 1 :]}")
+        for fn, label in [
+            (".command.sh", "command.sh (what was actually run)"),
+            (".command.err", f"command.err (tail {tail})"),
+            (".command.out", f"command.out (tail {tail})"),
+        ]:
+            print(_hr(label))
+            text = _fetch_s3_text(s3, f"{work_uri}/{fn}", tail)
+            for line in text.splitlines()[-tail:]:
+                print(f"    {line}")
+    return any_resolved
+
+
+def _report_kb_outputs(s3, bucket: str, experiment_id: str) -> None:
+    """Cross-check whether parca kb paths have contents."""
+    print(_hr("Published kb/ locations (sanity)"))
+    kb_hits = list_kb_outputs(s3, bucket, experiment_id)
+    if not kb_hits:
+        print("  (no objects found under any candidate parca_*/kb/ path)")
+        print("  → parca reported ✓ but wrote nothing to the expected S3 prefix.")
+        print("  → Check the parca task's .command.sh above for the -o path it used.")
+    else:
+        for uri, size in kb_hits[:20]:
+            print(f"  {size:>10,} bytes  {uri}")
+        if len(kb_hits) > 20:
+            print(f"  ... (+{len(kb_hits) - 20} more)")
+
+
+def _report_experiment_listing(s3, bucket: str, experiment_id: str) -> None:
+    """Dump everything under the experiment prefix as a last-resort diagnostic."""
+    print(_hr(f"Recursive listing of everything under vecoli-output/{experiment_id}/"))
+    paginator = s3.get_paginator("list_objects_v2")
+    count = 0
+    total_bytes = 0
+    prefixes_seen: dict[str, int] = {}
+    try:
+        for page in paginator.paginate(
+            Bucket=bucket,
+            Prefix=f"vecoli-output/{experiment_id}/",
+            MaxKeys=1000,
+        ):
+            for obj in page.get("Contents", []) or []:
+                count += 1
+                total_bytes += obj["Size"]
+                key_parts = obj["Key"].split("/")
+                group = "/".join(key_parts[:5]) if len(key_parts) >= 5 else "/".join(key_parts)
+                prefixes_seen[group] = prefixes_seen.get(group, 0) + 1
+    except ClientError as e:
+        print(f"  <listing failed: {e}>")
+    if count == 0:
+        print(f"  (nothing under vecoli-output/{experiment_id}/)")
+        alt_prefix = f"nextflow/work/{experiment_id}/"
+        print(f"\n  trying alt prefix: {alt_prefix}")
+        try:
+            r = s3.list_objects_v2(Bucket=bucket, Prefix=alt_prefix, MaxKeys=20)
+            for obj in r.get("Contents", []) or []:
+                print(f"    {obj['Size']:>10,}  {obj['Key']}")
+        except ClientError as e:
+            print(f"    <{e}>")
+    else:
+        print(f"  {count} objects, {total_bytes:,} total bytes")
+        for prefix, n in sorted(prefixes_seen.items(), key=lambda x: -x[1])[:20]:
+            print(f"    {n:>4} files  s3://{bucket}/{prefix}/…")
+
+
+def _print_status(ds: object, sim_id: int) -> None:
+    """Print the simulation status, handling errors gracefully."""
+    try:
+        status = ds.get_workflow_status(simulation_id=sim_id)
+        print(
+            f"  status:         {status.status.value}" + (f"  · {status.error_message}" if status.error_message else "")
+        )
+    except Exception as e:
+        print(f"  status:         <unavailable: {e}>")
+
+
+def _resolve_region(region: str | None, bucket: str) -> str:
+    """Resolve the AWS region, with a GovCloud heuristic for Stanford buckets."""
+    if region is not None:
+        return region
+    if "smsvpctest" in bucket:
+        resolved = "us-gov-west-1"
+        print(f"  (auto-selected region {resolved} based on bucket name)")
+        return resolved
+    return (
+        get_settings().storage_s3_region
+        or os.environ.get("AWS_DEFAULT_REGION")
+        or os.environ.get("AWS_REGION")
+        or "us-gov-west-1"
+    )
+
+
+def diagnose(
+    sim_id: int,
+    *,
+    base_url: str | None = None,
+    bucket: str | None = None,
+    region: str | None = None,
+    profile: str | None = None,
+    tail: int = 40,
+) -> int:
+    ds = get_data_service(base_url=base_url) if base_url else get_data_service()
+    try:
+        sim = ds.get_workflow(simulation_id=sim_id)
+    except Exception as e:
+        print(f"Could not fetch simulation {sim_id}: {e}")
+        return 2
+
+    bucket = _resolve_bucket(bucket)
+    region = _resolve_region(region, bucket)
+
+    experiment_id = sim.experiment_id
+    print(_hr(f"Simulation {sim_id}  ·  {experiment_id}"))
+    print(f"  simulator_id:   {sim.simulator_id}")
+    print(f"  config file:    {sim.simulation_config_filename}")
+    print(f"  job id:         {sim.job_id or '(unset)'}")
+    print(f"  bucket:         s3://{bucket}")
+
+    _print_status(ds, sim_id)
+
+    # Pull the nextflow log
+    try:
+        log = ds.get_workflow_log(simulation_id=sim_id, truncate=False)
+    except Exception as e:
+        print(f"\nCould not fetch workflow log: {e}")
+        return 2
+
+    print(_hr("Nextflow log tail (last 40 lines)"))
+    for line in log.splitlines()[-40:]:
+        print(f"  {line}")
+
+    tasks = parse_log(log)
+    print(_hr(f"Task breakdown ({len(tasks)} tasks seen)"))
+
+    # Sort: failed → ignored → running → ok
+    def _key(t: TaskRecord) -> tuple[int, str]:
+        return (
+            0 if t.failed else (1 if t.ignored else (2 if t.completed else 3)),
+            t.process,
+        )
+
+    tasks.sort(key=_key)
+    for t in tasks:
+        print(f"  {t.label:<22} [{t.hash_prefix}] {t.process:<35} | {t.status_raw}")
+
+    # Set up S3 client (explicit profile handling so we don't silently pick
+    # up stale env-var credentials when the AWS CLI works via SSO cache).
+    # Region was already resolved above with a GovCloud-bucket override.
+    s3 = _make_s3_client(region=region, profile=profile)
+
+    # Always inspect FAILED / IGNORED tasks. Also inspect runParca /
+    # createVariants regardless — if parca reported ✓ but the kb/ is empty
+    # (see sanity check below), the parca task's .command.err is where the
+    # real error hides.
+    interesting: list[TaskRecord] = [t for t in tasks if t.failed or t.ignored]
+    for t in tasks:
+        if t in interesting:
+            continue
+        if "runParca" in t.process or "createVariants" in t.process:
+            interesting.append(t)
+
+    any_resolved = _inspect_interesting_tasks(s3, bucket, experiment_id, interesting, tail)
+
+    if interesting and not any_resolved:
+        print(_hr("S3 layout under candidate work roots (auto-resolve failed)"))
+        show_experiment_tree(s3, bucket, experiment_id)
+
+    _report_kb_outputs(s3, bucket, experiment_id)
+    _report_experiment_listing(s3, bucket, experiment_id)
+
+    return 0 if not any(t.failed for t in tasks) else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p.add_argument("sim_id", type=int, help="Simulation database ID")
+    p.add_argument("--base-url", default=None, help="API base URL (overrides API_BASE_URL env)")
+    p.add_argument("--bucket", default=None, help="S3 bucket (overrides auto-detection from settings)")
+    p.add_argument("--region", default=None, help="AWS region (defaults to storage_s3_region)")
+    p.add_argument("--tail", type=int, default=40, help="Lines to show from each task file (default: 40)")
+    p.add_argument(
+        "--profile",
+        default=None,
+        help="AWS named profile to use (overrides AWS_PROFILE env var). "
+        "Useful when the AWS CLI works but boto3 picks up stale env credentials.",
+    )
+    args = p.parse_args(argv)
+
+    return diagnose(
+        sim_id=args.sim_id,
+        base_url=args.base_url,
+        bucket=args.bucket,
+        region=args.region,
+        profile=args.profile,
+        tail=args.tail,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sms_api/api/routers/sms.py
+++ b/sms_api/api/routers/sms.py
@@ -33,6 +33,22 @@ from sms_api.config import ComputeBackend, get_job_backend, get_settings
 from sms_api.dependencies import get_database_service, get_simulation_service
 from sms_api.simulation.models import AnalysisOptions, RepoDiscovery, Simulation, SimulationRun
 
+
+def _validate_simulation_config_filename(simulation_config_filename: str) -> None:
+    """Reject ``configs/`` prefix typos that would silently 404 on the server."""
+    if simulation_config_filename.startswith("configs/"):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"simulation_config_filename {simulation_config_filename!r} starts "
+                "with 'configs/'. The server prepends 'configs/' itself; pass the "
+                "path relative to the repo's configs/ directory (e.g. "
+                "'campaigns/pilot_mixed.json' instead of "
+                "'configs/campaigns/pilot_mixed.json')."
+            ),
+        )
+
+
 ENV = get_settings()
 
 logger = logging.getLogger(__name__)
@@ -107,6 +123,7 @@ async def run_simulation_workflow(
     This endpoint reads the workflow configuration from the vEcoli repo on the HPC
     system and allows overriding specific parameters via query params.
     """
+    _validate_simulation_config_filename(simulation_config_filename)
     if experiment_id is None:
         experiment_id = get_experiment_id(simulator_id, simulation_config_filename)
     sim_service = get_simulation_service()

--- a/sms_api/simulation/simulation_service.py
+++ b/sms_api/simulation/simulation_service.py
@@ -8,6 +8,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from textwrap import dedent
 
+from fastapi import HTTPException
 from typing_extensions import override
 
 from sms_api.common.hpc.job_service import JobStatusInfo
@@ -92,12 +93,20 @@ class SimulationService(ABC):
         pass
 
     @abstractmethod
-    async def read_config_template(self, simulator_version: SimulatorVersion, config_filename: str) -> str:
+    async def read_config_template(
+        self,
+        simulator_version: SimulatorVersion,
+        config_filename: str,
+        allow_default_fallback: bool = False,
+    ) -> str:
         """Read a vEcoli config template file for the given simulator version.
 
         Args:
             simulator_version: The simulator whose repo contains the config.
             config_filename: Filename under vEcoli/configs/ (e.g. "api_simulation_default.json").
+            allow_default_fallback: If True, silently return the embedded default
+                template when the requested file is missing or lacks API placeholders.
+                When False (default), raise an HTTPException instead.
 
         Returns:
             The raw JSON string contents of the config template.
@@ -459,8 +468,23 @@ class SimulationServiceHpc(SimulationService):
             return JobId.slurm(slurm_jobid)
 
     @override
-    async def read_config_template(self, simulator_version: SimulatorVersion, config_filename: str) -> str:
+    async def read_config_template(
+        self,
+        simulator_version: SimulatorVersion,
+        config_filename: str,
+        allow_default_fallback: bool = False,
+    ) -> str:
         from sms_api.simulation.simulation_service_k8s import _DEFAULT_CONFIG_TEMPLATE
+
+        if config_filename.startswith("configs/"):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"config_filename {config_filename!r} starts with 'configs/' — "
+                    "drop the prefix. The path is resolved relative to the repo's "
+                    "configs/ directory."
+                ),
+            )
 
         settings = get_settings()
         remote_config_path = (
@@ -473,22 +497,51 @@ class SimulationServiceHpc(SimulationService):
         async with get_ssh_session_service(SSHTarget.SLURM).session() as ssh:
             returncode, stdout, stderr = await ssh.run_command(f"cat {remote_config_path}")
             if returncode != 0:
-                logger.warning(
-                    "Config %s not found at %s — using embedded default template",
+                if allow_default_fallback:
+                    logger.warning(
+                        "Config %s not found at %s — using embedded default template (allow_default_fallback=True)",
+                        config_filename,
+                        remote_config_path,
+                    )
+                    return json.dumps(_DEFAULT_CONFIG_TEMPLATE)
+                logger.error(
+                    "Config %s not found at %s (rc=%d, stderr=%s)",
                     config_filename,
                     remote_config_path,
+                    returncode,
+                    stderr.strip()[:200],
+                )
+                raise HTTPException(
+                    status_code=404,
+                    detail=(
+                        f"Config file {config_filename!r} not found at "
+                        f"{remote_config_path}. Verify the path is relative "
+                        f"to the repo's configs/ directory and the simulator's "
+                        f"checkout includes it."
+                    ),
+                )
+
+        if "EXPERIMENT_ID_PLACEHOLDER" not in stdout:
+            if allow_default_fallback:
+                logger.warning(
+                    "Config %s is a vanilla vEcoli config (no API placeholders) — "
+                    "using embedded default template (allow_default_fallback=True)",
+                    config_filename,
                 )
                 return json.dumps(_DEFAULT_CONFIG_TEMPLATE)
-
-        # If the config is a vanilla vEcoli config (no API placeholders), use
-        # the embedded template instead — vanilla configs have internal relative
-        # paths that don't work in the API pipeline.
-        if "EXPERIMENT_ID_PLACEHOLDER" not in stdout:
-            logger.warning(
-                "Config %s is a vanilla vEcoli config (no API placeholders) — using embedded default template",
+            logger.error(
+                "Config %s lacks EXPERIMENT_ID_PLACEHOLDER — not silently switching to default template.",
                 config_filename,
             )
-            return json.dumps(_DEFAULT_CONFIG_TEMPLATE)
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"Config {config_filename!r} is a vanilla vEcoli config "
+                    f"(no EXPERIMENT_ID_PLACEHOLDER) and cannot be used directly "
+                    f"by the API pipeline. Use a config with API placeholders, "
+                    f"or use the default config."
+                ),
+            )
 
         return stdout
 

--- a/sms_api/simulation/simulation_service_k8s.py
+++ b/sms_api/simulation/simulation_service_k8s.py
@@ -10,6 +10,7 @@ import logging
 
 import boto3  # type: ignore[import-untyped]
 import httpx
+from fastapi import HTTPException
 from kubernetes import client as k8s_client
 from typing_extensions import override
 
@@ -493,13 +494,29 @@ echo "Submit image pushed: $ECR_REGISTRY/{settings.ecr_repository}:{image_tag}-s
         return JobId.k8s(job_name)
 
     @override
-    async def read_config_template(self, simulator_version: SimulatorVersion, config_filename: str) -> str:
+    async def read_config_template(
+        self,
+        simulator_version: SimulatorVersion,
+        config_filename: str,
+        allow_default_fallback: bool = False,
+    ) -> str:
         """Read a vEcoli config template from the GitHub repo via the Contents API.
 
-        Falls back to the embedded ``_DEFAULT_CONFIG_TEMPLATE`` when the
-        requested config file does not exist in the repo (e.g. the public
-        CovertLab/vEcoli repo does not ship ``api_simulation_default.json``).
+        Raises HTTPException(404) if the config file does not exist in the
+        repo at the requested commit. Set ``allow_default_fallback=True`` to
+        silently substitute the embedded ``_DEFAULT_CONFIG_TEMPLATE`` instead.
         """
+        if config_filename.startswith("configs/"):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"config_filename {config_filename!r} starts with 'configs/' — "
+                    "drop the prefix. The path is resolved relative to the repo's "
+                    "configs/ directory, so e.g. pass 'campaigns/pilot_mixed.json' "
+                    "instead of 'configs/campaigns/pilot_mixed.json'."
+                ),
+            )
+
         settings = get_settings()
         base = _github_api_url(simulator_version.git_repo_url)
         api_url = f"{base}/contents/configs/{config_filename}?ref={simulator_version.git_commit_hash}"
@@ -509,13 +526,31 @@ echo "Submit image pushed: $ECR_REGISTRY/{settings.ecr_repository}:{image_tag}-s
         async with httpx.AsyncClient() as client:
             response = await client.get(api_url, headers=headers)
             if response.status_code == 404:
-                logger.warning(
-                    "Config %s not found in %s@%s — using embedded default template",
+                if allow_default_fallback:
+                    logger.warning(
+                        "Config %s not found in %s@%s — using embedded default template (allow_default_fallback=True)",
+                        config_filename,
+                        simulator_version.git_repo_url,
+                        simulator_version.git_commit_hash,
+                    )
+                    return json.dumps(_DEFAULT_CONFIG_TEMPLATE)
+                logger.error(
+                    "Config %s not found in %s@%s (URL=%s)",
                     config_filename,
                     simulator_version.git_repo_url,
                     simulator_version.git_commit_hash,
+                    api_url,
                 )
-                return json.dumps(_DEFAULT_CONFIG_TEMPLATE)
+                raise HTTPException(
+                    status_code=404,
+                    detail=(
+                        f"Config file {config_filename!r} not found in "
+                        f"{simulator_version.git_repo_url} at commit "
+                        f"{simulator_version.git_commit_hash}. "
+                        f"Use GET /api/v1/simulations/discovery?simulator_id=... "
+                        f"to list available configs."
+                    ),
+                )
             response.raise_for_status()
             return response.text
 

--- a/sms_api/version.py
+++ b/sms_api/version.py
@@ -16,4 +16,5 @@
 # 0.7.6 — TUI/GUI feature parity, reactive simulator selection, repo dropdown, list sorting
 # 0.7.7 — fix analysis filters (generation_range/lineage_seed inside analysis_options),
 #          allow arbitrary public vEcoli branches, bump pytest for CVE fix
-__version__ = "0.7.7"
+# 0.7.8 — explicit config validation (no silent fallback), diagnose_sim.py diagnostic tool
+__version__ = "0.7.8"

--- a/tests/clients/test_analyses_compare.mjs
+++ b/tests/clients/test_analyses_compare.mjs
@@ -1,0 +1,70 @@
+/**
+ * Quick value comparison: baseline vs single-gen-5 vs seed-1-only
+ * to see if any filter actually changes ptools_rna output values.
+ */
+
+const BASE_URL = "https://sms.cam.uchc.edu";
+const ENDPOINT = `${BASE_URL}/api/v1/analyses`;
+const TIMEOUT_MS = 30 * 60 * 1000;
+
+async function post(label, body) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  const start = Date.now();
+  try {
+    const r = await fetch(ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    const elapsed = ((Date.now() - start) / 1000).toFixed(1);
+    const data = await r.json();
+    console.log(`[${label}] HTTP ${r.status} (${elapsed}s)`);
+    return data;
+  } catch (e) {
+    console.error(`[${label}] ${e.message}`);
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function getValues(data, gene) {
+  if (!data || !Array.isArray(data) || !data[0]?.content) return null;
+  const lines = data[0].content.split("\n");
+  const row = lines.find(l => l.startsWith(gene + "\t"));
+  return row ? row.split("\t").slice(1) : null;
+}
+
+async function main() {
+  const genes = ["EG10001", "EG10017", "EG10100", "EG10500", "EG11000"];
+
+  // seed 1 only — different from the already-cached seed 0
+  const seedOne = await post("Seed 1 only", {
+    experiment_id: "sim3-test-5062",
+    seeds: [1],
+    multiseed: [{ name: "ptools_rna", n_tp: 8, variant: 0 }]
+  });
+
+  // baseline (cached)
+  const baseline = await post("Baseline", {
+    experiment_id: "sim3-test-5062",
+    multiseed: [{ name: "ptools_rna", n_tp: 8, variant: 0 }]
+  });
+
+  console.log("\nVALUE COMPARISON (baseline vs seed-1-only):");
+  for (const g of genes) {
+    const bv = getValues(baseline, g);
+    const sv = getValues(seedOne, g);
+    if (!bv || !sv) { console.log(`  ${g}: missing data`); continue; }
+    const same = bv.every((v, i) => v === sv[i]);
+    console.log(`  ${g}: ${same ? "IDENTICAL" : "DIFFERENT"}`);
+    if (!same) {
+      console.log(`    baseline: ${bv.join(", ")}`);
+      console.log(`    seed 1:   ${sv.join(", ")}`);
+    }
+  }
+}
+
+main().catch(console.error);

--- a/tests/clients/test_analyses_single.mjs
+++ b/tests/clients/test_analyses_single.mjs
@@ -1,0 +1,131 @@
+/**
+ * Test generation/seed filtering with "single" analysis type instead of "multiseed".
+ * vEcoli's multiseed analysis ignores gen/seed filters — single should respect them.
+ */
+
+const BASE_URL = "https://sms.cam.uchc.edu";
+const ENDPOINT = `${BASE_URL}/api/v1/analyses`;
+const TIMEOUT_MS = 30 * 60 * 1000;
+
+function parseTsv(content) {
+  if (!content) return null;
+  const lines = content.split("\n").filter(Boolean);
+  const header = lines[0].split("\t");
+  const rows = {};
+  for (let i = 1; i < lines.length; i++) {
+    const cells = lines[i].split("\t");
+    rows[cells[0]] = cells.slice(1);
+  }
+  return { header, rows, rowCount: Object.keys(rows).length };
+}
+
+async function post(label, body) {
+  console.log(`\n${"=".repeat(70)}`);
+  console.log(`[${label}]`);
+  console.log(`Body: ${JSON.stringify(body)}`);
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  const start = Date.now();
+
+  try {
+    const r = await fetch(ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    const elapsed = ((Date.now() - start) / 1000).toFixed(1);
+    const text = await r.text();
+    let data;
+    try { data = JSON.parse(text); } catch { data = null; }
+
+    if (!r.ok) {
+      console.error(`  FAIL — HTTP ${r.status} (${elapsed}s)`);
+      if (data?.detail) {
+        const d = data.detail;
+        console.error(`  Error: ${d.message || d}`);
+        if (d.error_log) console.error(`  Log: ${d.error_log.slice(-500)}`);
+      } else {
+        console.error(text.slice(0, 500));
+      }
+      return { ok: false, status: r.status, elapsed, label };
+    }
+
+    console.log(`  HTTP ${r.status} (${elapsed}s)`);
+    const tsvs = [];
+    if (Array.isArray(data)) {
+      for (const item of data) {
+        const tsv = parseTsv(item.content);
+        if (tsv) {
+          console.log(`  ${item.filename}: ${tsv.rowCount} rows, ${tsv.header.length} cols`);
+          const sample = Object.entries(tsv.rows).slice(0, 2);
+          for (const [gene, vals] of sample) {
+            console.log(`    ${gene}: ${vals.join(", ")}`);
+          }
+        }
+        tsvs.push({ filename: item.filename, tsv });
+      }
+    }
+    return { ok: true, status: r.status, elapsed, label, data, tsvs };
+  } catch (e) {
+    const elapsed = ((Date.now() - start) / 1000).toFixed(1);
+    console.error(`  ERROR (${elapsed}s): ${e.message}`);
+    return { ok: false, error: e.message, elapsed, label };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function main() {
+  // Baseline: single ptools_rna, no filters
+  const baseline = await post("Single: no filters", {
+    experiment_id: "sim3-test-5062",
+    single: [{ name: "ptools_rna", n_tp: 8, variant: 0 }]
+  });
+
+  // Filtered: single ptools_rna, gen 2-5
+  const genFiltered = await post("Single: gen 2-5", {
+    experiment_id: "sim3-test-5062",
+    generation_start: 2,
+    generation_end: 5,
+    single: [{ name: "ptools_rna", n_tp: 8, variant: 0 }]
+  });
+
+  // Filtered: single ptools_rna, seed 1 only
+  const seedFiltered = await post("Single: seed 1 only", {
+    experiment_id: "sim3-test-5062",
+    seeds: [1],
+    single: [{ name: "ptools_rna", n_tp: 8, variant: 0 }]
+  });
+
+  // Compare values
+  console.log(`\n${"=".repeat(70)}`);
+  console.log("VALUE COMPARISON");
+  console.log("=".repeat(70));
+
+  const comparisons = [
+    ["Gen 2-5 vs baseline", baseline, genFiltered],
+    ["Seed 1 vs baseline", baseline, seedFiltered],
+  ];
+
+  for (const [label, a, b] of comparisons) {
+    if (!a?.tsvs?.[0]?.tsv || !b?.tsvs?.[0]?.tsv) {
+      console.log(`  ${label}: SKIP (missing data)`);
+      continue;
+    }
+    const aRows = a.tsvs[0].tsv.rows;
+    const bRows = b.tsvs[0].tsv.rows;
+    let diffs = 0, same = 0;
+    for (const gene of Object.keys(aRows).slice(0, 50)) {
+      if (!bRows[gene]) { diffs++; continue; }
+      const match = aRows[gene].every((v, i) => v === bRows[gene][i]);
+      if (match) same++; else diffs++;
+    }
+    console.log(`  ${label}: ${diffs} differ, ${same} identical (first 50 genes)`);
+    if (diffs > 0) console.log(`    CONFIRMED: filter changes output`);
+    else console.log(`    WARNING: output identical despite filter`);
+  }
+}
+
+main().catch(console.error);

--- a/tests/fixtures/simulation_service_mocks.py
+++ b/tests/fixtures/simulation_service_mocks.py
@@ -56,7 +56,9 @@ class ConcreteSimulationService(SimulationService):
         raise NotImplementedError
 
     @override
-    async def read_config_template(self, simulator_version: SimulatorVersion, config_filename: str) -> str:
+    async def read_config_template(
+        self, simulator_version: SimulatorVersion, config_filename: str, allow_default_fallback: bool = False
+    ) -> str:
         raise NotImplementedError
 
     @override

--- a/tests/simulation/test_k8s_backend.py
+++ b/tests/simulation/test_k8s_backend.py
@@ -385,12 +385,44 @@ class TestSimulationServiceK8s:
         assert "api.github.com/repos/test/repo" in call_url
         assert "test.json" in call_url
 
+    async def test_read_config_template_raises_on_404(
+        self,
+        simulation_service_k8s_mock: SimulationServiceK8s,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Verify read_config_template raises HTTPException(404) when config not found."""
+        from fastapi import HTTPException
+
+        from sms_api.simulation.models import SimulatorVersion
+
+        simulator = SimulatorVersion(
+            database_id=1,
+            git_commit_hash="6f7e5b9",
+            git_repo_url="https://github.com/CovertLab/vEcoli",
+            git_branch="master",
+        )
+
+        mock_response = AsyncMock()
+        mock_response.status_code = 404
+        mock_response.raise_for_status = MagicMock(side_effect=Exception("should not be called"))
+
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        monkeypatch.setattr("sms_api.simulation.simulation_service_k8s.httpx.AsyncClient", lambda: mock_client)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await simulation_service_k8s_mock.read_config_template(simulator, "nonexistent.json")
+        assert exc_info.value.status_code == 404
+
     async def test_read_config_template_fallback_on_404(
         self,
         simulation_service_k8s_mock: SimulationServiceK8s,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Verify read_config_template returns embedded default when GitHub returns 404."""
+        """Verify read_config_template returns embedded default when allow_default_fallback=True."""
         from sms_api.simulation.models import SimulatorVersion
         from sms_api.simulation.simulation_service_k8s import _DEFAULT_CONFIG_TEMPLATE
 
@@ -412,13 +444,36 @@ class TestSimulationServiceK8s:
 
         monkeypatch.setattr("sms_api.simulation.simulation_service_k8s.httpx.AsyncClient", lambda: mock_client)
 
-        result = await simulation_service_k8s_mock.read_config_template(simulator, "api_simulation_default.json")
+        result = await simulation_service_k8s_mock.read_config_template(
+            simulator, "api_simulation_default.json", allow_default_fallback=True
+        )
 
         parsed = json.loads(result)
         assert parsed["experiment_id"] == "EXPERIMENT_ID_PLACEHOLDER"
         assert parsed["parca_options"]["cpus"] == 6
         assert "aws_cdk" in parsed
         assert parsed == _DEFAULT_CONFIG_TEMPLATE
+
+    async def test_read_config_template_rejects_configs_prefix(
+        self,
+        simulation_service_k8s_mock: SimulationServiceK8s,
+    ) -> None:
+        """Verify configs/ prefix in filename is rejected with a 400."""
+        from fastapi import HTTPException
+
+        from sms_api.simulation.models import SimulatorVersion
+
+        simulator = SimulatorVersion(
+            database_id=1,
+            git_commit_hash="6f7e5b9",
+            git_repo_url="https://github.com/CovertLab/vEcoli",
+            git_branch="master",
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await simulation_service_k8s_mock.read_config_template(simulator, "configs/campaigns/pilot_mixed.json")
+        assert exc_info.value.status_code == 400
+        assert "configs/" in str(exc_info.value.detail)
 
     async def test_build_command_generates_valid_script(
         self,

--- a/uv.lock
+++ b/uv.lock
@@ -3092,7 +3092,7 @@ wheels = [
 
 [[package]]
 name = "sms-api"
-version = "0.7.7"
+version = "0.7.8"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
## Summary

- **No more silent config substitution**: `read_config_template` now raises HTTP 404 when the requested config file doesn't exist (instead of silently falling back to the default 1-gen template). The old fallback behavior is still available via `allow_default_fallback=True` for callers that explicitly want it.
- **Reject `configs/` prefix typo**: Both the router and service layer now return HTTP 400 if `simulation_config_filename` starts with `configs/` — the server already prepends that path, so doubling it caused silent 404s.
- **Diagnostic script**: `scripts/diagnose_sim.py` — a read-only tool that pulls Nextflow logs, parses per-task status, and fetches `.command.err`/`.command.out`/`.command.sh` from S3 for failed tasks.
- **CLI error handling**: All CLI commands now render user-friendly Rich panels for errors (API errors, connection failures, invalid JSON) instead of raw Python tracebacks. Set `ATLANTIS_DEBUG=1` for full tracebacks.
- **Data service error messages**: Replaced generic `"Error!"` / `"Could not load simulation data"` messages with specific status codes and server response details.
- **Pipe-friendly output**: `display_json` outputs raw JSON (no ANSI codes) when stdout is piped, enabling `atlantis simulation list | jq ...`.
- **`--n` flag on list commands**: `atlantis simulation list --n -1` returns the most recent entry; `--n 3` returns the first 3. Works on `simulator list`, `simulation list`, and `parca list`.
- **Live integration CI**: Manual-dispatch workflow (`live-integration.yml`) for running analysis endpoint tests against live infrastructure.
- **Test script reorganization**: Moved `.mjs` analysis test scripts from `scripts/` to `tests/clients/`.

## Test plan

- [x] New tests: `test_read_config_template_raises_on_404`, `test_read_config_template_rejects_configs_prefix`
- [x] Existing fallback test updated to use `allow_default_fallback=True`
- [x] `make check` passes (ruff, mypy, deptry)
- [x] Deployed to stanford-test (0.7.8), verified config validation returns proper 400/404
- [x] CLI error panels verified for connection refused, bad config prefix, nonexistent config
- [x] Full E2E test on stanford-test with valid workflow
- [x] `--n` flag verified: `--n -1`, `--n 2`, `--n -3` all correct
- [x] Piped JSON output verified with `jq`