### PR TITLE
fix: update ReadTheDocs Python version from 3.12 to 3.13

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.12"
+    python: "3.13"
 
 sphinx:
   configuration: docs/source/conf.py


### PR DESCRIPTION
## Summary

Align `.readthedocs.yaml` Python version with the rest of the project (bumped to 3.13 in v0.9.0).

Generated with [Claude Code](https://claude.com/claude-code)