### PR TITLE
chore(workbench): enable --trust-proxy; pin image to 481b3f2

### DIFF
--- a/kustomize/base/workbench/workbench.yaml
+++ b/kustomize/base/workbench/workbench.yaml
@@ -102,6 +102,13 @@ spec:
             # the workbench target group). uvicorn root_path is derived from this.
             - "--base-path"
             - "/workbench"
+            # Opt-in: trust X-Forwarded-Host for the CSRF/origin guard. Required
+            # behind this ALB hop chain (ALB -> tunnel -> k8s Service), which
+            # rewrites Host; without this every POST/DELETE 403s as
+            # "cross-origin request forbidden" (vivarium-workbench, fix in
+            # 481b3f2). Safe here because this Deployment is only ever reached
+            # through the ALB, never directly.
+            - "--trust-proxy"
           ports:
             - containerPort: 8000
           env:

--- a/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
@@ -14,11 +14,14 @@ images:
   # avoids an ErrImagePull ReplicaSet while api iterates independently.
   - name: ghcr.io/vivarium-collective/sms-ptools
     newTag: 0.5.9
-  # vivarium-workbench: published by cutting a GitHub Release in the workbench
-  # repo (build-and-push.yml → ghcr:<version>); pin that release tag here.
-  # 0.1.1 = first image with the pbg-ptools viewer plugin + decoupled v2ecoli.
+  # vivarium-workbench: normally published by cutting a GitHub Release in the
+  # workbench repo (build-and-push.yml → ghcr:<version>); pin that release tag
+  # here. 481b3f2 is an off-cycle git-sha build (workflow_dispatch against
+  # demo-v2ecoli) carrying the CSRF/reverse-proxy fix and the composite-resolve
+  # error logging/degrade fix, on top of the earlier e74b644 base-path fix
+  # (vivarium-workbench#465), ahead of the next semver release.
   - name: ghcr.io/vivarium-collective/vivarium-workbench
-    newTag: 0.1.1
+    newTag: 481b3f2
 
 replicas:
   - count: 1


### PR DESCRIPTION
## Summary
- Pins `vivarium-workbench` in the `sms-api-stanford-test` overlay from `e74b644` to `481b3f2`, an off-cycle image carrying two more dashboard fixes (CSRF/origin-guard reverse-proxy awareness, composite-resolve error logging/degrade) on top of the study-detail base-path fix already deployed. See [vivarium-workbench#465](https://github.com/vivarium-collective/vivarium-workbench/pull/465).
- Adds `--trust-proxy` to the workbench Deployment's container args (`kustomize/base/workbench/workbench.yaml`). This is required for the CSRF fix to take effect here — it's opt-in by design (avoids blindly trusting `X-Forwarded-Host` from a direct client), and this Deployment is only ever reached through the ALB, so it's safe to enable.

## Test plan
- [ ] `kubectl apply -k kustomize/overlays/sms-api-stanford-test` in `sms-api-stanford-test`, confirm `deployment/workbench` rolls out `481b3f2` and goes Ready
- [ ] Through the `smsvpctest` ALB tunnel: Run button no longer 403s; Composite Explorer's colony composite either resolves or shows a diagnostic `notice` instead of a bare 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)