### PR TITLE
test: skip HPC integration tests when no SLURM SSH key is configured

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,12 +9,23 @@ os.environ.setdefault("PUBLIC_MODE", "false")
 
 
 def _hpc_reachable() -> bool:
-    """Return True only if the HPC SSH host is reachable (VPN is on)."""
+    """Return True only if the HPC SSH host is reachable AND an SSH key is configured.
+
+    Requiring the key file — not just host reachability — keeps the SLURM
+    integration tests from running with a blank/unset slurm_submit_key_path.
+    The UConn login node is publicly reachable on :22, so a host-only check
+    lets those tests run and then crash at key load (an empty key path becomes
+    Path("")==".", so asyncssh does open(".") -> IsADirectoryError). The
+    per-test skipif has the same blind spot: Path("").exists() is True. Gating
+    on os.path.isfile(key_path) (False for "") makes them skip cleanly instead.
+    """
     try:
         from sms_api.config import get_settings
 
-        host = get_settings().slurm_submit_host
-        if not host:
+        settings = get_settings()
+        host = settings.slurm_submit_host
+        key_path = settings.slurm_submit_key_path
+        if not host or not os.path.isfile(os.path.expanduser(key_path)):
             return False
         with socket.create_connection((host, 22), timeout=3):
             return True


### PR DESCRIPTION
## Problem
The SLURM integration tests (`test_build`, `test_parca`, `test_simulation`, `test_scheduler`) **fail** locally instead of skipping when no SLURM SSH key is configured:

```
RuntimeError: SSH session failed: ... IsADirectoryError: [Errno 21] Is a directory: '.'
```

Two skip guards are both defeated by the same empty-path quirk:
- **Per-test** `@pytest.mark.skipif(not Path(get_settings().slurm_submit_key_path).exists())` — when the key path is blank, `Path("").exists()` is `Path(".").exists()` == **True**, so it never skips.
- **conftest** `_hpc_reachable()` checked only `slurm_submit_host:22` reachability. The UConn login node is publicly reachable, so `_HPC_REACHABLE` is `True`, the tests run, and asyncssh receives `client_keys=[""]` → `open(Path("").expanduser())` == `open(".")` → `IsADirectoryError`.

## Fix
Harden `_hpc_reachable()` to also require an **existing SSH key file** (`os.path.isfile(os.path.expanduser(key_path))`, which is `False` for `""`). When credentials aren't configured, the `integration`-marked HPC tests now skip cleanly. No production code change — test infra only.

## Verification
The 6 previously-crashing tests now **skip** (`6 failed → 6 skipped`, 0.01s, no SSH attempt). No previously-passing test is newly skipped — every new skip is one of the SSH/integration tests that was failing. With a real key + VPN, `_hpc_reachable()` returns `True` and they run as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)