### PR TITLE
feat(workbench): 0.1.1 + stamp ui.ptools_server_url via seed initContainer

### DIFF
--- a/kustomize/base/workbench/workbench.yaml
+++ b/kustomize/base/workbench/workbench.yaml
@@ -59,6 +59,27 @@ spec:
               else
                 echo "/workspace already seeded (workspace.yaml present); skipping";
               fi
+              # Deployment override for the pbg-ptools Omics Viewer: the baked-in
+              # workspace.yaml sets ui.ptools_server_url to a LOCAL dev container
+              # (http://localhost:1555). In-cluster the viewer builds a link the
+              # user's BROWSER opens, so it must be the browser-reachable PTools URL
+              # (ALB/tunnel), supplied per-overlay via PTOOLS_SERVER_URL. Re-applied
+              # every start so overlay changes take effect; skipped when unset.
+              if [ -n "${PTOOLS_SERVER_URL:-}" ]; then
+                python - <<'PY'
+              import os, pathlib, yaml
+              p = pathlib.Path("/workspace/workspace.yaml")
+              d = yaml.safe_load(p.read_text()) or {}
+              d.setdefault("ui", {})["ptools_server_url"] = os.environ["PTOOLS_SERVER_URL"]
+              p.write_text(yaml.safe_dump(d, sort_keys=False))
+              print("set ui.ptools_server_url =", os.environ["PTOOLS_SERVER_URL"])
+              PY
+              fi
+          env:
+            # Browser-reachable PTools base for the Omics Viewer; set per-overlay.
+            # Empty = leave the workspace's own ui.ptools_server_url untouched.
+            - name: PTOOLS_SERVER_URL
+              value: ""
           volumeMounts:
             - name: workspace
               mountPath: /workspace

--- a/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
@@ -95,3 +95,24 @@ patches:
     target:
       kind: Deployment
       name: api
+  # Browser-reachable PTools base for the pbg-ptools Omics Viewer. The seed
+  # initContainer stamps this into the served workspace.yaml (ui.ptools_server_url),
+  # overriding the baked-in local-dev http://localhost:1555. Tunnel value
+  # (sms-proxy -s smsvpctest -> localhost:8080, PTools at the ALB root); use a real
+  # internal-ALB DNS if the demo is hosted for others.
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: workbench
+      spec:
+        template:
+          spec:
+            initContainers:
+              - name: seed-workspace
+                env:
+                  - name: PTOOLS_SERVER_URL
+                    value: "http://localhost:8080"
+    target:
+      kind: Deployment
+      name: workbench


### PR DESCRIPTION
Follows the pbg-ptools decoupling (v2ecoli #338, workbench #462/#463, v0.1.1).

## Changes
- **Bump workbench image `0.1.0 → 0.1.1`** — the decoupled build; #463 installs the `pbg-ptools` Omics-Viewer plugin into the combined image.
- **Seed initContainer stamps `ui.ptools_server_url`** into the served `workspace.yaml` from a per-overlay `PTOOLS_SERVER_URL` env (python+pyyaml; runs every start; other `ui` keys preserved). The baked-in value is a **local-dev** container (`http://localhost:1555`); in-cluster the viewer builds a link the **browser** opens, so it must be the browser-reachable PTools URL.
- **stanford-test**: `PTOOLS_SERVER_URL=http://localhost:8080` (the `sms-proxy` tunnel; PTools at the ALB root). Use a real internal-ALB DNS for a hosted demo.

Validated the initContainer patch locally: updates `ptools_server_url`, preserves `ptools_orgid`/`ptools_data_dir`; no-op when the env is empty.

## Follow-up (separate)
The end-to-end Omics-Viewer round-trip needs **sms-ptools bumped past `0.5.9`** — the workspace notes reference `0.8.2`'s own-filesystem/`ptools_data_dir` contract. This PR only wires the URL config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)