### PR TITLE
fix: harden ecoli-sources server-side sync

### DIFF
--- a/kustomize/overlays/sms-api-rke-dev/kustomization.yaml
+++ b/kustomize/overlays/sms-api-rke-dev/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: sms-api-rke-dev
 
 images:
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.7.9
+    newTag: 0.8.0
   # ptools pinned to last-known-good tag — see Stanford-test kustomization
   # for rationale.  No sms-ptools:0.6.x image exists on ghcr.io because the
   # build-and-push GH Action's ptools step is broken.

--- a/kustomize/overlays/sms-api-rke/kustomization.yaml
+++ b/kustomize/overlays/sms-api-rke/kustomization.yaml
@@ -10,7 +10,7 @@ namespace: sms-api-rke
 
 images:
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.7.9
+    newTag: 0.8.0
   # ptools pinned to last-known-good tag — see Stanford-test kustomization
   # for rationale.  No sms-ptools:0.6.x image exists on ghcr.io because the
   # build-and-push GH Action's ptools step is broken.

--- a/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: sms-api-stanford-test
 
 images:
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.7.9
+    newTag: 0.8.0
   # ptools pinned to last-known-good tag — the build-and-push GH Action's
   # ptools step is currently broken (Dockerfile-nextflow issue), so there is
   # no sms-ptools:0.6.x image on ghcr.io.  0.5.9 is the tag the live Stanford

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sms_api"
-version = "0.7.9"
+version = "0.8.0"
 description = "This is the api server for Vivarium simulation services."
 authors = [{ name = "Alex Patrie", email = "alexanderpatrie@gmail.com" }, { name = "Jim Schaff", email = "jschaff@gmail.com" }]
 requires-python = "==3.12.9"

--- a/sms_api/common/handlers/simulations.py
+++ b/sms_api/common/handlers/simulations.py
@@ -54,27 +54,126 @@ DEFAULT_SIMDATA_PATH = get_settings().hpc_parca_base_path / "default" / "kb" / "
 ANALYSIS_CATEGORIES = {"single", "multiseed", "multigeneration", "multidaughter", "multivariant", "multiexperiment"}
 
 
+# -- ecoli-sources server-side sync --
+
+# Only GitHub repos under these orgs are allowed for server-side source sync.
+_ALLOWED_SOURCE_ORGS = {"vivarium-collective", "CovertLab", "CovertLabEcoli"}
+
+# Required columns in data/manifest.tsv (ecoli-sources convention).
+_MANIFEST_REQUIRED_COLUMNS = {"dataset_id", "file_path"}
+
+# Safety limits
+_MAX_TARBALL_BYTES = 500 * 1024 * 1024  # 500 MB
+_MAX_FILE_COUNT = 10_000
+_SKIP_DIRS = {".git", "__pycache__", ".venv", "node_modules", ".tox"}
+_SKIP_EXTENSIONS = {".pyc", ".pyo", ".so", ".dylib", ".exe"}
+
+
+def _parse_github_owner_repo(repo_url: str) -> tuple[str, str, str]:
+    """Parse a GitHub URL into (owner, repo, owner/repo). Validates against allowed orgs."""
+    parts = repo_url.rstrip("/").rstrip(".git").split("/")
+    if len(parts) < 2 or "github.com" not in repo_url:
+        raise HTTPException(status_code=400, detail=f"Invalid GitHub repo URL: {repo_url}")
+    owner, repo = parts[-2], parts[-1]
+    if owner not in _ALLOWED_SOURCE_ORGS:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Source repo org '{owner}' is not in the allowed list: {sorted(_ALLOWED_SOURCE_ORGS)}. "
+            f"Only repos from trusted organizations can be synced server-side.",
+        )
+    return owner, repo, f"{owner}/{repo}"
+
+
+def _validate_manifest(source_root: str) -> None:
+    """Validate that data/manifest.tsv exists and has the required columns."""
+    import csv
+
+    manifest_path = os.path.join(source_root, "data", "manifest.tsv")
+    if not os.path.isfile(manifest_path):
+        raise HTTPException(
+            status_code=400,
+            detail="Source repo is missing data/manifest.tsv. "
+            "The ecoli-sources format requires a TSV manifest at data/manifest.tsv "
+            "with at least columns: dataset_id, file_path.",
+        )
+    with open(manifest_path) as f:
+        reader = csv.reader(f, delimiter="\t")
+        try:
+            header = next(reader)
+        except StopIteration:
+            raise HTTPException(status_code=400, detail="data/manifest.tsv is empty.") from None
+    header_set = {col.strip() for col in header}
+    missing = _MANIFEST_REQUIRED_COLUMNS - header_set
+    if missing:
+        raise HTTPException(
+            status_code=400,
+            detail=f"data/manifest.tsv is missing required columns: {sorted(missing)}. Found: {sorted(header_set)}.",
+        )
+
+
+def _safe_s3_key(prefix: str, relpath: str) -> str:
+    """Build an S3 key from a prefix and relative path, rejecting traversal attempts."""
+    # Normalize and reject any '..' components
+    normalized = os.path.normpath(relpath)
+    if ".." in normalized.split(os.sep):
+        raise HTTPException(status_code=400, detail=f"Path traversal detected in source file: {relpath}")
+    return f"{prefix}/{normalized}"
+
+
+def _upload_source_tree(s3: Any, bucket: str, s3_prefix: str, source_root: str) -> int:
+    """Walk source_root and upload files to S3, skipping unwanted dirs/extensions."""
+    upload_count = 0
+    for dirpath, _dirnames, filenames in os.walk(source_root):
+        rel_dir = os.path.relpath(dirpath, source_root)
+        if any(skip in rel_dir.split(os.sep) for skip in _SKIP_DIRS):
+            continue
+        for filename in filenames:
+            if any(filename.endswith(ext) for ext in _SKIP_EXTENSIONS):
+                continue
+            if upload_count >= _MAX_FILE_COUNT:
+                raise HTTPException(
+                    status_code=413,
+                    detail=f"Source repo exceeds {_MAX_FILE_COUNT} files. Is this the right repo?",
+                )
+            local_path = os.path.join(dirpath, filename)
+            s3_key = _safe_s3_key(s3_prefix, os.path.relpath(local_path, source_root))
+            s3.upload_file(local_path, bucket, s3_key)
+            upload_count += 1
+    return upload_count
+
+
 async def _sync_ecoli_sources_from_github(
     repo_url: str,
     ref: str,
     settings: Any,
 ) -> str:
-    """Download an ecoli-sources repo from GitHub and upload its contents to S3.
+    """Download an ecoli-sources repo from GitHub and upload to S3.
 
-    Returns the S3 URI to use as ECOLI_SOURCES on the simulation container.
+    Validates:
+    - Repo org is in the allowed list
+    - Tarball size is within limits
+    - data/manifest.tsv exists with required columns
+    - No path traversal in uploaded keys
+    - File count within limits
+
+    Only available on K8s/Batch backend (stanford-test).
+    Returns the S3 URI to use as ECOLI_SOURCES.
     """
     import tempfile
 
     import boto3
     import httpx
 
-    # Derive org/repo from URL
-    # e.g. "https://github.com/vivarium-collective/ecoli-sources" -> "vivarium-collective/ecoli-sources"
-    parts = repo_url.rstrip("/").split("/")
-    if len(parts) < 2:
-        raise HTTPException(status_code=400, detail=f"Invalid ecoli_sources_repo_url: {repo_url}")
-    owner_repo = f"{parts[-2]}/{parts[-1]}"
-    repo_basename = parts[-1]
+    # Guard: only allowed on K8s/Batch backend
+    backend = get_job_backend()
+    if backend != ComputeBackend.BATCH:
+        raise HTTPException(
+            status_code=400,
+            detail="Server-side ecoli-sources sync is only available on the K8s/Batch backend (stanford-test). "
+            "Use --sources (local sync) for SLURM deployments.",
+        )
+
+    owner, repo_basename, owner_repo = _parse_github_owner_repo(repo_url)
 
     # Download tarball from GitHub
     tarball_url = f"https://api.github.com/repos/{owner_repo}/tarball/{ref}"
@@ -88,10 +187,17 @@ async def _sync_ecoli_sources_from_github(
         if resp.status_code != 200:
             raise HTTPException(
                 status_code=resp.status_code,
-                detail=f"Failed to download ecoli-sources tarball from {tarball_url}: {resp.text[:300]}",
+                detail=f"Failed to download tarball from {tarball_url}: HTTP {resp.status_code}",
             )
 
-    # Extract tarball to temp dir and upload to S3
+    # Validate tarball size
+    if len(resp.content) > _MAX_TARBALL_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"Source repo tarball is {len(resp.content) / 1024 / 1024:.0f} MB, "
+            f"exceeds limit of {_MAX_TARBALL_BYTES / 1024 / 1024:.0f} MB.",
+        )
+
     bucket = settings.s3_work_bucket or settings.storage_s3_bucket
     if not bucket:
         raise HTTPException(status_code=500, detail="No S3 bucket configured for ecoli-sources sync")
@@ -102,26 +208,21 @@ async def _sync_ecoli_sources_from_github(
     with tempfile.TemporaryDirectory() as tmpdir:
         tar_bytes = io.BytesIO(resp.content)
         with tarfile.open(fileobj=tar_bytes, mode="r:gz") as tar:
+            # Safety: reject tar members with absolute paths or traversal
+            for member in tar.getmembers():
+                if member.name.startswith("/") or ".." in member.name.split("/"):
+                    raise HTTPException(status_code=400, detail=f"Unsafe path in tarball: {member.name}")
             tar.extractall(tmpdir)  # noqa: S202
 
         # GitHub tarballs have a top-level dir like "owner-repo-hash/"
         extracted_dirs = os.listdir(tmpdir)
         source_root = os.path.join(tmpdir, extracted_dirs[0]) if len(extracted_dirs) == 1 else tmpdir
 
-        # Upload all files to S3
-        upload_count = 0
-        for dirpath, _dirnames, filenames in os.walk(source_root):
-            # Skip .git, __pycache__, .venv
-            rel_dir = os.path.relpath(dirpath, source_root)
-            if any(skip in rel_dir.split(os.sep) for skip in (".git", "__pycache__", ".venv")):
-                continue
-            for filename in filenames:
-                if filename.endswith(".pyc"):
-                    continue
-                local_path = os.path.join(dirpath, filename)
-                s3_key = f"{s3_prefix}/{os.path.relpath(local_path, source_root)}"
-                s3.upload_file(local_path, bucket, s3_key)
-                upload_count += 1
+        # Validate manifest
+        _validate_manifest(source_root)
+
+        # Upload files to S3
+        upload_count = _upload_source_tree(s3, bucket, s3_prefix, source_root)
 
     s3_uri = f"s3://{bucket}/{s3_prefix}"
     logger.info("Uploaded %d files from %s to %s", upload_count, owner_repo, s3_uri)

--- a/sms_api/version.py
+++ b/sms_api/version.py
@@ -18,4 +18,5 @@
 #          allow arbitrary public vEcoli branches, bump pytest for CVE fix
 # 0.7.8 — explicit config validation (no silent fallback), diagnose_sim.py diagnostic tool
 # 0.7.9 — ecoli-sources support (--sources flag), remove vecoli dep, dep bumps
-__version__ = "0.7.9"
+# 0.8.0 — harden ecoli-sources sync (org allowlist, path traversal, size limits, manifest validation)
+__version__ = "0.8.0"

--- a/tests/common/handlers/test_ecoli_sources_sync.py
+++ b/tests/common/handlers/test_ecoli_sources_sync.py
@@ -1,0 +1,218 @@
+"""Unit tests for ecoli-sources server-side sync hardening.
+
+Tests the helper functions added in the hardening pass:
+- _parse_github_owner_repo (org allowlist, URL validation)
+- _validate_manifest (manifest existence, required columns)
+- _safe_s3_key (path traversal rejection)
+- _upload_source_tree (skip dirs/extensions, file count limit)
+- _sync_ecoli_sources_from_github (backend guard)
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from sms_api.common.handlers.simulations import (
+    _ALLOWED_SOURCE_ORGS,
+    _MAX_FILE_COUNT,
+    _SKIP_DIRS,
+    _SKIP_EXTENSIONS,
+    _parse_github_owner_repo,
+    _safe_s3_key,
+    _sync_ecoli_sources_from_github,
+    _upload_source_tree,
+    _validate_manifest,
+)
+from sms_api.config import ComputeBackend
+
+# ---------------------------------------------------------------------------
+# _parse_github_owner_repo
+# ---------------------------------------------------------------------------
+
+
+class TestParseGithubOwnerRepo:
+    def test_valid_allowed_org(self) -> None:
+        owner, repo, full = _parse_github_owner_repo("https://github.com/vivarium-collective/ecoli-sources")
+        assert owner == "vivarium-collective"
+        assert repo == "ecoli-sources"
+        assert full == "vivarium-collective/ecoli-sources"
+
+    def test_valid_with_trailing_slash(self) -> None:
+        owner, repo, full = _parse_github_owner_repo("https://github.com/CovertLab/some-repo/")
+        assert owner == "CovertLab"
+        assert repo == "some-repo"
+
+    def test_valid_with_dot_git_suffix(self) -> None:
+        owner, repo, _ = _parse_github_owner_repo("https://github.com/CovertLabEcoli/ecoli-sources.git")
+        assert owner == "CovertLabEcoli"
+        assert repo == "ecoli-sources"
+
+    def test_all_allowed_orgs_accepted(self) -> None:
+        for org in _ALLOWED_SOURCE_ORGS:
+            owner, _, _ = _parse_github_owner_repo(f"https://github.com/{org}/test-repo")
+            assert owner == org
+
+    def test_disallowed_org_raises_403(self) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            _parse_github_owner_repo("https://github.com/evil-org/malicious-repo")
+        assert exc_info.value.status_code == 403
+        assert "evil-org" in exc_info.value.detail
+
+    def test_invalid_url_no_github(self) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            _parse_github_owner_repo("https://gitlab.com/vivarium-collective/repo")
+        assert exc_info.value.status_code == 400
+
+    def test_invalid_url_too_short(self) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            _parse_github_owner_repo("not-a-url")
+        assert exc_info.value.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# _validate_manifest
+# ---------------------------------------------------------------------------
+
+
+class TestValidateManifest:
+    def test_valid_manifest(self, tmp_path: Path) -> None:
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        manifest = data_dir / "manifest.tsv"
+        manifest.write_text("dataset_id\tfile_path\textra_col\nds1\t/some/path\tfoo\n")
+        _validate_manifest(str(tmp_path))  # should not raise
+
+    def test_missing_manifest_raises_400(self, tmp_path: Path) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_manifest(str(tmp_path))
+        assert exc_info.value.status_code == 400
+        assert "missing data/manifest.tsv" in exc_info.value.detail
+
+    def test_empty_manifest_raises_400(self, tmp_path: Path) -> None:
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        (data_dir / "manifest.tsv").write_text("")
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_manifest(str(tmp_path))
+        assert exc_info.value.status_code == 400
+        assert "empty" in exc_info.value.detail
+
+    def test_missing_required_columns_raises_400(self, tmp_path: Path) -> None:
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        (data_dir / "manifest.tsv").write_text("dataset_id\tsome_other_col\n")
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_manifest(str(tmp_path))
+        assert exc_info.value.status_code == 400
+        assert "file_path" in exc_info.value.detail
+
+
+# ---------------------------------------------------------------------------
+# _safe_s3_key
+# ---------------------------------------------------------------------------
+
+
+class TestSafeS3Key:
+    def test_normal_path(self) -> None:
+        result = _safe_s3_key("sources/repo/main", "data/manifest.tsv")
+        assert result == "sources/repo/main/data/manifest.tsv"
+
+    def test_traversal_rejected(self) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            _safe_s3_key("sources/repo/main", "../../etc/passwd")
+        assert exc_info.value.status_code == 400
+        assert "traversal" in exc_info.value.detail.lower()
+
+    def test_dot_dot_in_middle_rejected(self) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            _safe_s3_key("prefix", "a/b/../../../secret")
+        assert exc_info.value.status_code == 400
+
+    def test_single_dot_allowed(self) -> None:
+        result = _safe_s3_key("prefix", "./data/file.txt")
+        assert "data/file.txt" in result
+
+
+# ---------------------------------------------------------------------------
+# _upload_source_tree
+# ---------------------------------------------------------------------------
+
+
+class TestUploadSourceTree:
+    def test_uploads_normal_files(self, tmp_path: Path) -> None:
+        (tmp_path / "file1.txt").write_text("hello")
+        (tmp_path / "file2.py").write_text("print('hi')")
+        s3 = MagicMock()
+        count = _upload_source_tree(s3, "bucket", "prefix", str(tmp_path))
+        assert count == 2
+        assert s3.upload_file.call_count == 2
+
+    def test_skips_excluded_dirs(self, tmp_path: Path) -> None:
+        for skip_dir in _SKIP_DIRS:
+            d = tmp_path / skip_dir
+            d.mkdir(exist_ok=True)
+            (d / "should_skip.txt").write_text("skip me")
+        (tmp_path / "keep.txt").write_text("keep me")
+        s3 = MagicMock()
+        count = _upload_source_tree(s3, "bucket", "prefix", str(tmp_path))
+        assert count == 1
+        uploaded_path = s3.upload_file.call_args[0][0]
+        assert "keep.txt" in uploaded_path
+
+    def test_skips_excluded_extensions(self, tmp_path: Path) -> None:
+        (tmp_path / "good.py").write_text("ok")
+        for ext in _SKIP_EXTENSIONS:
+            (tmp_path / f"bad{ext}").write_bytes(b"\x00")
+        s3 = MagicMock()
+        count = _upload_source_tree(s3, "bucket", "prefix", str(tmp_path))
+        assert count == 1
+
+    def test_file_count_limit(self, tmp_path: Path) -> None:
+        # Create MAX_FILE_COUNT + 1 files
+        for i in range(_MAX_FILE_COUNT + 1):
+            (tmp_path / f"file_{i}.txt").write_text(f"{i}")
+        s3 = MagicMock()
+        with pytest.raises(HTTPException) as exc_info:
+            _upload_source_tree(s3, "bucket", "prefix", str(tmp_path))
+        assert exc_info.value.status_code == 413
+
+    def test_nested_skip_dir(self, tmp_path: Path) -> None:
+        nested = tmp_path / "src" / "__pycache__"
+        nested.mkdir(parents=True)
+        (nested / "cached.pyc").write_bytes(b"\x00")
+        (tmp_path / "src" / "main.py").write_text("ok")
+        s3 = MagicMock()
+        count = _upload_source_tree(s3, "bucket", "prefix", str(tmp_path))
+        assert count == 1
+
+
+# ---------------------------------------------------------------------------
+# _sync_ecoli_sources_from_github — backend guard
+# ---------------------------------------------------------------------------
+
+
+class TestSyncEcoliSourcesBackendGuard:
+    @pytest.mark.asyncio
+    async def test_slurm_backend_raises_400(self) -> None:
+        with patch("sms_api.common.handlers.simulations.get_job_backend", return_value=ComputeBackend.SLURM):
+            with pytest.raises(HTTPException) as exc_info:
+                await _sync_ecoli_sources_from_github(
+                    repo_url="https://github.com/vivarium-collective/ecoli-sources",
+                    ref="main",
+                    settings=MagicMock(),
+                )
+            assert exc_info.value.status_code == 400
+            assert "K8s/Batch" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_disallowed_org_raises_403_before_download(self) -> None:
+        with patch("sms_api.common.handlers.simulations.get_job_backend", return_value=ComputeBackend.BATCH):
+            with pytest.raises(HTTPException) as exc_info:
+                await _sync_ecoli_sources_from_github(
+                    repo_url="https://github.com/evil-org/bad-repo",
+                    ref="main",
+                    settings=MagicMock(),
+                )
+            assert exc_info.value.status_code == 403


### PR DESCRIPTION
## Summary
- Add org allowlist, backend guard, tarball size limit, path traversal protection, manifest validation, and file count limits to `_sync_ecoli_sources_from_github`
- Refactor into smaller validated helpers (`_parse_github_owner_repo`, `_validate_manifest`, `_safe_s3_key`, `_upload_source_tree`)
- Expand skip lists for directories and file extensions

## Test plan

### Unit tests (22/22 passing)
- [x] `_parse_github_owner_repo` — valid URLs for all allowed orgs (vivarium-collective, CovertLab, CovertLabEcoli)
- [x] `_parse_github_owner_repo` — trailing slash and `.git` suffix handled
- [x] `_parse_github_owner_repo` — disallowed org → 403
- [x] `_parse_github_owner_repo` — non-GitHub URL → 400
- [x] `_validate_manifest` — valid manifest passes
- [x] `_validate_manifest` — missing manifest → 400
- [x] `_validate_manifest` — empty manifest → 400
- [x] `_validate_manifest` — missing required columns → 400
- [x] `_safe_s3_key` — normal paths build correctly
- [x] `_safe_s3_key` — `../` traversal → 400
- [x] `_safe_s3_key` — nested `..` in middle → 400
- [x] `_safe_s3_key` — `./` (single dot) allowed
- [x] `_upload_source_tree` — uploads normal files
- [x] `_upload_source_tree` — skips `.git`, `__pycache__`, `.venv`, `node_modules`, `.tox`
- [x] `_upload_source_tree` — skips `.pyc`, `.pyo`, `.so`, `.dylib`, `.exe`
- [x] `_upload_source_tree` — exceeds 10k file limit → 413
- [x] `_upload_source_tree` — nested skip dirs excluded
- [x] `_sync_ecoli_sources_from_github` — SLURM backend → 400
- [x] `_sync_ecoli_sources_from_github` — disallowed org → 403 before download

### Static analysis
- [x] `make check` — ruff lint, ruff format, mypy, deptry all pass

### Live E2E (stanford-test via ptools-proxy)
- [x] Happy path: `--sources-repo https://github.com/vivarium-collective/ecoli-sources` syncs to S3 and submits (sim 77)
- [x] Disallowed org: `--sources-repo https://github.com/some-random-org/ecoli-sources` errors (currently 404 pre-deploy; will be 403 post-deploy)
- [x] Sim 77 completed: parca → variants → sim → 5 analyses, 8 Batch jobs, 14m57s, all succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)