### PR TITLE
docs(ray): correct stale store-layout docstring (verified vs live smsvpctest)

### DIFF
--- a/sms_api/common/handlers/simulations.py
+++ b/sms_api/common/handlers/simulations.py
@@ -1248,9 +1248,13 @@ async def _stream_s3_tar_gz_ray(experiment_id: str, chunk_size: int = 64 * 1024)
     """Stream a Ray ensemble's S3 outputs (zarr stores + summaries) into a tar.gz.
 
     The Ray entrypoint syncs the whole ``.pbg/runs/phase0-xarray`` tree to
-    ``s3://{bucket}/{s3_output_prefix}/{experiment_id}/`` — seed_NN/store.zarr
-    (many small chunk objects) plus per-seed and ensemble summary.json. Unlike
-    the Nextflow layout, we stream every object under the prefix as-is.
+    ``s3://{bucket}/{s3_output_prefix}/{experiment_id}/`` — for v2ecoli comparison
+    runs that is ``v2ecoli_seed{NN}.zarr/`` per seed (each a hive-partitioned
+    datatree of many small chunk objects; verified against ``sim61-v2c-*`` on
+    smsvpctest) plus ``v2ecoli_build_config.json``. This function does not build
+    those paths: unlike the Nextflow layout, we stream every object under the
+    prefix as-is. (The per-seed store URI the observables reader targets is built
+    by ``_build_store_uri`` in ``api/routers/sms.py``.)
     """
     settings = get_settings()
     experiment_prefix = f"{settings.s3_output_prefix}/{experiment_id}"


### PR DESCRIPTION
One-line docstring fix following the live verification of #152.

`_stream_s3_tar_gz_ray`'s docstring described the per-seed store as `seed_NN/store.zarr`. The real smsvpctest layout — verified against `sim61-v2c-with_aa-7292` / `sim61-v2c-acetate-82f6` in `s3://smsvpctest-shared-…/vecoli-output/{experiment_id}/` — is `v2ecoli_seed{NN}.zarr/` (a hive-partitioned datatree) plus `v2ecoli_build_config.json`.

The function globs the whole `{experiment_id}/` prefix, so the stale name was harmless at runtime — but it contradicted `_build_store_uri` in `api/routers/sms.py` (the observables reader), which is the correct path. This points the docstring at reality and cross-references the reader.

No code-path change. Refs #152.

🤖 Generated with [Claude Code](https://claude.com/claude-code)