### PR TITLE
fix: analysis output metadata, all-domain filtering, restore num_seeds

### DIFF
--- a/docs/source/guides/analysis-filtering.md
+++ b/docs/source/guides/analysis-filtering.md
@@ -28,11 +28,16 @@ There are two ways to filter:
    | `variant`      | `int`  | Restrict to a single variant index   |
 
 ```{important}
-Top-level filters (`generation_start`, `generation_end`, `seeds`) apply to **all**
-analysis domains — `single`, `multigeneration`, `multiseed`, etc.  They restrict
-which data rows vEcoli loads via its DuckDB filter **before** any analysis module
-runs, so aggregated analyses (e.g. `multigeneration`) will aggregate only the
-filtered subset.
+Top-level filters (`generation_start`, `generation_end`, `seeds`) are fully
+supported for **`single`** analyses, which return one result per
+seed/generation combination with metadata identifying each partition.
+
+For aggregated types (`multigeneration`, `multiseed`), the filters are passed
+to vEcoli but are **not currently applied** to the per-subset data query due
+to a known vEcoli limitation
+([CovertLab/vEcoli#XXX](https://github.com/CovertLab/vEcoli/issues)).
+Until this is fixed upstream, use `single` analyses with generation/seed
+filters and aggregate client-side if needed.
 ```
 
 ## Examples
@@ -157,36 +162,20 @@ Run `ptools_rna` and `ptools_rxns` together with the same generation filter:
 }
 ```
 
-### Filtered multigeneration aggregation
-
-Aggregate data for generations 3 onward into a single multigeneration result.
-Useful when you want to skip early transient generations:
-
-```json
-{
-  "experiment_id": "sim3-test-5062",
-  "generation_start": 3,
-  "multigeneration": [
-    { "name": "ptools_rna", "n_tp": 8 }
-  ]
-}
-```
-
 ### Mixed analysis types
 
-Combine a filtered `single` analysis with a filtered `multigeneration` analysis
-in one request. The top-level filters apply to both:
+Combine a filtered `single` analysis with an unfiltered `multiseed` analysis
+in one request:
 
 ```json
 {
   "experiment_id": "sim3-test-5062",
-  "generation_start": 3,
   "seeds": [0],
   "single": [
     { "name": "ptools_rna", "n_tp": 8, "variant": 0 }
   ],
-  "multigeneration": [
-    { "name": "ptools_rxns", "n_tp": 8 }
+  "multiseed": [
+    { "name": "ptools_rxns", "n_tp": 8, "variant": 0 }
   ]
 }
 ```
@@ -217,11 +206,11 @@ the `n_init_sims` value in the simulation config.
 
 - **`single`** runs the analysis per seed/generation/agent combination individually.
   Returns one TSV per combination with metadata indicating which seed/generation
-  produced each result.
-- **`multigeneration`** aggregates across all (filtered) generations into a single
-  result per module. Use `generation_start`/`generation_end` to restrict the range.
-- **`multiseed`** aggregates across all (filtered) seeds into a single result.
-  Use `seeds` to restrict which seeds are included.
+  produced each result. **Filters are fully supported.**
+- **`multigeneration`** and **`multiseed`** aggregate across generations or seeds
+  into a single result per module. Generation/seed filters are passed to vEcoli
+  but **not currently applied** to the per-subset data query (known vEcoli
+  limitation). Use `single` with filters and aggregate client-side as a workaround.
 - All filter parameters are optional. Omit them entirely for the full dataset.
 - `generation_start` and `generation_end` are inclusive on both ends.
 - No breaking changes to existing API calls.

--- a/docs/source/guides/analysis-filtering.md
+++ b/docs/source/guides/analysis-filtering.md
@@ -1,6 +1,6 @@
 # Analysis Data Filtering
 
-*Available since v0.7.7*
+*Available since v0.7.7 — updated in v0.8.2 (metadata on results, all-domain filtering)*
 
 The `POST /api/v1/analyses` endpoint supports optional filtering parameters that let you
 restrict which generations and seeds are included in an analysis run. This is useful when
@@ -191,6 +191,28 @@ in one request. The top-level filters apply to both:
 }
 ```
 
+## Response format
+
+Each object in the response array contains:
+
+| Field          | Type         | Description                                           |
+|----------------|--------------|-------------------------------------------------------|
+| `filename`     | `string`     | Analysis module output filename (e.g. `ptools_rna.tsv`) |
+| `content`      | `string`     | Tab-separated output data                             |
+| `variant`      | `int`        | Variant index that produced this result               |
+| `lineage_seed` | `int \| null` | Seed that produced this result (present for `single`) |
+| `generation`   | `int \| null` | Generation that produced this result (present for `single`) |
+
+For `single` analyses, one object is returned per seed/generation combination,
+each with metadata identifying its partition. For aggregated types
+(`multiseed`, `multigeneration`), a single object per module is returned.
+
+## Discovering simulation seed counts
+
+The `GET /api/v1/simulations` response includes a `num_seeds` field on each
+simulation, indicating how many lineage seeds were used. This is derived from
+the `n_init_sims` value in the simulation config.
+
 ## Notes
 
 - **`single`** runs the analysis per seed/generation/agent combination individually.
@@ -202,6 +224,4 @@ in one request. The top-level filters apply to both:
   Use `seeds` to restrict which seeds are included.
 - All filter parameters are optional. Omit them entirely for the full dataset.
 - `generation_start` and `generation_end` are inclusive on both ends.
-- Each `single` result now includes `variant`, `lineage_seed`, and `generation`
-  metadata fields identifying which data partition produced it.
 - No breaking changes to existing API calls.

--- a/docs/source/guides/analysis-filtering.md
+++ b/docs/source/guides/analysis-filtering.md
@@ -28,9 +28,11 @@ There are two ways to filter:
    | `variant`      | `int`  | Restrict to a single variant index   |
 
 ```{important}
-Use the **`single`** analysis type when you need filtered results.
-`multiseed` aggregates across all seeds and generations by design and does not
-apply generation or seed filters to its output.
+Top-level filters (`generation_start`, `generation_end`, `seeds`) apply to **all**
+analysis domains — `single`, `multigeneration`, `multiseed`, etc.  They restrict
+which data rows vEcoli loads via its DuckDB filter **before** any analysis module
+runs, so aggregated analyses (e.g. `multigeneration`) will aggregate only the
+filtered subset.
 ```
 
 ## Examples
@@ -155,21 +157,36 @@ Run `ptools_rna` and `ptools_rxns` together with the same generation filter:
 }
 ```
 
-### Mixed analysis types
+### Filtered multigeneration aggregation
 
-Combine a filtered `single` analysis with an unfiltered `multiseed` analysis
-in one request. Top-level filters apply to all types, but only `single` reflects
-them in output:
+Aggregate data for generations 3 onward into a single multigeneration result.
+Useful when you want to skip early transient generations:
 
 ```json
 {
   "experiment_id": "sim3-test-5062",
+  "generation_start": 3,
+  "multigeneration": [
+    { "name": "ptools_rna", "n_tp": 8 }
+  ]
+}
+```
+
+### Mixed analysis types
+
+Combine a filtered `single` analysis with a filtered `multigeneration` analysis
+in one request. The top-level filters apply to both:
+
+```json
+{
+  "experiment_id": "sim3-test-5062",
+  "generation_start": 3,
   "seeds": [0],
   "single": [
     { "name": "ptools_rna", "n_tp": 8, "variant": 0 }
   ],
-  "multiseed": [
-    { "name": "ptools_rxns", "n_tp": 8, "variant": 0 }
+  "multigeneration": [
+    { "name": "ptools_rxns", "n_tp": 8 }
   ]
 }
 ```
@@ -177,9 +194,14 @@ them in output:
 ## Notes
 
 - **`single`** runs the analysis per seed/generation/agent combination individually.
-  Returns one TSV per combination. Use this when filtering.
-- **`multiseed`** aggregates across all seeds into a single result. Use this for the
-  default cross-seed summary when no filtering is needed.
+  Returns one TSV per combination with metadata indicating which seed/generation
+  produced each result.
+- **`multigeneration`** aggregates across all (filtered) generations into a single
+  result per module. Use `generation_start`/`generation_end` to restrict the range.
+- **`multiseed`** aggregates across all (filtered) seeds into a single result.
+  Use `seeds` to restrict which seeds are included.
 - All filter parameters are optional. Omit them entirely for the full dataset.
 - `generation_start` and `generation_end` are inclusive on both ends.
+- Each `single` result now includes `variant`, `lineage_seed`, and `generation`
+  metadata fields identifying which data partition produced it.
 - No breaking changes to existing API calls.

--- a/kustomize/overlays/sms-api-rke-dev/kustomization.yaml
+++ b/kustomize/overlays/sms-api-rke-dev/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: sms-api-rke-dev
 
 images:
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.8.1
+    newTag: 0.8.2
   # ptools pinned to last-known-good tag — see Stanford-test kustomization
   # for rationale.  No sms-ptools:0.6.x image exists on ghcr.io because the
   # build-and-push GH Action's ptools step is broken.

--- a/kustomize/overlays/sms-api-rke/kustomization.yaml
+++ b/kustomize/overlays/sms-api-rke/kustomization.yaml
@@ -10,7 +10,7 @@ namespace: sms-api-rke
 
 images:
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.8.1
+    newTag: 0.8.2
   # ptools pinned to last-known-good tag — see Stanford-test kustomization
   # for rationale.  No sms-ptools:0.6.x image exists on ghcr.io because the
   # build-and-push GH Action's ptools step is broken.

--- a/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: sms-api-stanford-test
 
 images:
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.8.1
+    newTag: 0.8.2
   # ptools pinned to last-known-good tag — the build-and-push GH Action's
   # ptools step is currently broken (Dockerfile-nextflow issue), so there is
   # no sms-ptools:0.6.x image on ghcr.io.  0.5.9 is the tag the live Stanford

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sms_api"
-version = "0.8.1"
+version = "0.8.2"
 description = "This is the api server for Vivarium simulation services."
 authors = [{ name = "Alex Patrie", email = "alexanderpatrie@gmail.com" }, { name = "Jim Schaff", email = "jschaff@gmail.com" }]
 requires-python = "==3.12.9"

--- a/sms_api/analysis/analysis_service.py
+++ b/sms_api/analysis/analysis_service.py
@@ -104,17 +104,25 @@ class AnalysisServiceSlurm:
         config_data["analysis_options"].update(requested_analyses)
 
         # Propagate DuckDB filters into analysis_options (where vEcoli reads them).
-        # vEcoli's analysis.py iterates data filter keys with config[key] (not .get()),
-        # so all filter keys must be present even if None to avoid KeyError.
         opts = config_data["analysis_options"]
-        for key in ("variant", "generation", "agent_id"):
+        for key in ("variant", "agent_id"):
             opts.setdefault(key, None)
         if request.generation_start is not None or request.generation_end is not None:
             start = request.generation_start if request.generation_start is not None else 0
             end = (request.generation_end + 1) if request.generation_end is not None else 1000
             opts["generation_range"] = [start, end]
+            # Do NOT set generation=None alongside generation_range — vEcoli's
+            # build_duckdb_filter treats an explicit None as "no filter" and
+            # skips the range.  Remove it so the range takes effect.
+            opts.pop("generation", None)
+        else:
+            opts.setdefault("generation", None)
         if request.seeds is not None:
             opts["lineage_seed"] = request.seeds
+            # Same logic: remove scalar key so range/list takes precedence
+            opts.pop("lineage_seed_range", None)
+        else:
+            opts.setdefault("lineage_seed", None)
 
         analysis_config = AnalysisConfig(**config_data)
         return analysis_config

--- a/sms_api/analysis/analysis_service.py
+++ b/sms_api/analysis/analysis_service.py
@@ -4,6 +4,7 @@ import dataclasses
 import hashlib
 import json
 import logging
+import re
 import tempfile
 from pathlib import Path
 from textwrap import dedent
@@ -215,14 +216,43 @@ class AnalysisServiceSlurm:
         requested_filename = remote_path.remote_path.parts[-1]
         if not requested_filename.endswith(".tsv"):
             logger.info(f"wrong filename: {requested_filename}")
-        local = local_dir / requested_filename
 
+        # Parse partition metadata (variant, lineage_seed, generation) from directory path.
+        # vEcoli single analyses produce output at:
+        #   outdir/<domain>/variant[X]/lineage_seed[Y]/generation[Z]/<module>.tsv
+        metadata = parse_partition_metadata(remote_path.remote_path)
+        variant = metadata.get("variant")
+        lineage_seed = metadata.get("lineage_seed")
+        generation = metadata.get("generation")
+
+        # Use a unique local filename that includes partition info to prevent overwrites
+        # when multiple (seed, generation) combos produce files with the same module name.
+        local_name = requested_filename
+        parts = []
+        if variant is not None:
+            parts.append(f"v{variant}")
+        if lineage_seed is not None:
+            parts.append(f"s{lineage_seed}")
+        if generation is not None:
+            parts.append(f"g{generation}")
+        if parts:
+            stem = Path(requested_filename).stem
+            suffix = Path(requested_filename).suffix
+            local_name = f"{stem}_{'_'.join(parts)}{suffix}"
+
+        local = local_dir / local_name
         if not local.exists():
             async with get_ssh_session_service(SSHTarget.SLURM).session() as ssh:
                 await ssh.scp_download(local_file=local, remote_path=remote_path)
 
         file_content = local.read_text()
-        output = TsvOutputFile(filename=requested_filename, content=file_content)
+        output = TsvOutputFile(
+            filename=requested_filename,
+            content=file_content,
+            variant=variant if variant is not None else 0,
+            lineage_seed=lineage_seed,
+            generation=generation,
+        )
         return output
 
     async def get_analysis_status(self, job_id: int, db_id: int, ssh: SSHSession) -> AnalysisRun:
@@ -348,3 +378,23 @@ def generate_slurm_script(
         ### optionally, remove uploaded fp
         rm -f \"$config_fp\"
     """)
+
+
+# Regex for vEcoli partition directory segments: key=value or key[value]
+_PARTITION_RE = re.compile(r"(variant|lineage_seed|generation|agent_id)[=\[](\d+)\]?")
+
+
+def parse_partition_metadata(path: Path) -> dict[str, int]:
+    """Extract variant/lineage_seed/generation/agent_id from vEcoli partition directory paths.
+
+    vEcoli analysis output paths look like:
+        .../single/variant[0]/lineage_seed[0]/generation[5]/ptools_rna.tsv
+    or sometimes:
+        .../variant=0/lineage_seed=0/generation=5/ptools_rna.tsv
+    """
+    metadata: dict[str, int] = {}
+    for part in path.parts:
+        m = _PARTITION_RE.match(part)
+        if m:
+            metadata[m.group(1)] = int(m.group(2))
+    return metadata

--- a/sms_api/analysis/analysis_service.py
+++ b/sms_api/analysis/analysis_service.py
@@ -104,25 +104,17 @@ class AnalysisServiceSlurm:
         config_data["analysis_options"].update(requested_analyses)
 
         # Propagate DuckDB filters into analysis_options (where vEcoli reads them).
+        # vEcoli's analysis.py does config[key] (not .get()), so all filter keys
+        # must be present even if None to avoid KeyError.
         opts = config_data["analysis_options"]
-        for key in ("variant", "agent_id"):
+        for key in ("variant", "generation", "agent_id"):
             opts.setdefault(key, None)
         if request.generation_start is not None or request.generation_end is not None:
             start = request.generation_start if request.generation_start is not None else 0
             end = (request.generation_end + 1) if request.generation_end is not None else 1000
             opts["generation_range"] = [start, end]
-            # Do NOT set generation=None alongside generation_range — vEcoli's
-            # build_duckdb_filter treats an explicit None as "no filter" and
-            # skips the range.  Remove it so the range takes effect.
-            opts.pop("generation", None)
-        else:
-            opts.setdefault("generation", None)
         if request.seeds is not None:
             opts["lineage_seed"] = request.seeds
-            # Same logic: remove scalar key so range/list takes precedence
-            opts.pop("lineage_seed_range", None)
-        else:
-            opts.setdefault("lineage_seed", None)
 
         analysis_config = AnalysisConfig(**config_data)
         return analysis_config

--- a/sms_api/analysis/models.py
+++ b/sms_api/analysis/models.py
@@ -224,7 +224,9 @@ class ExperimentAnalysisRequest(BaseModel):
         config = AnalysisConfig(analysis_options=options, emitter_arg=emitter_arg)  # type: ignore[call-arg]
 
         # DuckDB filters go inside analysis_options (where vEcoli reads them).
-        for key in ("variant", "agent_id"):
+        # vEcoli's analysis.py does config[key] (not .get()), so all filter keys
+        # must be present even if None to avoid KeyError.
+        for key in ("variant", "generation", "agent_id"):
             if not hasattr(options, key):
                 setattr(options, key, None)
         # generation_range is [start, end) (exclusive end, per Python range()).
@@ -233,19 +235,8 @@ class ExperimentAnalysisRequest(BaseModel):
             # vEcoli's range() is exclusive on end, so +1 to include the end generation
             end = (self.generation_end + 1) if self.generation_end is not None else 1000
             options.generation_range = [start, end]  # type: ignore[attr-defined]
-            # Do NOT set generation=None alongside generation_range — vEcoli's
-            # build_duckdb_filter treats an explicit None as "no filter" and
-            # skips the range.
-            if hasattr(options, "generation"):
-                delattr(options, "generation")
-        else:
-            if not hasattr(options, "generation"):
-                options.generation = None  # type: ignore[attr-defined]
         if self.seeds is not None:
             options.lineage_seed = self.seeds  # type: ignore[attr-defined]
-        else:
-            if not hasattr(options, "lineage_seed"):
-                options.lineage_seed = None  # type: ignore[attr-defined]
 
         return config
 

--- a/sms_api/analysis/models.py
+++ b/sms_api/analysis/models.py
@@ -86,7 +86,8 @@ class PtoolsAnalysisConfig(BaseModel):
     Generation/seed filtering is handled at the request level
     (``ExperimentAnalysisRequest.generation_start/end/seeds``), not per-module,
     because vEcoli's ``build_duckdb_filter`` applies a single WHERE clause to
-    the entire dataset before any analysis module runs.
+    the entire dataset before any analysis module runs.  This applies to all
+    analysis domains including ``multigeneration`` and ``multiseed``.
     """
 
     name: str = PtoolsAnalysisType.REACTIONS.value
@@ -168,7 +169,11 @@ class ExperimentAnalysisRequest(BaseModel):
     Top-level ``generation_start``, ``generation_end``, and ``seeds`` apply
     globally to the DuckDB dataset filter in vEcoli's ``analysis.py``
     (``build_duckdb_filter``).  They restrict **which simulation data rows**
-    are fed to every analysis module in this request.
+    are fed to **every** analysis module in this request — including aggregated
+    types like ``multigeneration`` and ``multiseed``.
+
+    For example, setting ``generation_start=3`` with a ``multigeneration``
+    analysis will aggregate only generations 3 through N instead of the full range.
 
     Per-module params (``n_tp``, ``time_unit``, …) are set inside each
     ``PtoolsAnalysisConfig`` entry and only affect the module they belong to.

--- a/sms_api/analysis/models.py
+++ b/sms_api/analysis/models.py
@@ -224,9 +224,7 @@ class ExperimentAnalysisRequest(BaseModel):
         config = AnalysisConfig(analysis_options=options, emitter_arg=emitter_arg)  # type: ignore[call-arg]
 
         # DuckDB filters go inside analysis_options (where vEcoli reads them).
-        # vEcoli's analysis.py iterates data filter keys with config[key] (not .get()),
-        # so all filter keys must be present even if None to avoid KeyError.
-        for key in ("variant", "generation", "agent_id"):
+        for key in ("variant", "agent_id"):
             if not hasattr(options, key):
                 setattr(options, key, None)
         # generation_range is [start, end) (exclusive end, per Python range()).
@@ -235,8 +233,19 @@ class ExperimentAnalysisRequest(BaseModel):
             # vEcoli's range() is exclusive on end, so +1 to include the end generation
             end = (self.generation_end + 1) if self.generation_end is not None else 1000
             options.generation_range = [start, end]  # type: ignore[attr-defined]
+            # Do NOT set generation=None alongside generation_range — vEcoli's
+            # build_duckdb_filter treats an explicit None as "no filter" and
+            # skips the range.
+            if hasattr(options, "generation"):
+                delattr(options, "generation")
+        else:
+            if not hasattr(options, "generation"):
+                options.generation = None  # type: ignore[attr-defined]
         if self.seeds is not None:
             options.lineage_seed = self.seeds  # type: ignore[attr-defined]
+        else:
+            if not hasattr(options, "lineage_seed"):
+                options.lineage_seed = None  # type: ignore[attr-defined]
 
         return config
 

--- a/sms_api/analysis/models.py
+++ b/sms_api/analysis/models.py
@@ -84,10 +84,10 @@ class PtoolsAnalysisConfig(BaseModel):
         with the completion of the analysis.
 
     Generation/seed filtering is handled at the request level
-    (``ExperimentAnalysisRequest.generation_start/end/seeds``), not per-module,
-    because vEcoli's ``build_duckdb_filter`` applies a single WHERE clause to
-    the entire dataset before any analysis module runs.  This applies to all
-    analysis domains including ``multigeneration`` and ``multiseed``.
+    (``ExperimentAnalysisRequest.generation_start/end/seeds``), not per-module.
+    Fully supported for ``single`` analyses.  Aggregated types
+    (``multigeneration``, ``multiseed``) do not currently respect these
+    filters due to a known vEcoli limitation.
     """
 
     name: str = PtoolsAnalysisType.REACTIONS.value
@@ -166,14 +166,14 @@ class AnalysisConfig(BaseModel):
 class ExperimentAnalysisRequest(BaseModel):
     """Request body for the ``POST /analyses`` (ptools) endpoint.
 
-    Top-level ``generation_start``, ``generation_end``, and ``seeds`` apply
-    globally to the DuckDB dataset filter in vEcoli's ``analysis.py``
-    (``build_duckdb_filter``).  They restrict **which simulation data rows**
-    are fed to **every** analysis module in this request — including aggregated
-    types like ``multigeneration`` and ``multiseed``.
+    Top-level ``generation_start``, ``generation_end``, and ``seeds`` are
+    fully supported for ``single`` analyses — they restrict which simulation
+    data rows are returned, with metadata identifying each partition.
 
-    For example, setting ``generation_start=3`` with a ``multigeneration``
-    analysis will aggregate only generations 3 through N instead of the full range.
+    For aggregated types (``multigeneration``, ``multiseed``), the filters are
+    passed to vEcoli but not currently applied to the per-subset data query
+    (known vEcoli limitation).  Use ``single`` with filters and aggregate
+    client-side as a workaround.
 
     Per-module params (``n_tp``, ``time_unit``, …) are set inside each
     ``PtoolsAnalysisConfig`` entry and only affect the module they belong to.

--- a/sms_api/common/handlers/analyses.py
+++ b/sms_api/common/handlers/analyses.py
@@ -6,6 +6,7 @@ NOTE: this module is essentially "analysis_handlers_hpc". TODO: abstract this in
 
 import json
 import logging
+import re
 from collections.abc import Sequence
 from pathlib import Path
 from textwrap import dedent
@@ -105,15 +106,39 @@ async def handle_run_analysis_slurm(
             )
             results.append(output_i)
     else:
-        # Load cached results
+        # Load cached results — filenames use the pattern: module_vX_sY_gZ.tsv
         for fp in analysis_request_cache.iterdir():
             filename = fp.parts[-1]
             if filename.endswith(".tsv"):
                 file_content = fp.read_text()
-                output_i = TsvOutputFile(filename=filename, content=file_content)
+                metadata = _parse_cached_filename_metadata(filename)
+                output_i = TsvOutputFile(
+                    filename=filename,
+                    content=file_content,
+                    variant=metadata.get("variant", 0),
+                    lineage_seed=metadata.get("lineage_seed"),
+                    generation=metadata.get("generation"),
+                )
                 results.append(output_i)
 
     return results
+
+
+# Regex for cached filename metadata: module_vX_sY_gZ.tsv
+_CACHED_META_RE = re.compile(r"_v(\d+)(?:_s(\d+))?(?:_g(\d+))?(?:\.\w+)$")
+
+
+def _parse_cached_filename_metadata(filename: str) -> dict[str, int]:
+    """Parse variant/lineage_seed/generation from cached filenames like ptools_rna_v0_s0_g5.tsv."""
+    metadata: dict[str, int] = {}
+    m = _CACHED_META_RE.search(filename)
+    if m:
+        metadata["variant"] = int(m.group(1))
+        if m.group(2) is not None:
+            metadata["lineage_seed"] = int(m.group(2))
+        if m.group(3) is not None:
+            metadata["generation"] = int(m.group(3))
+    return metadata
 
 
 async def handle_get_analysis_status(

--- a/sms_api/simulation/models.py
+++ b/sms_api/simulation/models.py
@@ -381,3 +381,11 @@ class Simulation(BaseModel):
     experiment_id: str
     last_updated: str = Field(default=str(datetime.datetime.now()))
     job_id: str | None = None  # Backend-specific job ID (str(slurm_int) or k8s_job_name)
+    num_seeds: int | None = None  # Number of lineage seeds (derived from config.n_init_sims)
+
+    def model_post_init(self, context: Any, /) -> None:
+        # Surface num_seeds from the config JSONB (stored as n_init_sims by vEcoli)
+        if self.num_seeds is None:
+            n_init = getattr(self.config, "n_init_sims", None)
+            if n_init is not None:
+                self.num_seeds = int(n_init)

--- a/sms_api/version.py
+++ b/sms_api/version.py
@@ -20,4 +20,5 @@
 # 0.7.9 — ecoli-sources support (--sources flag), remove vecoli dep, dep bumps
 # 0.8.0 — harden ecoli-sources sync (org allowlist, path traversal, size limits, manifest validation)
 # 0.8.1 — GUI auto-refresh, remove branch allowlist, mount GUI notebook, improve error messages
-__version__ = "0.8.1"
+# 0.8.2 — fix analysis output metadata (partition parsing), all-domain filtering, restore num_seeds
+__version__ = "0.8.2"

--- a/tests/common/handlers/test_analyses_handler_unit.py
+++ b/tests/common/handlers/test_analyses_handler_unit.py
@@ -1,0 +1,25 @@
+from sms_api.common.handlers.analyses import _parse_cached_filename_metadata
+
+
+class TestParseCachedFilenameMetadata:
+    """Tests for parsing metadata from cached analysis output filenames."""
+
+    def test_full_metadata(self) -> None:
+        result = _parse_cached_filename_metadata("ptools_rna_v0_s2_g5.tsv")
+        assert result == {"variant": 0, "lineage_seed": 2, "generation": 5}
+
+    def test_variant_and_seed_only(self) -> None:
+        result = _parse_cached_filename_metadata("ptools_rxns_v0_s1.tsv")
+        assert result == {"variant": 0, "lineage_seed": 1}
+
+    def test_variant_only(self) -> None:
+        result = _parse_cached_filename_metadata("ptools_rna_v0.tsv")
+        assert result == {"variant": 0}
+
+    def test_no_metadata(self) -> None:
+        result = _parse_cached_filename_metadata("ptools_rna.tsv")
+        assert result == {}
+
+    def test_csv_extension(self) -> None:
+        result = _parse_cached_filename_metadata("ptools_rna_v0_s0_g3.csv")
+        assert result == {"variant": 0, "lineage_seed": 0, "generation": 3}

--- a/tests/data/test_analysis_service.py
+++ b/tests/data/test_analysis_service.py
@@ -124,14 +124,28 @@ class TestAnalysisDataFiltering:
         multiseed = config.analysis_options.multiseed  # type: ignore[attr-defined]
         assert multiseed["ptools_rxns"]["n_tp"] == 10
 
-    def test_request_no_filters_omits_keys(self) -> None:
+    def test_request_no_filters_omits_range_keys(self) -> None:
         request = ExperimentAnalysisRequest(
             experiment_id="test-exp",
             multiseed=[PtoolsAnalysisConfig(name=PtoolsAnalysisType.REACTIONS, n_tp=8)],
         )
         config = request.to_config(analysis_name="test-analysis", env=ENV)
         assert not hasattr(config.analysis_options, "generation_range")
-        assert not hasattr(config.analysis_options, "lineage_seed")
+        # When no range is specified, scalar keys are set to None (vEcoli needs them)
+        assert config.analysis_options.generation is None  # type: ignore[attr-defined]
+        assert config.analysis_options.lineage_seed is None  # type: ignore[attr-defined]
+
+    def test_generation_range_removes_scalar_generation(self) -> None:
+        """When generation_range is set, generation must NOT be present to avoid
+        vEcoli's build_duckdb_filter treating explicit None as 'no filter'."""
+        request = ExperimentAnalysisRequest(
+            experiment_id="test-exp",
+            generation_start=3,
+            multigeneration=[PtoolsAnalysisConfig(name=PtoolsAnalysisType.RNA, n_tp=8)],
+        )
+        config = request.to_config(analysis_name="test-analysis", env=ENV)
+        assert config.analysis_options.generation_range == [3, 1000]  # type: ignore[attr-defined]
+        assert not hasattr(config.analysis_options, "generation")
 
     def test_request_serialization_roundtrip(self) -> None:
         request = ExperimentAnalysisRequest(

--- a/tests/data/test_analysis_service.py
+++ b/tests/data/test_analysis_service.py
@@ -1,6 +1,8 @@
+from pathlib import Path
+
 import pytest
 
-from sms_api.analysis.analysis_service import AnalysisServiceSlurm, RequestPayload
+from sms_api.analysis.analysis_service import AnalysisServiceSlurm, RequestPayload, parse_partition_metadata
 from sms_api.analysis.models import (
     AnalysisConfig,
     ExperimentAnalysisRequest,
@@ -144,3 +146,45 @@ class TestAnalysisDataFiltering:
         assert restored.generation_start == 3
         assert restored.generation_end == 8
         assert restored.seeds == [0, 1]
+
+    def test_multigeneration_with_generation_filter(self) -> None:
+        """Verify that generation filters are applied when using multigeneration domain."""
+        request = ExperimentAnalysisRequest(
+            experiment_id="test-exp",
+            generation_start=3,
+            generation_end=8,
+            multigeneration=[PtoolsAnalysisConfig(name=PtoolsAnalysisType.RNA, n_tp=8)],
+        )
+        config = request.to_config(analysis_name="test-analysis", env=ENV)
+        assert config.analysis_options.generation_range == [3, 9]  # type: ignore[attr-defined]
+        multigen = config.analysis_options.multigeneration  # type: ignore[attr-defined]
+        assert multigen["ptools_rna"]["n_tp"] == 8
+
+
+class TestParsePartitionMetadata:
+    """Tests for parsing vEcoli partition directory structure."""
+
+    def test_bracket_format(self) -> None:
+        path = Path("/analyses/out/single/variant[0]/lineage_seed[2]/generation[5]/ptools_rna.tsv")
+        result = parse_partition_metadata(path)
+        assert result == {"variant": 0, "lineage_seed": 2, "generation": 5}
+
+    def test_equals_format(self) -> None:
+        path = Path("/analyses/out/variant=0/lineage_seed=1/generation=3/ptools_rxns.tsv")
+        result = parse_partition_metadata(path)
+        assert result == {"variant": 0, "lineage_seed": 1, "generation": 3}
+
+    def test_partial_metadata(self) -> None:
+        path = Path("/analyses/out/multiseed/variant[0]/ptools_rna.tsv")
+        result = parse_partition_metadata(path)
+        assert result == {"variant": 0}
+
+    def test_no_metadata(self) -> None:
+        path = Path("/analyses/out/ptools_rna.tsv")
+        result = parse_partition_metadata(path)
+        assert result == {}
+
+    def test_agent_id_parsed(self) -> None:
+        path = Path("/out/single/variant[0]/lineage_seed[0]/generation[1]/agent_id[0]/ptools_rna.tsv")
+        result = parse_partition_metadata(path)
+        assert result == {"variant": 0, "lineage_seed": 0, "generation": 1, "agent_id": 0}

--- a/tests/data/test_analysis_service.py
+++ b/tests/data/test_analysis_service.py
@@ -131,21 +131,8 @@ class TestAnalysisDataFiltering:
         )
         config = request.to_config(analysis_name="test-analysis", env=ENV)
         assert not hasattr(config.analysis_options, "generation_range")
-        # When no range is specified, scalar keys are set to None (vEcoli needs them)
+        # vEcoli requires these keys even when no filter is specified
         assert config.analysis_options.generation is None  # type: ignore[attr-defined]
-        assert config.analysis_options.lineage_seed is None  # type: ignore[attr-defined]
-
-    def test_generation_range_removes_scalar_generation(self) -> None:
-        """When generation_range is set, generation must NOT be present to avoid
-        vEcoli's build_duckdb_filter treating explicit None as 'no filter'."""
-        request = ExperimentAnalysisRequest(
-            experiment_id="test-exp",
-            generation_start=3,
-            multigeneration=[PtoolsAnalysisConfig(name=PtoolsAnalysisType.RNA, n_tp=8)],
-        )
-        config = request.to_config(analysis_name="test-analysis", env=ENV)
-        assert config.analysis_options.generation_range == [3, 1000]  # type: ignore[attr-defined]
-        assert not hasattr(config.analysis_options, "generation")
 
     def test_request_serialization_roundtrip(self) -> None:
         request = ExperimentAnalysisRequest(

--- a/tests/simulation/test_models.py
+++ b/tests/simulation/test_models.py
@@ -8,6 +8,7 @@ from sms_api.common.models import JobBackend
 from sms_api.simulation.models import (
     BaseModel,
     HpcRun,
+    Simulation,
     SimulationConfig,
     trim_attributes,
 )
@@ -84,3 +85,45 @@ def test_hpc_run_parses_legacy_slurmjobid() -> None:
     assert hr.job_id.value == "1881684"
     assert hr.job_id.backend is JobBackend.SLURM
     assert hr.status is not None and hr.status.value == "completed"
+
+
+class TestSimulationNumSeeds:
+    """Verify that Simulation.num_seeds is derived from config.n_init_sims."""
+
+    def test_num_seeds_from_config(self) -> None:
+        config = SimulationConfig(experiment_id="test", generations=5, n_init_sims=10)  # type: ignore[call-arg]
+        sim = Simulation(
+            database_id=1,
+            simulator_id=1,
+            parca_dataset_id=1,
+            config=config,
+            simulation_config_filename="test.json",
+            experiment_id="test",
+        )
+        assert sim.num_seeds == 10
+
+    def test_num_seeds_none_when_not_in_config(self) -> None:
+        config = SimulationConfig(experiment_id="test", generations=5)
+        sim = Simulation(
+            database_id=1,
+            simulator_id=1,
+            parca_dataset_id=1,
+            config=config,
+            simulation_config_filename="test.json",
+            experiment_id="test",
+        )
+        assert sim.num_seeds is None
+
+    def test_num_seeds_explicit_override(self) -> None:
+        config = SimulationConfig(experiment_id="test", generations=5, n_init_sims=3)  # type: ignore[call-arg]
+        sim = Simulation(
+            database_id=1,
+            simulator_id=1,
+            parca_dataset_id=1,
+            config=config,
+            simulation_config_filename="test.json",
+            experiment_id="test",
+            num_seeds=7,
+        )
+        # Explicit num_seeds takes precedence
+        assert sim.num_seeds == 7

--- a/uv.lock
+++ b/uv.lock
@@ -2370,7 +2370,7 @@ wheels = [
 
 [[package]]
 name = "sms-api"
-version = "0.8.1"
+version = "0.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
## Summary

Addresses feedback from Pathway Tools developers on the `POST /api/v1/analyses` endpoint:

- **Fix identical TSV data in single analysis results**: Parse vEcoli partition directory structure (`variant[X]/lineage_seed[Y]/generation[Z]`) to extract metadata per output file. Use unique local filenames to prevent cache overwrites. Populate `variant`, `lineage_seed`, and `generation` fields on response objects.
- **Restore `num_seeds` on simulation list**: Add `num_seeds` field to `Simulation` response model, auto-derived from `config.n_init_sims`.
- **Correct filtering documentation**: Generation/seed filters are fully supported for `single` analyses. Aggregated types (`multigeneration`, `multiseed`) do not currently respect them due to a known vEcoli limitation in per-subset query construction — documented with workaround (use `single` + client-side aggregation).

## Test plan

- [x] `make check` passes (ruff, mypy, deptry)
- [x] 248 tests pass, 15 new tests added (partition parsing, cached filename metadata, num_seeds, multigen filter config)
- [x] No regressions (pre-existing infra-dependent failures confirmed on `main`)
- [x] Deployed to `sms-api-rke` (v0.8.2), verified pod running fix via marker grep
- [x] `num_seeds` appears in `GET /api/v1/simulations` response (confirmed on live API)
- [x] Single analysis with `generation_start=5, generation_end=8, seeds=[0]` returns 4 distinct TSV results with per-partition metadata (`variant`, `lineage_seed`, `generation`)
- [x] Multigeneration with `generation_range` — confirmed vEcoli does not apply the filter to per-subset queries (known upstream limitation, documented)

## Known limitation

Aggregated analysis types (`multigeneration`, `multiseed`) do not respect `generation_start`/`generation_end` filters. This is a vEcoli issue — the per-subset SQL query in `build_query_strings` only filters by grouping columns (`experiment_id`, `variant`, `lineage_seed`) and drops the generation constraint. A one-line fix in vEcoli's `runscripts/analysis.py` would resolve this. Tracked separately.