### PR TITLE
fix(ray): --composite vecoli stages a separate pristine-upstream ParCa cache

### DIFF
--- a/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: sms-api-stanford-test
 
 images:
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.9.15
+    newTag: 0.9.16
   # ptools pinned to last-known-good tag — the build-and-push GH Action's
   # ptools step is currently broken (Dockerfile-nextflow issue), so there is
   # no sms-ptools:0.6.x image on ghcr.io.  0.5.9 is the tag the live Stanford

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sms_api"
-version = "0.9.15"
+version = "0.9.16"
 description = "This is the api server for Vivarium simulation services."
 authors = [{ name = "Alex Patrie", email = "alexanderpatrie@gmail.com" }, { name = "Jim Schaff", email = "jschaff@gmail.com" }]
 requires-python = ">=3.13,<3.14"

--- a/sms_api/simulation/simulation_service_ray.py
+++ b/sms_api/simulation/simulation_service_ray.py
@@ -80,6 +80,18 @@ class SimulationServiceRay(SimulationService):
         settings = get_settings()
         return f"s3://{settings.s3_work_bucket}/ray-parca-cache/{commit}/"
 
+    def _upstream_cache_s3_uri(self, commit: str) -> str:
+        """S3 URI for the PRISTINE upstream-vEcoli ParCa cache (``--composite vecoli``).
+
+        Kept SEPARATE from ``_cache_s3_uri`` (the v2ecoli cache): the external
+        upstream wrapper needs an UPSTREAM-MASTER-built ``simData.cPickle``, not
+        the v2ecoli one (whose TCS ``modified_molecules`` skew makes upstream's
+        two-component-system ODE go negative). Keyed by the same image commit so
+        both engines' parca→sim hand-offs derive their URI with no runtime wiring.
+        """
+        settings = get_settings()
+        return f"s3://{settings.s3_work_bucket}/ray-upstream-parca-cache/{commit}/"
+
     def _results_s3_uri(self, experiment_id: str) -> str:
         settings = get_settings()
         return f"s3://{settings.s3_work_bucket}/{settings.s3_output_prefix}/{experiment_id}/"
@@ -233,6 +245,30 @@ class SimulationServiceRay(SimulationService):
             f" --fixture {PARCA_SIMDATA_DIR}/parca_state.pkl.gz --cache {PARCA_CACHE_DIR}"
         )
 
+    def _upstream_parca_command(self) -> str:
+        """Build a PRISTINE upstream-vEcoli ParCa simData for the ``--composite vecoli`` wrapper.
+
+        Runs once on the 1-node parca job from the image's bundled upstream
+        checkout (``$V2E_VECOLI_DIR=/app/vEcoli``), dropping a flat
+        ``simData.cPickle`` into ``PARCA_CACHE_DIR``. The entrypoint then syncs
+        that dir to ``_upstream_cache_s3_uri``; the N-node sim stages the SAME
+        cache to every node (Ray workers must read identical sim_data — a
+        per-node refit would diverge since ParCa is not bit-reproducible).
+
+        ``--cpus 1`` is REQUIRED, not a perf knob: upstream's fit_sim_data_1 only
+        spawns a worker Pool when cpus>1, and those workers re-import
+        wholecell.utils.polymerize from the source-only /app/vEcoli checkout —
+        which has no compiled Cython (.so) and hard-raises "Failed to import
+        Cython module", looping forever. The serial path (cpus==1) runs entirely
+        in the main process, where the wrapper's import shim has pinned the
+        INSTALLED compiled wholecell into sys.modules, so the import resolves.
+        """
+        return (
+            f"cd {V2ECOLI_DIR} && python scripts/build_upstream_parca.py"
+            f" --outdir {V2ECOLI_DIR}/out/upstream --cpus 1"
+            f" --copy-to {PARCA_CACHE_DIR}"
+        )
+
     def _sim_command(
         self,
         n_seeds: int,
@@ -374,7 +410,6 @@ bash docker/build-and-push-ecr.sh -i {commit} -r {settings.ray_ecr_repository} -
         settings = get_settings()
         commit = simulator.git_commit_hash
         experiment_id = ecoli_simulation.config.experiment_id
-        cache_s3 = self._cache_s3_uri(commit)
 
         # Run the TRUE commit image: derive a per-commit MNP job-def revision pointing at
         # v2ecoli:<commit> (both ParCa and the sim run the same image).
@@ -387,6 +422,14 @@ bash docker/build-and-push-ecr.sh -i {commit} -r {settings.ray_ecr_repository} -
         composite = getattr(ecoli_simulation.config, "composite", None)
         condition = getattr(ecoli_simulation.config, "condition", None)
         max_generations = getattr(ecoli_simulation.config, "max_generations", None)
+
+        # Engine-specific ParCa source: the pristine upstream wrapper (--composite
+        # vecoli) stages an UPSTREAM-built simData (separate cache + build cmd);
+        # every other engine stages the v2ecoli cache. Both ParCa and the sim use
+        # the matching pair so the staged simData is consistent across all nodes.
+        is_upstream = composite == "vecoli"
+        cache_s3 = self._upstream_cache_s3_uri(commit) if is_upstream else self._cache_s3_uri(commit)
+        parca_command = self._upstream_parca_command() if is_upstream else self._parca_command()
 
         # Cost-allocation tags (propagate to ECS tasks → payer-account Cost
         # Explorer attributes spend per run/engine/condition). Values must be
@@ -405,7 +448,7 @@ bash docker/build-and-push-ecr.sh -i {commit} -r {settings.ray_ecr_repository} -
             job_name=f"ray-parca-{commit}-{_rand_suffix()}",
             job_definition=job_def,
             num_nodes=1,
-            ray_job_cmd=self._parca_command(),
+            ray_job_cmd=parca_command,
             out_s3=cache_s3,
             out_dir=PARCA_CACHE_DIR,
             tags={**base_tags, "Phase": "parca"},

--- a/sms_api/version.py
+++ b/sms_api/version.py
@@ -38,4 +38,6 @@
 # 0.9.15 — same export endpoint + observables read-path fixes; bumped past the
 #          ad-hoc 0.9.13/0.9.14 deploy tags so the next tagged release is the
 #          unambiguous high-water mark (supersedes 0.9.12)
-__version__ = "0.9.15"
+# 0.9.16 — Ray: --composite vecoli stages a SEPARATE pristine-upstream ParCa cache
+#          (build_upstream_parca.py, serial --cpus 1) instead of the v2ecoli cache
+__version__ = "0.9.16"


### PR DESCRIPTION
## What

Routes the `--composite vecoli` engine (the external pristine-upstream-vEcoli wrapper) to its **own** ParCa cache, separate from the v2ecoli cache.

## Why

Running the unmodified upstream vEcoli model on the **v2ecoli** ParCa cache crashes every node: the v2ecoli port's TCS `modified_molecules` skew drives upstream's two-component-system ODE negative (`"Solution to ODE for two-component systems has negative values"`). The upstream wrapper needs an **upstream-master-built** `simData.cPickle`.

## Changes

- **`_upstream_cache_s3_uri(commit)`** — distinct S3 prefix `ray-upstream-parca-cache/<commit>/`.
- **`_upstream_parca_command()`** — runs `scripts/build_upstream_parca.py` from the image's bundled `/app/vEcoli`, **serial (`--cpus 1`)**. This is required, not a perf knob: upstream `fit_sim_data_1` only spawns a worker Pool when `cpus>1`, and those workers re-import the *source-only / uncompiled* `wholecell` Cython from the upstream checkout, hard-raise `"Failed to import Cython module"`, and respawn-loop forever (observed: a >1 h hang). The serial path stays in the main process, where the wrapper's import shim has pinned the compiled `wholecell`.
- **`submit_ecoli_simulation_job`** — for `composite == "vecoli"`, the ParCa job builds the upstream cache and the N-node sim stages **that** (all Ray nodes must read identical `sim_data`; a per-node refit would diverge since ParCa isn't bit-reproducible).

`v2ecoli` / `phase0` paths are unchanged. Version `0.9.15 → 0.9.16`; stanford-test kustomize tag bumped.

## Validation

Deployed (as `0.9.14`, same code) to `sms-api-stanford-test` and validated end-to-end: the basal smoke built the upstream cache and ran the wrapper to real gen-1 data with **no TCS crash and no Cython hang**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)