### PR TITLE
fix(ray): validate v2ecoli comparison knobs at the API boundary — closes #154

### DIFF
--- a/sms_api/api/client/api/simulations/run_ecoli_simulation_new.py
+++ b/sms_api/api/client/api/simulations/run_ecoli_simulation_new.py
@@ -7,6 +7,8 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.analysis_options import AnalysisOptions
 from ...models.http_validation_error import HTTPValidationError
+from ...models.run_ecoli_simulation_new_composite_type_0 import RunEcoliSimulationNewCompositeType0
+from ...models.run_ecoli_simulation_new_vecoli_source_type_0 import RunEcoliSimulationNewVecoliSourceType0
 from ...models.simulation import Simulation
 from ...types import UNSET, Response, Unset
 
@@ -19,9 +21,10 @@ def _get_kwargs(
     simulation_config_filename: Union[Unset, str] = "api_simulation_default.json",
     num_generations: Union[None, Unset, int] = UNSET,
     num_seeds: Union[None, Unset, int] = UNSET,
-    composite: Union[None, Unset, str] = UNSET,
+    composite: Union[None, RunEcoliSimulationNewCompositeType0, Unset] = UNSET,
     condition: Union[None, Unset, str] = UNSET,
     max_generations: Union[None, Unset, int] = UNSET,
+    vecoli_source: Union[None, RunEcoliSimulationNewVecoliSourceType0, Unset] = UNSET,
     description: Union[None, Unset, str] = UNSET,
     run_parca: Union[None, Unset, bool] = UNSET,
     observables: Union[None, Unset, list[str]] = UNSET,
@@ -62,6 +65,8 @@ def _get_kwargs(
     json_composite: Union[None, Unset, str]
     if isinstance(composite, Unset):
         json_composite = UNSET
+    elif isinstance(composite, RunEcoliSimulationNewCompositeType0):
+        json_composite = composite.value
     else:
         json_composite = composite
     params["composite"] = json_composite
@@ -79,6 +84,15 @@ def _get_kwargs(
     else:
         json_max_generations = max_generations
     params["max_generations"] = json_max_generations
+
+    json_vecoli_source: Union[None, Unset, str]
+    if isinstance(vecoli_source, Unset):
+        json_vecoli_source = UNSET
+    elif isinstance(vecoli_source, RunEcoliSimulationNewVecoliSourceType0):
+        json_vecoli_source = vecoli_source.value
+    else:
+        json_vecoli_source = vecoli_source
+    params["vecoli_source"] = json_vecoli_source
 
     json_description: Union[None, Unset, str]
     if isinstance(description, Unset):
@@ -189,9 +203,10 @@ def sync_detailed(
     simulation_config_filename: Union[Unset, str] = "api_simulation_default.json",
     num_generations: Union[None, Unset, int] = UNSET,
     num_seeds: Union[None, Unset, int] = UNSET,
-    composite: Union[None, Unset, str] = UNSET,
+    composite: Union[None, RunEcoliSimulationNewCompositeType0, Unset] = UNSET,
     condition: Union[None, Unset, str] = UNSET,
     max_generations: Union[None, Unset, int] = UNSET,
+    vecoli_source: Union[None, RunEcoliSimulationNewVecoliSourceType0, Unset] = UNSET,
     description: Union[None, Unset, str] = UNSET,
     run_parca: Union[None, Unset, bool] = UNSET,
     observables: Union[None, Unset, list[str]] = UNSET,
@@ -216,13 +231,16 @@ def sync_detailed(
             'api_simulation_default.json'.
         num_generations (Union[None, Unset, int]): Number of generations to simulate
         num_seeds (Union[None, Unset, int]): Number of initial seeds (lineages)
-        composite (Union[None, Unset, str]): Ray two-engine comparison: 'v2ecoli' (ported) or
-            'vecoli' (imported via build_composite_native). When set, runs the comparison ensemble
-            driver instead of the phase0 ensemble.
+        composite (Union[None, RunEcoliSimulationNewCompositeType0, Unset]): Ray two-engine
+            comparison: 'v2ecoli' (ported) or 'vecoli' (imported via build_composite_native). When
+            set, runs the comparison ensemble driver instead of the phase0 ensemble.
         condition (Union[None, Unset, str]): Growth condition/media for the comparison run (e.g.
             basal, acetate).
         max_generations (Union[None, Unset, int]): Generations per lineage for the comparison
             ensemble.
+        vecoli_source (Union[None, RunEcoliSimulationNewVecoliSourceType0, Unset]): How the
+            genuine vEcoli side runs (composite='vecoli' only): 'upstream' (default, ~50 pbg steps) or
+            'vivarium-process' (vEcoli as one pbg node with vivarium-core's Engine inside).
         description (Union[None, Unset, str]): Description of the simulation
         run_parca (Union[None, Unset, bool]): If true, run the simulation parameter calculator
             prior to running simulation (re-parameterizes simulation workflow).
@@ -259,6 +277,7 @@ def sync_detailed(
         composite=composite,
         condition=condition,
         max_generations=max_generations,
+        vecoli_source=vecoli_source,
         description=description,
         run_parca=run_parca,
         observables=observables,
@@ -284,9 +303,10 @@ def sync(
     simulation_config_filename: Union[Unset, str] = "api_simulation_default.json",
     num_generations: Union[None, Unset, int] = UNSET,
     num_seeds: Union[None, Unset, int] = UNSET,
-    composite: Union[None, Unset, str] = UNSET,
+    composite: Union[None, RunEcoliSimulationNewCompositeType0, Unset] = UNSET,
     condition: Union[None, Unset, str] = UNSET,
     max_generations: Union[None, Unset, int] = UNSET,
+    vecoli_source: Union[None, RunEcoliSimulationNewVecoliSourceType0, Unset] = UNSET,
     description: Union[None, Unset, str] = UNSET,
     run_parca: Union[None, Unset, bool] = UNSET,
     observables: Union[None, Unset, list[str]] = UNSET,
@@ -311,13 +331,16 @@ def sync(
             'api_simulation_default.json'.
         num_generations (Union[None, Unset, int]): Number of generations to simulate
         num_seeds (Union[None, Unset, int]): Number of initial seeds (lineages)
-        composite (Union[None, Unset, str]): Ray two-engine comparison: 'v2ecoli' (ported) or
-            'vecoli' (imported via build_composite_native). When set, runs the comparison ensemble
-            driver instead of the phase0 ensemble.
+        composite (Union[None, RunEcoliSimulationNewCompositeType0, Unset]): Ray two-engine
+            comparison: 'v2ecoli' (ported) or 'vecoli' (imported via build_composite_native). When
+            set, runs the comparison ensemble driver instead of the phase0 ensemble.
         condition (Union[None, Unset, str]): Growth condition/media for the comparison run (e.g.
             basal, acetate).
         max_generations (Union[None, Unset, int]): Generations per lineage for the comparison
             ensemble.
+        vecoli_source (Union[None, RunEcoliSimulationNewVecoliSourceType0, Unset]): How the
+            genuine vEcoli side runs (composite='vecoli' only): 'upstream' (default, ~50 pbg steps) or
+            'vivarium-process' (vEcoli as one pbg node with vivarium-core's Engine inside).
         description (Union[None, Unset, str]): Description of the simulation
         run_parca (Union[None, Unset, bool]): If true, run the simulation parameter calculator
             prior to running simulation (re-parameterizes simulation workflow).
@@ -355,6 +378,7 @@ def sync(
         composite=composite,
         condition=condition,
         max_generations=max_generations,
+        vecoli_source=vecoli_source,
         description=description,
         run_parca=run_parca,
         observables=observables,
@@ -374,9 +398,10 @@ async def asyncio_detailed(
     simulation_config_filename: Union[Unset, str] = "api_simulation_default.json",
     num_generations: Union[None, Unset, int] = UNSET,
     num_seeds: Union[None, Unset, int] = UNSET,
-    composite: Union[None, Unset, str] = UNSET,
+    composite: Union[None, RunEcoliSimulationNewCompositeType0, Unset] = UNSET,
     condition: Union[None, Unset, str] = UNSET,
     max_generations: Union[None, Unset, int] = UNSET,
+    vecoli_source: Union[None, RunEcoliSimulationNewVecoliSourceType0, Unset] = UNSET,
     description: Union[None, Unset, str] = UNSET,
     run_parca: Union[None, Unset, bool] = UNSET,
     observables: Union[None, Unset, list[str]] = UNSET,
@@ -401,13 +426,16 @@ async def asyncio_detailed(
             'api_simulation_default.json'.
         num_generations (Union[None, Unset, int]): Number of generations to simulate
         num_seeds (Union[None, Unset, int]): Number of initial seeds (lineages)
-        composite (Union[None, Unset, str]): Ray two-engine comparison: 'v2ecoli' (ported) or
-            'vecoli' (imported via build_composite_native). When set, runs the comparison ensemble
-            driver instead of the phase0 ensemble.
+        composite (Union[None, RunEcoliSimulationNewCompositeType0, Unset]): Ray two-engine
+            comparison: 'v2ecoli' (ported) or 'vecoli' (imported via build_composite_native). When
+            set, runs the comparison ensemble driver instead of the phase0 ensemble.
         condition (Union[None, Unset, str]): Growth condition/media for the comparison run (e.g.
             basal, acetate).
         max_generations (Union[None, Unset, int]): Generations per lineage for the comparison
             ensemble.
+        vecoli_source (Union[None, RunEcoliSimulationNewVecoliSourceType0, Unset]): How the
+            genuine vEcoli side runs (composite='vecoli' only): 'upstream' (default, ~50 pbg steps) or
+            'vivarium-process' (vEcoli as one pbg node with vivarium-core's Engine inside).
         description (Union[None, Unset, str]): Description of the simulation
         run_parca (Union[None, Unset, bool]): If true, run the simulation parameter calculator
             prior to running simulation (re-parameterizes simulation workflow).
@@ -444,6 +472,7 @@ async def asyncio_detailed(
         composite=composite,
         condition=condition,
         max_generations=max_generations,
+        vecoli_source=vecoli_source,
         description=description,
         run_parca=run_parca,
         observables=observables,
@@ -467,9 +496,10 @@ async def asyncio(
     simulation_config_filename: Union[Unset, str] = "api_simulation_default.json",
     num_generations: Union[None, Unset, int] = UNSET,
     num_seeds: Union[None, Unset, int] = UNSET,
-    composite: Union[None, Unset, str] = UNSET,
+    composite: Union[None, RunEcoliSimulationNewCompositeType0, Unset] = UNSET,
     condition: Union[None, Unset, str] = UNSET,
     max_generations: Union[None, Unset, int] = UNSET,
+    vecoli_source: Union[None, RunEcoliSimulationNewVecoliSourceType0, Unset] = UNSET,
     description: Union[None, Unset, str] = UNSET,
     run_parca: Union[None, Unset, bool] = UNSET,
     observables: Union[None, Unset, list[str]] = UNSET,
@@ -494,13 +524,16 @@ async def asyncio(
             'api_simulation_default.json'.
         num_generations (Union[None, Unset, int]): Number of generations to simulate
         num_seeds (Union[None, Unset, int]): Number of initial seeds (lineages)
-        composite (Union[None, Unset, str]): Ray two-engine comparison: 'v2ecoli' (ported) or
-            'vecoli' (imported via build_composite_native). When set, runs the comparison ensemble
-            driver instead of the phase0 ensemble.
+        composite (Union[None, RunEcoliSimulationNewCompositeType0, Unset]): Ray two-engine
+            comparison: 'v2ecoli' (ported) or 'vecoli' (imported via build_composite_native). When
+            set, runs the comparison ensemble driver instead of the phase0 ensemble.
         condition (Union[None, Unset, str]): Growth condition/media for the comparison run (e.g.
             basal, acetate).
         max_generations (Union[None, Unset, int]): Generations per lineage for the comparison
             ensemble.
+        vecoli_source (Union[None, RunEcoliSimulationNewVecoliSourceType0, Unset]): How the
+            genuine vEcoli side runs (composite='vecoli' only): 'upstream' (default, ~50 pbg steps) or
+            'vivarium-process' (vEcoli as one pbg node with vivarium-core's Engine inside).
         description (Union[None, Unset, str]): Description of the simulation
         run_parca (Union[None, Unset, bool]): If true, run the simulation parameter calculator
             prior to running simulation (re-parameterizes simulation workflow).
@@ -539,6 +572,7 @@ async def asyncio(
             composite=composite,
             condition=condition,
             max_generations=max_generations,
+            vecoli_source=vecoli_source,
             description=description,
             run_parca=run_parca,
             observables=observables,

--- a/sms_api/api/client/models/__init__.py
+++ b/sms_api/api/client/models/__init__.py
@@ -53,6 +53,8 @@ from .repo_discovery_analysis_modules import RepoDiscoveryAnalysisModules
 from .run_ecoli_simulation_analysis_response_run_ecoli_simulation_analysis import (
     RunEcoliSimulationAnalysisResponseRunEcoliSimulationAnalysis,
 )
+from .run_ecoli_simulation_new_composite_type_0 import RunEcoliSimulationNewCompositeType0
+from .run_ecoli_simulation_new_vecoli_source_type_0 import RunEcoliSimulationNewVecoliSourceType0
 from .simulation import Simulation
 from .simulation_analysis_data_response_type import SimulationAnalysisDataResponseType
 from .simulation_config import SimulationConfig
@@ -118,6 +120,8 @@ __all__ = (
     "RepoDiscovery",
     "RepoDiscoveryAnalysisModules",
     "RunEcoliSimulationAnalysisResponseRunEcoliSimulationAnalysis",
+    "RunEcoliSimulationNewCompositeType0",
+    "RunEcoliSimulationNewVecoliSourceType0",
     "Simulation",
     "SimulationAnalysisDataResponseType",
     "SimulationConfig",

--- a/sms_api/api/client/models/run_ecoli_simulation_new_composite_type_0.py
+++ b/sms_api/api/client/models/run_ecoli_simulation_new_composite_type_0.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class RunEcoliSimulationNewCompositeType0(str, Enum):
+    V2ECOLI = "v2ecoli"
+    VECOLI = "vecoli"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sms_api/api/client/models/run_ecoli_simulation_new_vecoli_source_type_0.py
+++ b/sms_api/api/client/models/run_ecoli_simulation_new_vecoli_source_type_0.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class RunEcoliSimulationNewVecoliSourceType0(str, Enum):
+    UPSTREAM = "upstream"
+    VIVARIUM_PROCESS = "vivarium-process"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sms_api/api/routers/sms.py
+++ b/sms_api/api/routers/sms.py
@@ -34,12 +34,14 @@ from sms_api.dependencies import get_database_service, get_simulation_service
 from sms_api.simulation.github_repo import open_repo_tarball_stream
 from sms_api.simulation.models import (
     AnalysisOptions,
+    CompositeEngine,
     ObservableInfoModel,
     RepoDiscovery,
     Simulation,
     SimulationObservableIndex,
     SimulationObservables,
     SimulationRun,
+    VecoliSource,
 )
 from sms_api.simulation.observable_reader import list_observables_async, read_observables_async
 
@@ -166,7 +168,7 @@ async def run_simulation_workflow(
     ),
     num_generations: int | None = Query(default=None, description="Number of generations to simulate"),
     num_seeds: int | None = Query(default=None, description="Number of initial seeds (lineages)"),
-    composite: str | None = Query(
+    composite: CompositeEngine | None = Query(
         default=None,
         description="Ray two-engine comparison: 'v2ecoli' (ported) or 'vecoli' "
         "(imported via build_composite_native). When set, runs the comparison "
@@ -179,6 +181,12 @@ async def run_simulation_workflow(
     max_generations: int | None = Query(
         default=None,
         description="Generations per lineage for the comparison ensemble.",
+    ),
+    vecoli_source: VecoliSource | None = Query(
+        default=None,
+        description="How the genuine vEcoli side runs (composite='vecoli' only): "
+        "'upstream' (default, ~50 pbg steps) or 'vivarium-process' (vEcoli as one "
+        "pbg node with vivarium-core's Engine inside).",
     ),
     description: str | None = Query(default=None, description="Description of the simulation"),
     run_parca: bool | None = Query(
@@ -242,6 +250,7 @@ async def run_simulation_workflow(
             composite=composite,
             condition=condition,
             max_generations=max_generations,
+            vecoli_source=vecoli_source,
             description=description,
             run_parca=run_parca,
             observables=observables,

--- a/sms_api/api/spec/openapi_3_1_0_generated.yaml
+++ b/sms_api/api/spec/openapi_3_1_0_generated.yaml
@@ -137,7 +137,10 @@ paths:
         required: false
         schema:
           anyOf:
-          - type: string
+          - enum:
+            - v2ecoli
+            - vecoli
+            type: string
           - type: 'null'
           description: 'Ray two-engine comparison: ''v2ecoli'' (ported) or ''vecoli''
             (imported via build_composite_native). When set, runs the comparison ensemble
@@ -167,6 +170,23 @@ paths:
           description: Generations per lineage for the comparison ensemble.
           title: Max Generations
         description: Generations per lineage for the comparison ensemble.
+      - name: vecoli_source
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - enum:
+            - upstream
+            - vivarium-process
+            type: string
+          - type: 'null'
+          description: 'How the genuine vEcoli side runs (composite=''vecoli'' only):
+            ''upstream'' (default, ~50 pbg steps) or ''vivarium-process'' (vEcoli
+            as one pbg node with vivarium-core''s Engine inside).'
+          title: Vecoli Source
+        description: 'How the genuine vEcoli side runs (composite=''vecoli'' only):
+          ''upstream'' (default, ~50 pbg steps) or ''vivarium-process'' (vEcoli as
+          one pbg node with vivarium-core''s Engine inside).'
       - name: description
         in: query
         required: false
@@ -878,9 +898,9 @@ paths:
                   git_repo_url: https://github.com/CovertLabEcoli/vEcoli-private
                   git_branch: master
                   database_id: 25
-                  created_at: '2026-06-29T23:19:33.951936'
+                  created_at: '2026-07-10T12:37:53.862427'
                 parca_config:
-                  outdir: .
+                  outdir: /projects/SMS/sms_api/jim/sims
       responses:
         '200':
           description: Successful Response
@@ -2323,7 +2343,7 @@ components:
         parca_config:
           $ref: '#/components/schemas/ParcaOptions'
           default:
-            outdir: .
+            outdir: /projects/SMS/sms_api/jim/sims
       additionalProperties: true
       type: object
       required:
@@ -2334,7 +2354,7 @@ components:
         outdir:
           type: string
           title: Outdir
-          default: .
+          default: /projects/SMS/sms_api/jim/sims
       additionalProperties: true
       type: object
       title: ParcaOptions
@@ -2485,7 +2505,7 @@ components:
         last_updated:
           type: string
           title: Last Updated
-          default: '2026-06-29 23:19:33.784599'
+          default: '2026-07-10 12:37:53.611158'
         job_id:
           anyOf:
           - type: string
@@ -2522,7 +2542,7 @@ components:
         parca_options:
           $ref: '#/components/schemas/ParcaOptions'
           default:
-            outdir: .
+            outdir: /projects/SMS/sms_api/jim/sims
         analysis_options:
           $ref: '#/components/schemas/AnalysisOptions'
           default: {}

--- a/sms_api/common/handlers/simulations.py
+++ b/sms_api/common/handlers/simulations.py
@@ -35,6 +35,7 @@ from sms_api.simulation.database_service import DatabaseService
 from sms_api.simulation.hpc_utils import get_correlation_id
 from sms_api.simulation.models import (
     AnalysisOptions,
+    CompositeEngine,
     HpcRun,
     JobType,
     ParcaDataset,
@@ -45,6 +46,7 @@ from sms_api.simulation.models import (
     SimulationRequest,
     SimulationRun,
     SimulatorVersion,
+    VecoliSource,
 )
 from sms_api.simulation.simulation_service import SimulationService
 
@@ -373,9 +375,10 @@ async def run_simulation_workflow(  # noqa: C901
     simulation_config_filename: str,
     num_generations: int | None = None,
     num_seeds: int | None = None,
-    composite: str | None = None,
+    composite: CompositeEngine | None = None,
     condition: str | None = None,
     max_generations: int | None = None,
+    vecoli_source: VecoliSource | None = None,
     description: str | None = None,
     run_parca: bool | None = None,
     observables: list[str] | None = None,
@@ -489,14 +492,18 @@ async def run_simulation_workflow(  # noqa: C901
         config_data["n_init_sims"] = num_seeds
     # Two-engine comparison knobs (Ray backend): when `composite` is set the Ray
     # sim job runs scripts/run_comparison_ensemble.py instead of the phase0
-    # ensemble. SimulationConfig allows extra fields, so these flow through to
-    # SimulationServiceK8s/Ray._sim_command via getattr.
+    # ensemble. Validated at the API boundary (Literal Query params → 422 on a
+    # typo); they ride through SimulationConfig as extra passthrough keys (set only
+    # when provided) so they never inject our defaults into the vEcoli solver
+    # config. The Ray backend reads them via getattr.
     if composite is not None:
         config_data["composite"] = composite
     if condition is not None:
         config_data["condition"] = condition
     if max_generations is not None:
         config_data["max_generations"] = max_generations
+    if vecoli_source is not None:
+        config_data["vecoli_source"] = vecoli_source
     if description is not None:
         config_data["description"] = description
     effective_observables = observables if observables else DEFAULT_OBSERVABLES

--- a/sms_api/simulation/models.py
+++ b/sms_api/simulation/models.py
@@ -191,6 +191,23 @@ class AnalysisOptions(BaseModel):
         trim_attributes(self)
 
 
+# Ray two-engine comparison knobs — validated at the API boundary (Literal Query
+# params on the run endpoint → 422 on a typo), NOT declared on SimulationConfig.
+# SimulationConfig is a passthrough to the vEcoli solver's schema, and the
+# established convention here is to declare only fields authoritative to us and
+# leave everything the solver owns undeclared (extra="allow" carries them through
+# without injecting our defaults). So these ride in as extra keys, present only
+# when the caller set them, and the Ray backend reads them via getattr.
+# ``CompositeEngine`` — which engine the comparison driver runs:
+#   "v2ecoli" (the ported bigraph model) or "vecoli" (pristine upstream vEcoli,
+#   which requires the separate upstream ParCa cache; see _is_upstream_vecoli).
+CompositeEngine = Literal["v2ecoli", "vecoli"]
+# ``VecoliSource`` — how the genuine vEcoli side runs (only meaningful for
+# composite="vecoli"): "upstream" (default, ~50 pbg steps) or "vivarium-process"
+# (vEcoli as one pbg node with vivarium-core's Engine inside).
+VecoliSource = Literal["upstream", "vivarium-process"]
+
+
 class SimulationConfig(BaseModel):
     model_config = ConfigDict(extra="allow")
     experiment_id: str

--- a/sms_api/simulation/simulation_service_ray.py
+++ b/sms_api/simulation/simulation_service_ray.py
@@ -42,7 +42,14 @@ from sms_api.simulation.github_repo import (
     fetch_latest_commit_hash,
     fetch_repo_discovery,
 )
-from sms_api.simulation.models import ParcaDataset, RepoDiscovery, Simulation, SimulatorVersion
+from sms_api.simulation.models import (
+    CompositeEngine,
+    ParcaDataset,
+    RepoDiscovery,
+    Simulation,
+    SimulatorVersion,
+    VecoliSource,
+)
 from sms_api.simulation.simulation_service import SimulationService
 
 logger = logging.getLogger(__name__)
@@ -60,6 +67,17 @@ REPORT_PATH = "/tmp/report.json"  # noqa: S108
 
 def _rand_suffix() -> str:
     return "".join(random.choices(string.ascii_lowercase + string.digits, k=6))
+
+
+def _is_upstream_vecoli(composite: CompositeEngine | None) -> bool:
+    """The pristine upstream-vEcoli engine (``--composite vecoli``).
+
+    The single source of truth for the routing question "does this run need the
+    separate upstream ParCa cache + ``--vecoli-source`` flag?" — used both to
+    select the ParCa cache/command in ``submit_ecoli_simulation_job`` and to gate
+    the ``--vecoli-source`` arg in ``_sim_command``.
+    """
+    return composite == "vecoli"
 
 
 class SimulationServiceRay(SimulationService):
@@ -275,10 +293,10 @@ class SimulationServiceRay(SimulationService):
         n_steps: int,
         chunk: int,
         *,
-        composite: str | None = None,
+        composite: CompositeEngine | None = None,
         condition: str | None = None,
         max_generations: int | None = None,
-        vecoli_source: str | None = None,
+        vecoli_source: VecoliSource | None = None,
     ) -> str:
         # When ``composite`` is set, run the two-engine comparison driver — both
         # engines (v2ecoli port + vEcoli imported via build_composite_native)
@@ -295,7 +313,7 @@ class SimulationServiceRay(SimulationService):
             # "vivarium-process" (vEcoli as ONE pbg node with vivarium-core's Engine
             # inside — faithful by construction). Both stage the SAME upstream ParCa
             # cache (is_upstream routing is unchanged), so only the driver flag differs.
-            src = f" --vecoli-source {vecoli_source}" if (composite == "vecoli" and vecoli_source) else ""
+            src = f" --vecoli-source {vecoli_source}" if (_is_upstream_vecoli(composite) and vecoli_source) else ""
             return (
                 f"cd {V2ECOLI_DIR} && python scripts/run_comparison_ensemble.py"
                 f" --composite {composite} --condition {condition or 'basal'}"
@@ -422,22 +440,26 @@ bash docker/build-and-push-ecr.sh -i {commit} -r {settings.ray_ecr_repository} -
         # v2ecoli:<commit> (both ParCa and the sim run the same image).
         job_def = self._ensure_mnp_job_def(self._image_uri(commit), commit)
 
-        n_seeds = ecoli_simulation.num_seeds or getattr(ecoli_simulation.config, "n_init_sims", None) or 1
-        n_steps = getattr(ecoli_simulation.config, "ray_n_steps", None) or settings.ray_n_steps
-        chunk = getattr(ecoli_simulation.config, "ray_chunk", None) or settings.ray_chunk
+        config = ecoli_simulation.config
+        # SimulationConfig is a vEcoli passthrough (extra="allow"); the comparison
+        # knobs are validated at the API boundary (Literal Query params) and ride
+        # in as extra keys, so they're read here via getattr (present only when the
+        # caller set them). ``composite``/``vecoli_source`` values are already
+        # constrained by the endpoint's CompositeEngine/VecoliSource types.
+        n_seeds = ecoli_simulation.num_seeds or getattr(config, "n_init_sims", None) or 1
+        n_steps = getattr(config, "ray_n_steps", None) or settings.ray_n_steps
+        chunk = getattr(config, "ray_chunk", None) or settings.ray_chunk
         # Optional two-engine comparison knobs (default phase0 ensemble when unset).
-        composite = getattr(ecoli_simulation.config, "composite", None)
-        condition = getattr(ecoli_simulation.config, "condition", None)
-        max_generations = getattr(ecoli_simulation.config, "max_generations", None)
-        # How the vEcoli side runs (composite=vecoli only): "upstream" (default) or
-        # "vivarium-process" (vEcoli as one pbg node, vivarium Engine inside).
-        vecoli_source = getattr(ecoli_simulation.config, "vecoli_source", None)
+        composite = getattr(config, "composite", None)
+        condition = getattr(config, "condition", None)
+        max_generations = getattr(config, "max_generations", None)
+        vecoli_source = getattr(config, "vecoli_source", None)
 
         # Engine-specific ParCa source: the pristine upstream wrapper (--composite
         # vecoli) stages an UPSTREAM-built simData (separate cache + build cmd);
         # every other engine stages the v2ecoli cache. Both ParCa and the sim use
         # the matching pair so the staged simData is consistent across all nodes.
-        is_upstream = composite == "vecoli"
+        is_upstream = _is_upstream_vecoli(composite)
         cache_s3 = self._upstream_cache_s3_uri(commit) if is_upstream else self._cache_s3_uri(commit)
         parca_command = self._upstream_parca_command() if is_upstream else self._parca_command()
 

--- a/tests/simulation/test_ray_backend.py
+++ b/tests/simulation/test_ray_backend.py
@@ -302,6 +302,35 @@ class TestSimulationServiceRayBuild:
             cmd = service._sim_command(n_seeds=1, n_steps=10, chunk=4, composite="v2ecoli", max_generations=5)
         assert "--max-generations 5" in cmd
 
+    def test_sim_command_vecoli_source_only_appended_for_upstream_vecoli(self) -> None:
+        """--vecoli-source is meaningful only for --composite vecoli."""
+        service = SimulationServiceRay()
+        with patch("sms_api.simulation.simulation_service_ray.get_settings", _ray_settings):
+            vecoli = service._sim_command(
+                n_seeds=1, n_steps=10, chunk=4, composite="vecoli", vecoli_source="vivarium-process"
+            )
+            v2ecoli = service._sim_command(
+                n_seeds=1, n_steps=10, chunk=4, composite="v2ecoli", vecoli_source="vivarium-process"
+            )
+        assert "--vecoli-source vivarium-process" in vecoli
+        # v2ecoli engine ignores vecoli_source (guarded by _is_upstream_vecoli)
+        assert "--vecoli-source" not in v2ecoli
+
+
+class TestIsUpstreamVecoli:
+    """The single routing predicate shared by submit_ecoli_simulation_job and _sim_command."""
+
+    def test_only_vecoli_is_upstream(self) -> None:
+        from sms_api.simulation.simulation_service_ray import _is_upstream_vecoli
+
+        assert _is_upstream_vecoli("vecoli") is True
+        assert _is_upstream_vecoli("v2ecoli") is False
+        assert _is_upstream_vecoli(None) is False
+
+
+class TestSimulationServiceRayBuildSubmit:
+    """Build-image submission: DooD Batch job to the amd64 queue, then poll."""
+
     @pytest.mark.asyncio
     async def test_run_build_submits_to_amd64_queue_and_polls(self) -> None:
         service = SimulationServiceRay()


### PR DESCRIPTION
Closes #154.

## Problem
The Ray two-engine comparison knobs (`composite`, `condition`, `max_generations`, `vecoli_source`) were read from the config via `getattr` with no validation. A typo (`composit`, `vecoli_souce`) silently became `None` and fell back to the phase0 path. For `composite`, that stages the **v2ecoli** ParCa cache under the comparison driver — **reintroducing the TCS-negative-ODE crash #147 fixed**, with no error.

## Fix — validate at the boundary, don't pollute the passthrough config
- **`sms.py`** — type the run endpoint's `composite` Query param as a `Literal` (`CompositeEngine`) so FastAPI returns **422** on a bad value, and expose `vecoli_source` (`Literal` `VecoliSource`), previously reachable only via raw config JSONB with no validation. This is the real guard: it protects **every** caller regardless of client (the hand-rolled workbench `urllib` client, `httpx`, curl).
- **`simulation_service_ray.py`** — collapse the duplicated `composite == "vecoli"` routing predicate into one `_is_upstream_vecoli()` helper used by both the ParCa cache/command selection and the `--vecoli-source` gate.
- **`handlers/simulations.py`** — thread `vecoli_source` through to the config.

## Design note (why the knobs are *not* declared on `SimulationConfig`)
`SimulationConfig` is a passthrough to the vEcoli **solver's** schema (`extra="allow"`). This repo's established convention — visible in git history (Sept-2025 closed-mirror was walked back in `a314a4b0` "added extra allowed", `6b7eca86` "make cpus optional without defaults") — is to **declare only fields authoritative to us and leave solver-owned fields undeclared**, so we never inject our defaults into the foreign payload.

An earlier revision of this PR declared the four knobs as `SimulationConfig` fields with `None` defaults; that leaked `composite: null`, `condition: null`, … into the solver's `workflow.json` on every run (`condition` is a real vEcoli field, so this overrode a value the solver owns). So the knobs stay `extra="allow"` passthrough (present only when set) and the Ray backend reads them via `getattr`. `CompositeEngine`/`VecoliSource` `Literal` aliases live in `models.py` for the endpoint/handler/service signatures.

`SimulationConfig`'s schema is unchanged vs `main`.

## Verification
`make check` green (ruff + ruff-format + mypy strict/180 + deptry); targeted tests pass (routing predicate + `--vecoli-source` gating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)