### PR TITLE
chore(stanford-test): pin vivarium-workbench 0.1.0 → 0.1.1

### DIFF
--- a/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
@@ -14,10 +14,11 @@ images:
   # avoids an ErrImagePull ReplicaSet while api iterates independently.
   - name: ghcr.io/vivarium-collective/sms-ptools
     newTag: 0.5.9
-  # vivarium-workbench: build + push with the workbench repo's
-  # deploy/build-and-push.sh, then pin that tag (a git sha) here.
+  # vivarium-workbench: published by cutting a GitHub Release in the workbench
+  # repo (build-and-push.yml → ghcr:<version>); pin that release tag here.
+  # 0.1.1 = first image with the pbg-ptools viewer plugin + decoupled v2ecoli.
   - name: ghcr.io/vivarium-collective/vivarium-workbench
-    newTag: 0.1.0
+    newTag: 0.1.1
 
 replicas:
   - count: 1


### PR DESCRIPTION
Bumps the workbench image deployed by the **sms-api-stanford-test** overlay to the newly released **`ghcr.io/vivarium-collective/vivarium-workbench:0.1.1`**.

## What's in 0.1.1
First workbench image reflecting the pbg-ptools decoupling:
- installs the standalone **`pbg-ptools`** viewer plugin (workbench #463) — the Pathway Tools Omics Viewer now renders from the plugin, not from v2ecoli
- builds against **decoupled** v2ecoli `main` (v2ecoli #338)

The image is already built + pushed (workbench release `v0.1.1`, `build-and-push.yml` green), so this is deploy-ready.

## Scope
- **Only** `sms-api-stanford-test` — it's the sole overlay that deploys the workbench (references `../../base/workbench` directly; the shared base does not).
- Also refreshes the stale pin comment: the workbench is now published by cutting a GitHub Release (→ `ghcr:<version>`), not the local `deploy/build-and-push.sh` sha workflow.
- **Prod (`sms-api-stanford`) intentionally NOT touched** — bringing the workbench to prod also needs its ALB workbench target group (`WorkbenchTargetGroupArn` for the prod stack) + a prod PVC; deferred until that's in place, before the production deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)