### PR TITLE
Make v2ecoli (Ray-on-Batch) simulators work end-to-end

### DIFF
--- a/sms_api/api/routers/core.py
+++ b/sms_api/api/routers/core.py
@@ -18,6 +18,7 @@ from sms_api.dependencies import (
     get_database_service,
     get_postgres_engine,
     get_simulation_service,
+    get_simulation_service_for_repo,
 )
 from sms_api.simulation.models import (
     HpcRun,
@@ -156,7 +157,10 @@ async def insert_simulator_version(
     if db_service is None:
         logger.error("Simulation database service is not initialized")
         raise HTTPException(status_code=500, detail="Simulation database service is not initialized")
-    sim_service = get_simulation_service()
+    # Route the build to the simulator's backend (v2ecoli→Ray builds v2ecoli:<sha> via its
+    # docker/ recipe; vEcoli→Batch builds vecoli:{commit}). Passing the deployment DEFAULT
+    # service here would send every repo's build to the default backend.
+    sim_service = get_simulation_service_for_repo(simulator.git_repo_url)
     if sim_service is None:
         logger.error("Simulation service is not initialized")
         raise HTTPException(status_code=500, detail="Simulation service is not initialized")

--- a/sms_api/common/handlers/simulations.py
+++ b/sms_api/common/handlers/simulations.py
@@ -1290,6 +1290,8 @@ async def get_simulation_log(db_service: DatabaseService, simulation_id: int, tr
 
     if hpc_run.job_id.backend == JobBackend.K8S:
         log_content = await _get_k8s_log(hpc_run, db_service, simulation_id)
+    elif hpc_run.job_id.backend == JobBackend.RAY:
+        log_content = await _get_ray_log(hpc_run, db_service, simulation_id)
     elif hpc_run.job_id.backend == JobBackend.LOCAL:
         log_content = f"Logs not available for local tasks (job {hpc_run.job_id})"
     else:
@@ -1493,6 +1495,34 @@ async def _get_slurm_log(hpc_run: HpcRun) -> str:
         except StopIteration:
             raise RuntimeError(f"No simulation job name available for HPC run {hpc_run.database_id}")
     return log_stdout
+
+
+async def _get_ray_log(hpc_run: HpcRun, db_service: DatabaseService, simulation_id: int) -> str:
+    """Surface a Ray MNP run's log.
+
+    Ray-on-Batch runs have no SSH login node or K8s pod to read — bulk per-node Ray
+    session logs go to ``RAY_LOG_S3_PREFIX`` and AWS Batch CloudWatch. The high-signal
+    per-run artifact is the ensemble ``summary.json`` (per-seed step counts / errors),
+    written to the run's S3 output prefix. Surface that plus pointers to the bulk logs.
+    Best-effort: never raises (a missing summary just means the run hasn't produced it yet).
+    """
+    settings = get_settings()
+    parts: list[str] = [f"Ray MNP simulation job {hpc_run.job_id.value} (state via `simulation status`)."]
+
+    simulation = await db_service.get_simulation(simulation_id=simulation_id)
+    file_service = get_file_service()
+    if simulation is not None and file_service is not None:
+        summary_key = f"{settings.s3_output_prefix}/{simulation.config.experiment_id}/summary.json"
+        try:
+            content = await file_service.get_file_contents(S3FilePath(s3_path=Path(summary_key)))
+            if content:
+                parts.append("=== summary.json (per-seed results) ===\n" + content.decode("utf-8", errors="replace"))
+        except Exception:
+            logger.info("Ray summary.json not yet available for simulation %s", simulation_id)
+
+    if settings.ray_log_s3_prefix:
+        parts.append(f"Bulk Ray session logs: {settings.ray_log_s3_prefix} (+ AWS Batch CloudWatch).")
+    return "\n\n".join(parts)
 
 
 async def _get_k8s_log(hpc_run: HpcRun, db_service: DatabaseService, simulation_id: int) -> str:

--- a/sms_api/common/handlers/simulations.py
+++ b/sms_api/common/handlers/simulations.py
@@ -441,9 +441,13 @@ async def run_simulation_workflow(  # noqa: C901
             # Discovery failure should not block the workflow — log and continue
             logger.warning("Could not validate analysis_options against repo (discovery failed), proceeding anyway")
 
-    # 2. Read the config template via the resolved service (SSH for SLURM, GitHub API for K8s/Ray)
+    # 2. Read the config template via the resolved service (SSH for SLURM, GitHub API for K8s/Ray).
+    # v2ecoli (RAY) has no configs/ dir and runs from CLI args, so fall back to the embedded
+    # default template instead of 404-ing when the requested config file isn't in the repo.
     config_str = await service.read_config_template(
-        simulator_version=simulator, config_filename=simulation_config_filename
+        simulator_version=simulator,
+        config_filename=simulation_config_filename,
+        allow_default_fallback=(backend == ComputeBackend.RAY),
     )
 
     # 3. Replace placeholders in the config template

--- a/sms_api/common/simulator_defaults.py
+++ b/sms_api/common/simulator_defaults.py
@@ -29,6 +29,11 @@ class RepoUrl(StrEnumBase):
     VECOLI_FORK_REPO_URL = "https://github.com/vivarium-collective/vEcoli"
     VECOLI_PUBLIC_REPO_URL = "https://github.com/CovertLab/vEcoli"
     VECOLI_PRIVATE_REPO_URL = "https://github.com/CovertLabEcoli/vEcoli-private"
+    # v2ecoli (process-bigraph rewrite) — runs on the Ray-on-Batch backend
+    # (compute_backend_for_repo maps it to RAY). Listed here so it passes the
+    # verify_simulator_payload allow-list; its config semantics differ from vEcoli
+    # (no configs/ dir), so the Ray run path uses the embedded default template.
+    V2ECOLI_REPO_URL = "https://github.com/vivarium-collective/v2ecoli"
 
 
 PUBLIC_MODE = get_public_mode()

--- a/sms_api/simulation/simulation_service_k8s.py
+++ b/sms_api/simulation/simulation_service_k8s.py
@@ -93,17 +93,19 @@ apk add --no-cache aws-cli git bash
 # Docker daemon runs on the host — verify socket is mounted
 docker info >/dev/null 2>&1 || {{ echo "ERROR: Docker socket not available"; exit 1; }}
 
-# Get GitHub PAT from Secrets Manager for private repo access
+# Get GitHub PAT from Secrets Manager for private repo access.
+# Disable xtrace around the secret so the PAT (and the clone URL embedding it) never lands
+# in the build logs (CloudWatch). Re-enable tracing once the clone is done.
+set +x
 GH_PAT=$(aws secretsmanager get-secret-value \
     --secret-id {settings.build_git_secret_arn} \
     --query SecretString --output text)
-
 # Inject PAT into clone URL for HTTPS auth (x-access-token is GitHub's convention)
 CLONE_URL=$(echo "{repo_url}" | sed "s|https://github.com/|https://x-access-token:${{GH_PAT}}@github.com/|")
-
-# Clone repo at the specified branch
 export GIT_TERMINAL_PROMPT=0
 git clone --branch {branch} --single-branch "$CLONE_URL" /build/vEcoli
+unset GH_PAT CLONE_URL
+set -x
 cd /build/vEcoli
 git checkout {commit}
 

--- a/sms_api/simulation/simulation_service_ray.py
+++ b/sms_api/simulation/simulation_service_ray.py
@@ -166,21 +166,22 @@ class SimulationServiceRay(SimulationService):
             shared_env.append({"name": "RAY_LOG_S3_PREFIX", "value": settings.ray_log_s3_prefix})
 
         # The head additionally runs the workload (RAY_JOB_CMD) and writes the report.
+        # Workers receive these too but never act on them — the entrypoint branches on
+        # AWS_BATCH_JOB_NODE_INDEX and only the head executes RAY_JOB_CMD/writes the report.
         head_env: list[dict[str, str]] = [
             {"name": "RAY_JOB_CMD", "value": ray_job_cmd},
             {"name": "RAY_REPORT_PATH", "value": REPORT_PATH},
             *shared_env,
         ]
 
+        # The CDK base job definition declares a SINGLE node range ("0:") — the entrypoint
+        # self-branches head vs. worker — so the submit-time override must target that same
+        # range. (Splitting into "0:0"/"1:" makes Batch reject: "NodeOverride targets should
+        # match job definition".) One override on "0:" with the full env reaches every node;
+        # the per-node staging/output knobs in shared_env are what workers need.
         node_property_overrides: list[dict[str, Any]] = [
-            {"targetNodes": "0:0", "containerOverrides": {"environment": head_env}},
+            {"targetNodes": "0:", "containerOverrides": {"environment": head_env}},
         ]
-        if num_nodes > 1:
-            # `1:` targets every worker node (a `1:` range is invalid for a 1-node job).
-            node_property_overrides.append({
-                "targetNodes": "1:",
-                "containerOverrides": {"environment": list(shared_env)},
-            })
 
         node_overrides: dict[str, Any] = {
             "numNodes": num_nodes,

--- a/sms_api/simulation/simulation_service_ray.py
+++ b/sms_api/simulation/simulation_service_ray.py
@@ -208,10 +208,23 @@ class SimulationServiceRay(SimulationService):
         return batch_job_id
 
     def _parca_command(self) -> str:
+        """Run ParCa, then hydrate the sim-input bundle into PARCA_CACHE_DIR (out/cache).
+
+        v2ecoli's sim loads ``out/cache/{initial_state.json, sim_data_cache.dill, ...}`` via
+        ``build_composite(cache_dir=out/cache)``. ``v2ecoli-parca`` only emits the raw
+        ``parca_state.pkl`` (+ a Km cache), so ``scripts/build_cache.py`` must hydrate that
+        into the bundle. build_cache.py/load_parca_state read a GZIPPED fixture, so gzip the
+        parca output first (the round-trip bridges v2ecoli's .pkl→.pkl.gz mismatch). Only
+        PARCA_CACHE_DIR is synced to S3 (RAY_OUT_DIR), and that is exactly what the sim stages.
+        """
         settings = get_settings()
         return (
-            f"v2ecoli-parca --mode {settings.ray_parca_mode} --cpus {settings.ray_parca_cpus}"
+            f"cd {V2ECOLI_DIR}"
+            f" && v2ecoli-parca --mode {settings.ray_parca_mode} --cpus {settings.ray_parca_cpus}"
             f" -o {PARCA_SIMDATA_DIR} --cache-dir {PARCA_CACHE_DIR}"
+            f" && gzip -f -k {PARCA_SIMDATA_DIR}/parca_state.pkl"
+            f" && python scripts/build_cache.py"
+            f" --fixture {PARCA_SIMDATA_DIR}/parca_state.pkl.gz --cache {PARCA_CACHE_DIR}"
         )
 
     def _sim_command(self, n_seeds: int, n_steps: int, chunk: int) -> str:

--- a/sms_api/simulation/simulation_service_ray.py
+++ b/sms_api/simulation/simulation_service_ray.py
@@ -260,12 +260,16 @@ apk add --no-cache aws-cli git bash
 docker info >/dev/null 2>&1 || {{ echo "ERROR: Docker socket not available"; exit 1; }}
 
 # GitHub PAT (Secrets Manager) for the clone; x-access-token is GitHub's HTTPS convention.
+# Disable xtrace around the secret so the PAT (and the clone URL embedding it) never lands
+# in the build logs (CloudWatch). Re-enable tracing once the clone is done.
+set +x
 GH_PAT=$(aws secretsmanager get-secret-value \
     --secret-id {settings.build_git_secret_arn} --query SecretString --output text)
 CLONE_URL=$(echo "{repo_url}" | sed "s|https://github.com/|https://x-access-token:${{GH_PAT}}@github.com/|")
-
 export GIT_TERMINAL_PROMPT=0
 git clone --branch {branch} --single-branch "$CLONE_URL" /build/v2ecoli
+unset GH_PAT CLONE_URL
+set -x
 cd /build/v2ecoli
 git checkout {commit}
 

--- a/sms_api/version.py
+++ b/sms_api/version.py
@@ -26,4 +26,5 @@
 # 0.9.2 — BioModels integration release
 # 0.9.3 — accept v2ecoli repo (RepoUrl allow-list), config-template fallback for Ray/v2ecoli
 # 0.9.4 — route simulator build by repo at the upload endpoint (v2ecoli builds on Ray, not the default)
-__version__ = "0.9.4"
+# 0.9.5 — Ray MNP submit: single "0:" node override to match the CDK job def; mask PAT in build logs
+__version__ = "0.9.5"

--- a/sms_api/version.py
+++ b/sms_api/version.py
@@ -28,4 +28,5 @@
 # 0.9.4 — route simulator build by repo at the upload endpoint (v2ecoli builds on Ray, not the default)
 # 0.9.5 — Ray MNP submit: single "0:" node override to match the CDK job def; mask PAT in build logs
 # 0.9.6 — Ray parca: hydrate out/cache via build_cache.py so the sim finds initial_state.json
-__version__ = "0.9.6"
+# 0.9.7 — simulation log endpoint: RAY branch (surface summary.json) instead of 500-ing on SLURM SSH
+__version__ = "0.9.7"

--- a/sms_api/version.py
+++ b/sms_api/version.py
@@ -25,4 +25,5 @@
 # 0.9.1 — fix test_run_analysis to use HPC-available simulator (203ab2a), graceful GitHub cred skip
 # 0.9.2 — BioModels integration release
 # 0.9.3 — accept v2ecoli repo (RepoUrl allow-list), config-template fallback for Ray/v2ecoli
-__version__ = "0.9.3"
+# 0.9.4 — route simulator build by repo at the upload endpoint (v2ecoli builds on Ray, not the default)
+__version__ = "0.9.4"

--- a/sms_api/version.py
+++ b/sms_api/version.py
@@ -27,4 +27,5 @@
 # 0.9.3 — accept v2ecoli repo (RepoUrl allow-list), config-template fallback for Ray/v2ecoli
 # 0.9.4 — route simulator build by repo at the upload endpoint (v2ecoli builds on Ray, not the default)
 # 0.9.5 — Ray MNP submit: single "0:" node override to match the CDK job def; mask PAT in build logs
-__version__ = "0.9.5"
+# 0.9.6 — Ray parca: hydrate out/cache via build_cache.py so the sim finds initial_state.json
+__version__ = "0.9.6"

--- a/sms_api/version.py
+++ b/sms_api/version.py
@@ -23,4 +23,6 @@
 # 0.8.2 — fix analysis output metadata (partition parsing), all-domain filtering, restore num_seeds
 # 0.9.0 — compose (process-bigraph) subsystem, Python 3.13, /compose/v1/ endpoints
 # 0.9.1 — fix test_run_analysis to use HPC-available simulator (203ab2a), graceful GitHub cred skip
-__version__ = "0.9.2"
+# 0.9.2 — BioModels integration release
+# 0.9.3 — accept v2ecoli repo (RepoUrl allow-list), config-template fallback for Ray/v2ecoli
+__version__ = "0.9.3"

--- a/tests/simulation/test_ray_backend.py
+++ b/tests/simulation/test_ray_backend.py
@@ -178,20 +178,21 @@ class TestSimulationServiceRaySubmit:
         assert sim_env["RAY_STAGE_S3"] == parca_env["RAY_OUT_S3"]
         assert sim_env["RAY_STAGE_DIR"] == PARCA_CACHE_DIR
 
-        # Multi-node env targeting: workers (`1:`) must ALSO get the staging + output
-        # knobs (they need the cache to run seeds and must ship their own zarr), but
-        # NOT RAY_JOB_CMD (only the head runs the driver).
+        # Node env targeting: the CDK base job def declares a SINGLE range ("0:"), so the
+        # submit override must target that same range (Batch rejects "0:0"/"1:" splits as
+        # "NodeOverride targets should match job definition"). One override on "0:" carries
+        # the full env to every node — the staging + output knobs workers need to run seeds
+        # and ship their zarr, plus RAY_JOB_CMD/RAY_REPORT_PATH, which workers receive but
+        # never act on (the entrypoint branches on AWS_BATCH_JOB_NODE_INDEX; only the head
+        # runs the driver).
         sim_overrides = _overrides(sim_call)
-        assert len(sim_overrides) == 2
-        assert sim_overrides[0]["targetNodes"] == "0:0"
-        assert sim_overrides[1]["targetNodes"] == "1:"
-        worker_env = _env_at(sim_call, 1)
-        assert "RAY_JOB_CMD" not in worker_env
-        assert "RAY_REPORT_PATH" not in worker_env
-        assert worker_env["RAY_STAGE_S3"] == sim_env["RAY_STAGE_S3"]
-        assert worker_env["RAY_STAGE_DIR"] == PARCA_CACHE_DIR
-        assert worker_env["RAY_OUT_S3"] == sim_env["RAY_OUT_S3"]
-        assert worker_env["RAY_OUT_DIR"] == SIM_OUT_DIR
+        assert len(sim_overrides) == 1
+        assert sim_overrides[0]["targetNodes"] == "0:"
+        all_node_env = _env_at(sim_call, 0)
+        assert all_node_env["RAY_STAGE_S3"] == sim_env["RAY_STAGE_S3"]
+        assert all_node_env["RAY_STAGE_DIR"] == PARCA_CACHE_DIR
+        assert all_node_env["RAY_OUT_S3"] == sim_env["RAY_OUT_S3"]
+        assert all_node_env["RAY_OUT_DIR"] == SIM_OUT_DIR
 
         # Queue comes from settings; both jobs run the SAME per-commit job-def revision
         # (derived from the base) so they use the simulator's TRUE commit image.

--- a/tests/simulation/test_ray_backend.py
+++ b/tests/simulation/test_ray_backend.py
@@ -162,6 +162,11 @@ class TestSimulationServiceRaySubmit:
         assert parca_call.kwargs["nodeOverrides"]["numNodes"] == 1
         assert len(_overrides(parca_call)) == 1
         assert "v2ecoli-parca" in parca_env["RAY_JOB_CMD"]
+        # ParCa alone only emits raw parca_state.pkl; the sim loads out/cache/initial_state.json,
+        # so the parca step must also hydrate the bundle via scripts/build_cache.py (into the
+        # cache dir that gets synced to S3). Without this the sim seeds fail with FileNotFound.
+        assert "build_cache.py" in parca_env["RAY_JOB_CMD"]
+        assert f"--cache {PARCA_CACHE_DIR}" in parca_env["RAY_JOB_CMD"]
         assert parca_env["RAY_OUT_DIR"] == PARCA_CACHE_DIR
         assert "dependsOn" not in parca_call.kwargs
 


### PR DESCRIPTION
## Summary

Fixes the integration gaps that prevented a **v2ecoli** simulator from running on the
Ray-on-Batch backend end-to-end. All were found while deploying the merged Ray backend
(PRs #138/#139/#21/v2Ecoli #174) to the stanford-test (smsvpctest) site and driving a real
run through the **atlantis CLI**.

**Verified end-to-end on smsvpctest 2026-06-12:** `atlantis simulator latest` → per-repo
routing → v2ecoli image build on Ray → ECR (`v2ecoli:d3f5d93`) → per-commit MNP job-def →
`atlantis simulation run` → ParCa(1-node)→`build_cache`→sim(3-node), SEQUENTIAL-gated → all
SUCCEEDED. `summary.json`: **2/2 seeds**, 600 steps each; **163 zarr objects** captured to
`s3://…/vecoli-output/<exp>/seed_NN/store.zarr`.

## The fixes (one per gap)

1. **`RepoUrl` allow-list rejected v2ecoli** (500 on `/simulator/upload`) — added
   `V2ECOLI_REPO_URL`. (`compute_backend_for_repo` already maps it → RAY.)
2. **Config-template 404** — v2ecoli has no `configs/` dir and the Ray run uses CLI args, so
   `run_simulation_workflow` reads the template with `allow_default_fallback=(backend==RAY)`.
3. **Build routed to the wrong backend** — `insert_simulator_version` passed the deployment
   DEFAULT service, and `upload_simulator` only routes by repo when no service is passed, so
   v2ecoli built on the vEcoli/K8s path (`runscripts/container/build-and-push-ecr.sh -r vecoli`,
   exit 127). Resolve the service from the simulator's repo at the endpoint.
4. **PAT leaked in DooD build logs** — `set -ex` traced the `x-access-token:<pat>@github.com`
   clone URL into CloudWatch. Wrap the secret fetch + clone in `set +x`/`unset` in both the Ray
   and K8s build recipes. (Leaked CloudWatch streams were scrubbed out-of-band.)
5. **MNP node-override mismatch** — `_submit_mnp` split overrides into `0:0`/`1:`, but the CDK
   base job def declares a single `0:` range (the entrypoint self-branches head/worker), so Batch
   rejected the submit ("NodeOverride targets should match job definition"). Use one `0:` override
   with the full env. Validated against Batch.
6. **ParCa→cache→sim wiring** — the sim loads `out/cache/initial_state.json` via
   `build_composite`, but `v2ecoli-parca` only emits raw `out/sim_data/parca_state.pkl`, so every
   seed failed FileNotFound. Run the full pipeline in the parca step: `v2ecoli-parca` → gzip the
   `parca_state.pkl` (build_cache/load_parca_state read a gzipped fixture) → `scripts/build_cache.py
   --cache out/cache`.
7. **`simulation log` 500'd for Ray** — `get_simulation_log` fell through to the SLURM SSH path
   for any non-K8s/LOCAL backend (`SSHSessionService 'slurm' not initialized`). Add a RAY branch
   that surfaces the run's S3 `summary.json` plus the bulk-log locations (best-effort).

## Tests / CI
- `tests/simulation/test_ray_backend.py` updated (single `0:` override; parca runs `build_cache.py`).
- `uv run pre-commit run --all-files` ✓, `uv run mypy` ✓, `tests/simulation` 76 passed / 8 skipped.

## Deploy notes
- Requires sms-cdk #21 deployed (named ray-mnp roles + IRSA PassRole + v2ecoli ECR perms + 100 GiB
  build disk) — done on smsvpctest.
- Version bumped 0.9.2 → 0.9.7 (each gap forced a clean rollout during verification). The
  smsvpctest overlay currently pins 0.9.7 from this branch; **after merge, rebuild from `main`.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)