### PR TITLE
release: 0.9.17 + deploy vivarium-workbench to stanford-test

### DIFF
--- a/kustomize/base/workbench/kustomization.yaml
+++ b/kustomize/base/workbench/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Standalone base for the vivarium-workbench Deployment + Service. Kept OUT of the
+# shared base/kustomization.yaml so it deploys ONLY where an overlay references it
+# (the Stanford EKS overlays) — never on the rke/local (SLURM) deployments, which
+# have no ALB TargetGroupBinding or EBS PVC for it. Overlays add the EBS PVC, the
+# TargetGroupBinding, and the pinned image tag.
+resources:
+  - workbench.yaml

--- a/kustomize/base/workbench/workbench.yaml
+++ b/kustomize/base/workbench/workbench.yaml
@@ -31,12 +31,17 @@ spec:
       labels:
         app: vivarium-workbench
     spec:
-      # Match the shared-storage identity sms-api uses (see api.yaml) so files/git
-      # on the EBS PVC are written as the expected uid/gid.
+      # Run as ROOT (uid 0). The combined image installs its uv-managed CPython
+      # under /root/.local/share/uv/python (root home, mode 700); as any non-root
+      # uid the interpreter cannot read its own stdlib there — sys.base_prefix
+      # falls back to the build-time /install and Python dies with "No module named
+      # 'encodings'". So this image MUST run as root. (No restricted PodSecurity
+      # enforcement on this namespace; unlike api, which runs as 17163 by choice.)
+      # fsGroup 0 so the EBS workspace volume is root-writable.
       securityContext:
-        runAsUser: 17163
-        runAsGroup: 10000
-        fsGroup: 10000
+        runAsUser: 0
+        runAsGroup: 0
+        fsGroup: 0
       # Seed the (initially empty) EBS workspace ONCE from the image's baked-in
       # v2ecoli workspace. `workspace.yaml` is the seeded-marker so pod restarts /
       # user edits are never clobbered (and EBS's ext4 lost+found is ignored).

--- a/kustomize/base/workbench/workbench.yaml
+++ b/kustomize/base/workbench/workbench.yaml
@@ -1,0 +1,120 @@
+# vivarium-workbench Deployment + Service — a PEER of the api service (modeled on
+# api.yaml). The workbench renders workspaces in-process (imports pbg_v2ecoli via
+# build_core) and delegates ALL compute/storage to sms-api over in-cluster HTTP;
+# it needs no Postgres, IRSA, or AWS creds.
+#
+# This file is intentionally NOT listed in base/kustomization.yaml — the workbench
+# only makes sense on the EKS/GovCloud (Stanford) deployments (it needs the ALB
+# TargetGroupBinding + an EBS PVC), so ONLY the Stanford overlays reference it
+# directly (resources: ../../base/workbench.yaml). The rke/local (SLURM) overlays
+# must not deploy it.
+#
+# Env-specific bits come from the overlay: namespace, image tag (images:), the EBS
+# PVC (workbench-pvc.yaml), and the TargetGroupBinding. The image + ghcr pull
+# secret come from this repo's overlay conventions; the workspace is served from
+# the mounted EBS PVC, seeded once from the image's baked-in /app/v2ecoli.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: workbench
+  labels:
+    app: vivarium-workbench
+spec:
+  # Single replica: the workbench holds a git working copy + SQLite on an RWO EBS
+  # volume, so exactly one writer.
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vivarium-workbench
+  template:
+    metadata:
+      labels:
+        app: vivarium-workbench
+    spec:
+      # Match the shared-storage identity sms-api uses (see api.yaml) so files/git
+      # on the EBS PVC are written as the expected uid/gid.
+      securityContext:
+        runAsUser: 17163
+        runAsGroup: 10000
+        fsGroup: 10000
+      # Seed the (initially empty) EBS workspace ONCE from the image's baked-in
+      # v2ecoli workspace. `workspace.yaml` is the seeded-marker so pod restarts /
+      # user edits are never clobbered (and EBS's ext4 lost+found is ignored).
+      initContainers:
+        - name: seed-workspace
+          image: ghcr.io/vivarium-collective/vivarium-workbench:latest
+          imagePullPolicy: Always
+          command:
+            - "sh"
+            - "-c"
+            - |
+              if [ ! -f /workspace/workspace.yaml ]; then
+                echo "seeding /workspace from baked-in /app/v2ecoli";
+                cp -a /app/v2ecoli/. /workspace/;
+              else
+                echo "/workspace already seeded (workspace.yaml present); skipping";
+              fi
+          volumeMounts:
+            - name: workspace
+              mountPath: /workspace
+      containers:
+        - name: workbench
+          # Overlays pin the tag via `images:` (build with deploy/build-and-push.sh).
+          image: ghcr.io/vivarium-collective/vivarium-workbench:latest
+          imagePullPolicy: Always
+          command: ["vivarium-workbench"]
+          args:
+            - "serve"
+            - "--workspace"
+            - "/workspace"
+            - "--host"
+            - "0.0.0.0"
+            - "--port"
+            - "8000"
+            # Served under /workbench so it co-tenants the internal ALB with sms-api
+            # (the sms-cdk /workbench/* + /bigraph-loom/* listener rules forward to
+            # the workbench target group). uvicorn root_path is derived from this.
+            - "--base-path"
+            - "/workbench"
+          ports:
+            - containerPort: 8000
+          env:
+            # The ONLY backend: sms-api's in-cluster Service. Same-namespace short
+            # DNS (the workbench is a peer of `api` in the sms-api namespace).
+            - name: SMS_API_BASE
+              value: "http://api:8000"
+            - name: VIVARIUM_WORKBENCH_WORKSPACE
+              value: "/workspace"
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: workspace
+              mountPath: /workspace
+      volumes:
+        # Private EBS gp3 PVC (RWO) — workspace + caches. The claim is defined in
+        # the overlay (workbench-pvc.yaml). No shared filesystem with the compute:
+        # run outputs arrive from S3 via sms-api's download endpoints.
+        - name: workspace
+          persistentVolumeClaim:
+            claimName: workbench-workspace
+      imagePullSecrets:
+        - name: ghcr-secret
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: workbench
+  labels:
+    app: vivarium-workbench
+spec:
+  ports:
+    - name: "8000"
+      port: 8000
+      targetPort: 8000
+  selector:
+    app: vivarium-workbench

--- a/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
@@ -15,6 +15,10 @@ images:
   # avoids an ErrImagePull ReplicaSet while api iterates independently.
   - name: ghcr.io/vivarium-collective/sms-ptools
     newTag: 0.5.9
+  # vivarium-workbench: build + push with the workbench repo's
+  # deploy/build-and-push.sh, then pin that tag (a git sha) here.
+  - name: ghcr.io/vivarium-collective/vivarium-workbench
+    newTag: REPLACE_WITH_BUILT_TAG
 
 replicas:
   - count: 1
@@ -31,6 +35,11 @@ resources:
   - target-group-binding.yaml # to accept traffic from predefined ALB rather than use an ingres
   - secret-ghcr.yaml
   - secret-shared.yaml
+  # vivarium-workbench: peer Deployment+Service (base/workbench.yaml is referenced
+  # directly, NOT via base/kustomization.yaml, so it deploys ONLY on Stanford) +
+  # its EBS PVC. Its TargetGroupBinding is in target-group-binding.yaml above.
+  - ../../base/workbench
+  - workbench-pvc.yaml
   - ../../config/sms-api-stanford-test
   - ../../base
 

--- a/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: sms-api-stanford-test
 
 images:
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.9.16
+    newTag: 0.9.17
   # ptools pinned to last-known-good tag — the build-and-push GH Action's
   # ptools step is currently broken (Dockerfile-nextflow issue), so there is
   # no sms-ptools:0.6.x image on ghcr.io.  0.5.9 is the tag the live Stanford

--- a/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
@@ -18,7 +18,7 @@ images:
   # vivarium-workbench: build + push with the workbench repo's
   # deploy/build-and-push.sh, then pin that tag (a git sha) here.
   - name: ghcr.io/vivarium-collective/vivarium-workbench
-    newTag: REPLACE_WITH_BUILT_TAG
+    newTag: 0.1.0
 
 replicas:
   - count: 1

--- a/kustomize/overlays/sms-api-stanford-test/target-group-binding.yaml
+++ b/kustomize/overlays/sms-api-stanford-test/target-group-binding.yaml
@@ -17,3 +17,18 @@ spec:
     name: ptools
     port: 1555
   targetGroupARN: arn:aws-us-gov:elasticloadbalancing:us-gov-west-1:476270107793:targetgroup/smsvpctestinternalalb-ptools/c1552fe9cd0e1bb8
+---
+# Binds the workbench Service to the sms-cdk workbench target group. The two
+# listener rules /workbench/* and /bigraph-loom/* both forward to this one TG.
+# ARN = `WorkbenchTargetGroupArn` output of the `smsvpctest-internal-alb` stack
+# (fetch: aws cloudformation describe-stacks --stack-name smsvpctest-internal-alb
+#  --query "Stacks[0].Outputs[?OutputKey=='WorkbenchTargetGroupArn'].OutputValue").
+apiVersion: elbv2.k8s.aws/v1beta1
+kind: TargetGroupBinding
+metadata:
+  name: workbench-binding
+spec:
+  serviceRef:
+    name: workbench
+    port: 8000
+  targetGroupARN: arn:aws-us-gov:elasticloadbalancing:us-gov-west-1:476270107793:targetgroup/smsvpctestinternalalb-workbench/3baa5cae9a0ab7c2

--- a/kustomize/overlays/sms-api-stanford-test/workbench-pvc.yaml
+++ b/kustomize/overlays/sms-api-stanford-test/workbench-pvc.yaml
@@ -1,0 +1,16 @@
+# Private EBS gp3 volume for the workbench's workspace (git working copy / YAML /
+# SQLite) + caches. RWO — one writer, matches the single-replica Deployment.
+# `gp3-retain` (Retain reclaim policy) keeps the volume if the PVC is deleted, so
+# the workspace survives a redeploy; the SC is present on the smsvpctest cluster.
+# NOT shared with the compute — run outputs arrive from S3 via sms-api.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: workbench-workspace
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: gp3-retain
+  resources:
+    requests:
+      storage: 20Gi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sms_api"
-version = "0.9.16"
+version = "0.9.17"
 description = "This is the api server for Vivarium simulation services."
 authors = [{ name = "Alex Patrie", email = "alexanderpatrie@gmail.com" }, { name = "Jim Schaff", email = "jschaff@gmail.com" }]
 requires-python = ">=3.13,<3.14"

--- a/sms_api/version.py
+++ b/sms_api/version.py
@@ -40,4 +40,10 @@
 #          unambiguous high-water mark (supersedes 0.9.12)
 # 0.9.16 — Ray: --composite vecoli stages a SEPARATE pristine-upstream ParCa cache
 #          (build_upstream_parca.py, serial --cpus 1) instead of the v2ecoli cache
-__version__ = "0.9.16"
+# 0.9.17 — data-layout module centralizes all S3 store/cache paths and closes the
+#          reader-vs-downloader drift (#153/#152); comparison knobs validated at the
+#          API boundary via Literal query params (#154); recognize
+#          CovertLabEcoli/sms-ecoli as a Ray repo + harden repo->backend dispatch
+#          to the explicit RepoUrl map (#164); observables endpoint returns 409 for
+#          non-Ray runs; vivarium-workbench deploy manifests move into kustomize (#165)
+__version__ = "0.9.17"

--- a/uv.lock
+++ b/uv.lock
@@ -3075,7 +3075,7 @@ wheels = [
 
 [[package]]
 name = "sms-api"
-version = "0.9.16"
+version = "0.9.17"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
Cuts **0.9.17** and lands the vivarium-workbench Kubernetes deployment. `main` had drifted past the never-released `0.9.16` stamp, so this folds the release into the workbench PR (the merge *is* the release), making `main` the single deployable source of truth.

## Release 0.9.17 (since v0.9.15)
- **#162 / #153** — centralize all S3 store/cache paths in `common/storage/data_layout.py` (backend-scoped `RayLayout`/`NextflowLayout` + `layout_for`); closes the reader-vs-downloader drift (#152). Observables endpoint now 409s for non-Ray runs.
- **#158 / #154** — validate the v2ecoli comparison knobs (`composite`/`vecoli_source`) at the API boundary via `Literal` query params (422 on typo) instead of silent `getattr` misroute.
- **#164** — recognize `CovertLabEcoli/sms-ecoli` (the production Ray repo) + harden `compute_backend_for_repo` to an explicit `RepoUrl` map (it matched neither substring and mis-routed to Batch).
- **#150** — generic pbg compose path: drop `pbest`, own the container def + runner.
- **#147 / #148** — Ray `--composite vecoli` pristine-upstream ParCa cache; `--vecoli-source` engine threading.
- **#146** — export a build's `repo@commit` workspace as a tarball. **#157** — store-layout docstring fix.

Version synced: `version.py`, `pyproject.toml`, `sms-api-stanford-test` overlay → `0.9.17`.

## Workbench deployment (this PR's feature)
- `kustomize/base/workbench/` — standalone base (Deployment + Service), referenced only by the Stanford overlay (never rke/local). Peer of `api` (`SMS_API_BASE=http://api:8000`); serves under `/workbench`; seed-initContainer populates the EBS PVC from the image's `/app/v2ecoli`.
- **Runs as root** — the combined image installs its uv-managed CPython under `/root/.local/share/uv/python` (mode 700); as a non-root uid the interpreter can't read its own stdlib (`ModuleNotFoundError: No module named 'encodings'` → CrashLoopBackOff). No restricted PodSecurity on the namespace.
- stanford-test overlay: `gp3-retain` EBS PVC + workbench `TargetGroupBinding` (`WorkbenchTargetGroupArn` from the deployed `smsvpctest-internal-alb`) + image pinned to `0.1.0`.

## Deployed + verified on stanford-test
Pod `1/1 Running`, ALB workbench target **healthy**, serves `/workbench`, reaches sms-api in-cluster. `make check` green.

Post-merge: tag `v0.9.17`, GH release, CI build `sms-api:0.9.17`, roll stanford-test api.

🤖 Generated with [Claude Code](https://claude.com/claude-code)