### PR TITLE
chore(deps): bump GH Actions, uvicorn, and Mako security fix

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -17,13 +17,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry (ghcr.io)
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/live-integration.yml
+++ b/.github/workflows/live-integration.yml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 35
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run analysis single test
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -36,7 +36,7 @@ jobs:
         shell: bash
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up the environment
         uses: ./.github/actions/setup-python-env
@@ -50,7 +50,7 @@ jobs:
         run: uv run mypy
 
       - name: Upload coverage reports to Codecov with GitHub Action on Python 3.11
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         if: ${{ matrix.python-version == '3.11' }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up the environment
         uses: ./.github/actions/setup-python-env

--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up the environment
         uses: ./.github/actions/setup-python-env

--- a/.github/workflows/validate-codecov-config.yml
+++ b/.github/workflows/validate-codecov-config.yml
@@ -10,6 +10,6 @@ jobs:
   validate-codecov-config:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Validate codecov configuration
         run: curl -sSL --fail-with-body --data-binary @codecov.yaml https://codecov.io/validate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{ name = "Alex Patrie", email = "alexanderpatrie@gmail.com" }, { name
 requires-python = "==3.12.9"
 readme = "README.md"
 dependencies = [
-    "uvicorn>=0.34.3,<0.45",
+    "uvicorn>=0.34.3,<0.47",
     "dotenv>=0.9.9,<0.10",
     "fastapi>=0.135.0",
     "pydantic>=2.11.5,<3",
@@ -19,6 +19,7 @@ dependencies = [
     "asyncpg>=0.30.0,<0.32",
     "redis>=5.0.0,<8",
     "alembic>=1.16.2,<2",
+    "Mako>=1.3.11",
     "async-lru>=2.0.5,<3",
     "httpx>=0.28.1,<0.29",
     "polars-lts-cpu[pyarrow]>=1.31.0,<2",

--- a/uv.lock
+++ b/uv.lock
@@ -1204,14 +1204,14 @@ wheels = [
 
 [[package]]
 name = "mako"
-version = "1.3.10"
+version = "1.3.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/8a/805404d0c0b9f3d7a326475ca008db57aea9c5c9f2e1e39ed0faa335571c/mako-1.3.11.tar.gz", hash = "sha256:071eb4ab4c5010443152255d77db7faa6ce5916f35226eb02dc34479b6858069", size = 399811, upload-time = "2026-04-14T20:19:51.493Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a5/19d7aaa7e433713ffe881df33705925a196afb9532efc8475d26593921a6/mako-1.3.11-py3-none-any.whl", hash = "sha256:e372c6e333cf004aa736a15f425087ec977e1fcbd2966aae7f17c8dc1da27a77", size = 78503, upload-time = "2026-04-14T20:19:53.233Z" },
 ]
 
 [[package]]
@@ -2370,7 +2370,7 @@ wheels = [
 
 [[package]]
 name = "sms-api"
-version = "0.7.9"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },
@@ -2389,6 +2389,7 @@ dependencies = [
     { name = "httpx" },
     { name = "ijson" },
     { name = "kubernetes" },
+    { name = "mako" },
     { name = "marimo" },
     { name = "nbformat" },
     { name = "numba" },
@@ -2469,6 +2470,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1,<0.29" },
     { name = "ijson", specifier = ">=3.4.0" },
     { name = "kubernetes", specifier = ">=31.0.0" },
+    { name = "mako", specifier = ">=1.3.11" },
     { name = "marimo", specifier = ">=0.23.0,<1" },
     { name = "nbformat", specifier = ">=5.10.4,<6" },
     { name = "numba", specifier = ">=0.63.1" },
@@ -2496,7 +2498,7 @@ requires-dist = [
     { name = "typer", specifier = ">=0.16.1" },
     { name = "types-aioboto3", extras = ["s3"], specifier = ">=13.3.0" },
     { name = "typing-extensions", specifier = ">=4.14.0,<5" },
-    { name = "uvicorn", specifier = ">=0.34.3,<0.45" },
+    { name = "uvicorn", specifier = ">=0.34.3,<0.47" },
     { name = "vegafusion", specifier = ">=2.0.2,<3" },
     { name = "vl-convert-python", specifier = ">=1.8.0,<2" },
     { name = "xmltodict", specifier = ">=0.14.2" },


### PR DESCRIPTION
## Summary
- Bump all GH Actions to latest major versions (checkout v6, buildx v4, login v4, cache v5, codecov v6)
- Widen uvicorn upper bound from <0.45 to <0.47
- Pin Mako >=1.3.11 to resolve path traversal CVE (dependabot alert #80)

Closes #111, closes #114

## Test plan
- [x] `make check` — ruff, mypy, deptry all pass
- [x] `uv run pytest` — 202 passed, 6 pre-existing failures (SSH/SLURM-dependent), 24 skipped
- [ ] CI workflows pass with new action versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)