### PR TITLE
stanford-test overlay: bump sms-api 0.9.1 → 0.9.7

### DIFF
--- a/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: sms-api-stanford-test
 
 images:
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.9.1
+    newTag: 0.9.7
   # ptools pinned to last-known-good tag — the build-and-push GH Action's
   # ptools step is currently broken (Dockerfile-nextflow issue), so there is
   # no sms-ptools:0.6.x image on ghcr.io.  0.5.9 is the tag the live Stanford


### PR DESCRIPTION
One-line deploy change: point the **stanford-test** (smsvpctest) overlay at `sms-api:0.9.7`,
the Ray-capable image deployed and verified end-to-end in #141 (v2ecoli simulators build on
Ray, run on Batch MNP, capture zarr to S3 — driven via the atlantis CLI).

Scope is intentionally just the `newTag` bump. The sealed secrets (`secret-{ghcr,shared}.yaml`)
and `shared.env` endpoints are regenerated from CDK outputs by `secrets.sh` on every deploy, so
they're not committed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)