### PR TITLE
feat(db): self-diagnosing Alembic reconciliation for customer-controlled deploys

### DIFF
--- a/kustomize/overlays/sms-api-stanford-test-db-migration/alembic-job.yaml
+++ b/kustomize/overlays/sms-api-stanford-test-db-migration/alembic-job.yaml
@@ -10,7 +10,13 @@ spec:
         - name: alembic
           image: ghcr.io/vivarium-collective/sms-api:latest
           imagePullPolicy: Always
-          command: ["uv", "run", "alembic", "upgrade", "head"]
+          # Self-diagnosing reconciler (not bare `alembic upgrade head`): adopts
+          # legacy create_all-bootstrapped databases (stamp matched rev -> upgrade),
+          # upgrades already-managed ones, builds fresh ones from base, and refuses
+          # loudly on an inconsistent schema. See sms_api/simulation/db_reconcile.py.
+          # Requires an image tag that contains the module (>= 0.9.19) — kept in
+          # sync with the `newTag` in this overlay's kustomization.yaml.
+          command: ["uv", "run", "python", "-m", "sms_api.simulation.db_reconcile", "--apply"]
           env:
             - name: SQLALCHEMY_DATABASE_URL
               valueFrom:

--- a/kustomize/overlays/sms-api-stanford-test-db-migration/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-test-db-migration/kustomization.yaml
@@ -5,7 +5,9 @@ namespace: sms-api-stanford-test
 
 images:
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.6.3
+    # Must contain sms_api/simulation/db_reconcile.py (the Job runs it). Keep in
+    # sync with the app overlay's sms-api tag; do not lower below 0.9.19.
+    newTag: 0.9.19
 
 resources:
   - alembic-job.yaml

--- a/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: sms-api-stanford-test
 
 images:
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.9.18
+    newTag: 0.9.19
   # ptools pinned to last-known-good tag — CI only builds sms-api, so there is
   # no newer sms-ptools:0.6.x image on ghcr.io.  0.5.9 is the tag the live Stanford
   # pod has been running successfully; keeping both namespaces pointing here

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sms_api"
-version = "0.9.18"
+version = "0.9.19"
 description = "This is the api server for Vivarium simulation services."
 authors = [{ name = "Alex Patrie", email = "alexanderpatrie@gmail.com" }, { name = "Jim Schaff", email = "jschaff@gmail.com" }]
 requires-python = ">=3.13,<3.14"

--- a/scripts/db_analyze.py
+++ b/scripts/db_analyze.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+"""Read-only: report the database's Alembic reconciliation state. Changes nothing.
+
+    uv run python scripts/db_analyze.py
+
+Connection: uses SQLALCHEMY_DATABASE_URL if set, else POSTGRES_HOST/PORT/USER/
+PASSWORD/DATABASE. In-cluster the same check is available as
+``uv run python -m sms_api.simulation.db_reconcile --analyze``.
+
+Exit code 0 = safe to reconcile; 2 = INCONSISTENT, manual reconciliation needed.
+"""
+
+from sms_api.simulation.db_reconcile import main
+
+if __name__ == "__main__":
+    raise SystemExit(main(["--analyze"]))

--- a/scripts/db_reconcile.py
+++ b/scripts/db_reconcile.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+"""Diagnose and reconcile the database's Alembic state (idempotent, mutating).
+
+    uv run python scripts/db_reconcile.py          # apply
+    uv run python scripts/db_analyze.py            # read-only preview first
+
+Handles every state on one code path: fresh installs (upgrade from base),
+already-managed databases (upgrade head, no-op if current), and legacy
+create_all-bootstrapped databases (stamp the matched revision, then upgrade).
+Refuses and prints manual instructions if the schema is inconsistent.
+
+Connection: uses SQLALCHEMY_DATABASE_URL if set, else POSTGRES_HOST/PORT/USER/
+PASSWORD/DATABASE. This is the same entrypoint the migration Job runs as
+``python -m sms_api.simulation.db_reconcile --apply``.
+"""
+
+from sms_api.simulation.db_reconcile import main
+
+if __name__ == "__main__":
+    raise SystemExit(main(["--apply"]))

--- a/sms_api/simulation/db_reconcile.py
+++ b/sms_api/simulation/db_reconcile.py
@@ -1,0 +1,355 @@
+"""Self-diagnosing Alembic reconciliation for customer-controlled deployments.
+
+Historically the app bootstrapped its schema with ``Base.metadata.create_all``
+at startup (see ``tables_orm.create_db``). ``create_all`` creates *missing*
+tables/types but never *alters* existing ones, and it never writes an
+``alembic_version`` row. Any environment where the app pod touches the database
+before the migration job therefore ends up in a state Alembic cannot manage:
+
+* tables exist, but ``alembic_version`` is absent, so ``alembic upgrade head``
+  runs from base and fails re-``CREATE``-ing tables that already exist; and
+* enums/columns added by later migrations may be missing (a frozen enum, a
+  never-dropped column), because ``create_all`` could not alter them.
+
+Because the final deployment is customer-controlled we cannot remotely curate
+each database. This module inspects *any* database state and does the correct,
+idempotent thing:
+
+======================  ===========================================  ==============================================
+State                   Signal                                       Action
+======================  ===========================================  ==============================================
+``FRESH``               no app tables, no ``alembic_version``         ``upgrade head`` (base creates everything)
+``MANAGED``             ``alembic_version`` present                  ``upgrade head`` (normal path, no-op if current)
+``LEGACY``              app tables exist, no ``alembic_version``      ``stamp <matched>`` then ``upgrade head``
+``INCONSISTENT``        fingerprints non-linear (a gap)              refuse; print manual instructions
+======================  ===========================================  ==============================================
+
+The ``LEGACY`` match is found by walking a small, ordered fingerprint table —
+one detectable schema marker per revision that predates Alembic adoption. That
+table is frozen at the head which existed when adoption was introduced: once a
+database is stamped it is ``alembic_version``-managed forever, so migrations
+added *after* adoption never need a new fingerprint.
+
+Wire the migration Job to ``python -m sms_api.simulation.db_reconcile --apply``
+(or ``scripts/db_reconcile.py``) so it is correct for fresh installs, our own
+drifted databases, and already-managed ones on a single code path. Run
+``--analyze`` (or ``scripts/db_analyze.py``) first for a read-only report.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import dataclasses
+import enum
+import os
+import sys
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncConnection, create_async_engine
+
+# Repo root = two levels up from sms_api/simulation/db_reconcile.py
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ALEMBIC_INI = REPO_ROOT / "alembic.ini"
+
+# Ordered markers, one per revision that predates Alembic adoption, used ONLY to
+# adopt un-stamped (create_all-bootstrapped) databases. Each entry is
+# ``(revision, human label, async predicate)``. FROZEN at the adoption-era head:
+# never add entries for migrations authored after adoption — those databases
+# already carry an ``alembic_version`` row and take the MANAGED path.
+
+
+async def _table_exists(conn: AsyncConnection, name: str) -> bool:
+    q = text("SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = :n)")
+    return bool((await conn.execute(q, {"n": name})).scalar())
+
+
+async def _column_exists(conn: AsyncConnection, table: str, column: str) -> bool:
+    q = text("SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = :t AND column_name = :c)")
+    return bool((await conn.execute(q, {"t": table, "c": column})).scalar())
+
+
+async def _enum_has_value(conn: AsyncConnection, enum_name: str, value: str) -> bool:
+    q = text(
+        "SELECT EXISTS (SELECT 1 FROM pg_type t JOIN pg_enum e ON e.enumtypid = t.oid "
+        "WHERE t.typname = :t AND e.enumlabel = :v)"
+    )
+    return bool((await conn.execute(q, {"t": enum_name, "v": value})).scalar())
+
+
+async def _marker_baseline(conn: AsyncConnection) -> bool:
+    return await _table_exists(conn, "simulation")
+
+
+async def _marker_hpcrun_k8s(conn: AsyncConnection) -> bool:
+    has_new = await _column_exists(conn, "hpcrun", "job_id_ext")
+    has_old = await _column_exists(conn, "hpcrun", "slurmjobid")
+    return has_new and not has_old
+
+
+async def _marker_jobstatus_cancelled(conn: AsyncConnection) -> bool:
+    return await _enum_has_value(conn, "jobstatusdb", "cancelled")
+
+
+# (revision, human-readable marker description, async predicate)
+LEGACY_FINGERPRINTS: list[tuple[str, str]] = [
+    ("fb7621a73e24", "baseline: table 'simulation' exists"),
+    ("0f991fad32ba", "hpcrun.job_id_ext present and hpcrun.slurmjobid dropped"),
+    ("a1c3e5f7b9d2", "enum jobstatusdb has value 'cancelled'"),
+]
+_LEGACY_PREDICATES = [_marker_baseline, _marker_hpcrun_k8s, _marker_jobstatus_cancelled]
+
+
+class DbState(enum.Enum):
+    FRESH = "fresh"
+    MANAGED = "managed"
+    LEGACY = "legacy"
+    INCONSISTENT = "inconsistent"
+
+
+@dataclasses.dataclass
+class Diagnosis:
+    """The result of inspecting a database against the migration history."""
+
+    state: DbState
+    head_revision: str | None
+    current_revision: str | None  # from alembic_version, when MANAGED
+    matched_revision: str | None  # stamp target, when LEGACY
+    markers: list[tuple[str, bool]]  # (label, present) for every legacy fingerprint
+    message: str
+
+    @property
+    def needs_stamp(self) -> bool:
+        return self.state is DbState.LEGACY
+
+    @property
+    def can_upgrade(self) -> bool:
+        return self.state in (DbState.FRESH, DbState.MANAGED, DbState.LEGACY)
+
+
+def classify(
+    *,
+    alembic_revision: str | None,
+    fingerprint: list[bool],
+    head_revision: str | None,
+    legacy_fingerprints: list[tuple[str, str]] = LEGACY_FINGERPRINTS,
+) -> Diagnosis:
+    """Pure state-machine over inspection facts (no database access — unit-tested).
+
+    ``fingerprint[i]`` is whether the marker for ``legacy_fingerprints[i]`` is
+    present. ``alembic_revision`` is the value in ``alembic_version`` (or None).
+    """
+    labels = [label for _, label in legacy_fingerprints]
+    revs = [rev for rev, _ in legacy_fingerprints]
+    markers = list(zip(labels, fingerprint, strict=True))
+
+    if alembic_revision is not None:
+        return Diagnosis(
+            state=DbState.MANAGED,
+            head_revision=head_revision,
+            current_revision=alembic_revision,
+            matched_revision=None,
+            markers=markers,
+            message=(
+                f"Database is Alembic-managed at revision {alembic_revision}. "
+                f"'upgrade head' will apply any pending migrations."
+            ),
+        )
+
+    # No alembic_version row. With no markers at all the database is empty —
+    # let 'upgrade head' build everything from base.
+    if not any(fingerprint):
+        return Diagnosis(
+            state=DbState.FRESH,
+            head_revision=head_revision,
+            current_revision=None,
+            matched_revision=None,
+            markers=markers,
+            message="No application tables and no alembic_version — fresh database. 'upgrade head' builds it from base.",
+        )
+
+    # Legacy (create_all-bootstrapped): walk the fingerprint. A valid legacy
+    # database has all-True markers followed by all-False; a True after a False
+    # is a non-linear gap (e.g. baseline table missing while a later marker is
+    # present) we refuse to guess about.
+    matched_idx = -1
+    seen_false = False
+    for i, present in enumerate(fingerprint):
+        if present:
+            if seen_false:
+                return Diagnosis(
+                    state=DbState.INCONSISTENT,
+                    head_revision=head_revision,
+                    current_revision=None,
+                    matched_revision=None,
+                    markers=markers,
+                    message=(
+                        f"Inconsistent schema: marker for {revs[i]} is present but an earlier marker is missing. "
+                        f"The database does not match any single revision; manual reconciliation required."
+                    ),
+                )
+            matched_idx = i
+        else:
+            seen_false = True
+
+    matched = revs[matched_idx]
+    return Diagnosis(
+        state=DbState.LEGACY,
+        head_revision=head_revision,
+        current_revision=None,
+        matched_revision=matched,
+        markers=markers,
+        message=(
+            f"Legacy create_all database (no alembic_version). Schema matches revision {matched}. "
+            f"Will 'stamp {matched}' then 'upgrade head'."
+        ),
+    )
+
+
+def _normalize_async_url(url: str) -> str:
+    """Ensure an asyncpg driver so the same URL works for the async engine and Alembic."""
+    if url.startswith("postgresql+asyncpg://"):
+        return url
+    for bare in ("postgresql://", "postgres://"):
+        if url.startswith(bare):
+            return "postgresql+asyncpg://" + url[len(bare) :]
+    return url
+
+
+def resolve_database_url() -> str:
+    """Resolve the connection URL, preferring SQLALCHEMY_DATABASE_URL, else POSTGRES_*.
+
+    Also writes the normalized URL back to ``SQLALCHEMY_DATABASE_URL`` so Alembic's
+    ``env.py`` (which reads that variable) uses the identical connection.
+    """
+    url = os.environ.get("SQLALCHEMY_DATABASE_URL")
+    if not url:
+        missing = [
+            name
+            for name in ("POSTGRES_HOST", "POSTGRES_PORT", "POSTGRES_USER", "POSTGRES_PASSWORD", "POSTGRES_DATABASE")
+            if not os.environ.get(name)
+        ]
+        if missing:
+            raise RuntimeError(
+                "No database connection configured. Set SQLALCHEMY_DATABASE_URL, or all of: "
+                + ", ".join(missing)
+            )
+        user = os.environ["POSTGRES_USER"]
+        password = os.environ["POSTGRES_PASSWORD"]
+        host = os.environ["POSTGRES_HOST"]
+        port = os.environ["POSTGRES_PORT"]
+        database = os.environ["POSTGRES_DATABASE"]
+        url = f"postgresql+asyncpg://{user}:{password}@{host}:{port}/{database}"
+    url = _normalize_async_url(url)
+    os.environ["SQLALCHEMY_DATABASE_URL"] = url
+    return url
+
+
+def _alembic_config(url: str) -> Config:
+    cfg = Config(str(ALEMBIC_INI))
+    cfg.set_main_option("sqlalchemy.url", url)
+    return cfg
+
+
+def _head_revision(cfg: Config) -> str | None:
+    return ScriptDirectory.from_config(cfg).get_current_head()
+
+
+async def _inspect(url: str, cfg: Config) -> Diagnosis:
+    engine = create_async_engine(url)
+    try:
+        async with engine.connect() as conn:
+            if await _table_exists(conn, "alembic_version"):
+                current = (await conn.execute(text("SELECT version_num FROM alembic_version LIMIT 1"))).scalar()
+                alembic_revision: str | None = str(current) if current is not None else None
+            else:
+                alembic_revision = None
+            fingerprint = [await predicate(conn) for predicate in _LEGACY_PREDICATES]
+    finally:
+        await engine.dispose()
+    return classify(alembic_revision=alembic_revision, fingerprint=fingerprint, head_revision=_head_revision(cfg))
+
+
+def diagnose(url: str, cfg: Config) -> Diagnosis:
+    """Inspect the database and return a Diagnosis (read-only)."""
+    return asyncio.run(_inspect(url, cfg))
+
+
+def render_report(diag: Diagnosis) -> str:
+    lines = [
+        "Database reconciliation report",
+        "------------------------------",
+        f"  state:            {diag.state.value}",
+        f"  head revision:    {diag.head_revision}",
+        f"  current revision: {diag.current_revision if diag.current_revision else '(none — no alembic_version)'}",
+    ]
+    if diag.matched_revision:
+        lines.append(f"  matched revision: {diag.matched_revision}  (stamp target)")
+    lines.append("  schema markers:")
+    for label, present in diag.markers:
+        lines.append(f"    [{'x' if present else ' '}] {label}")
+    lines.append("")
+    lines.append(diag.message)
+    return "\n".join(lines)
+
+
+def _manual_instructions(diag: Diagnosis) -> str:
+    return (
+        "\nManual reconciliation required — the tool made NO changes.\n"
+        "The schema does not correspond to a single known revision. Inspect it and, once you have\n"
+        "determined the revision it truly matches, adopt it explicitly:\n\n"
+        "    uv run alembic stamp <revision>   # the rev the schema matches; creates alembic_version\n"
+        "    uv run alembic upgrade head        # apply the remaining migrations\n\n"
+        f"Detected markers: {diag.markers}\n"
+    )
+
+
+def apply(url: str, cfg: Config, diag: Diagnosis) -> int:
+    """Perform the reconciliation implied by ``diag``. Idempotent. Returns an exit code."""
+    if diag.state is DbState.INCONSISTENT:
+        print(_manual_instructions(diag), file=sys.stderr)
+        return 2
+
+    if diag.state is DbState.LEGACY and diag.matched_revision is not None:
+        print(f"→ stamping database at {diag.matched_revision} (adopting create_all schema into Alembic)")
+        command.stamp(cfg, diag.matched_revision)
+
+    print("→ running 'alembic upgrade head'")
+    command.upgrade(cfg, "head")
+    print("✓ database reconciled and upgraded to head")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="db_reconcile",
+        description="Diagnose and (optionally) reconcile the database's Alembic state.",
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--analyze", action="store_true", help="Read-only: print the diagnosis and exit (default).")
+    group.add_argument("--apply", action="store_true", help="Stamp/upgrade the database as diagnosed (mutating).")
+    args = parser.parse_args(argv)
+
+    try:
+        url = resolve_database_url()
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    cfg = _alembic_config(url)
+    diag = diagnose(url, cfg)
+    print(render_report(diag))
+
+    if not args.apply:
+        # Read-only mode: signal INCONSISTENT via exit code so automation can gate.
+        return 2 if diag.state is DbState.INCONSISTENT else 0
+
+    print()
+    return apply(url, cfg, diag)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sms_api/simulation/db_reconcile.py
+++ b/sms_api/simulation/db_reconcile.py
@@ -46,11 +46,12 @@ import os
 import sys
 from pathlib import Path
 
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncConnection, create_async_engine
+
 from alembic import command
 from alembic.config import Config
 from alembic.script import ScriptDirectory
-from sqlalchemy import text
-from sqlalchemy.ext.asyncio import AsyncConnection, create_async_engine
 
 # Repo root = two levels up from sms_api/simulation/db_reconcile.py
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -169,7 +170,9 @@ def classify(
             current_revision=None,
             matched_revision=None,
             markers=markers,
-            message="No application tables and no alembic_version — fresh database. 'upgrade head' builds it from base.",
+            message=(
+                "No application tables and no alembic_version — fresh database. 'upgrade head' builds it from base."
+            ),
         )
 
     # Legacy (create_all-bootstrapped): walk the fingerprint. A valid legacy
@@ -235,8 +238,7 @@ def resolve_database_url() -> str:
         ]
         if missing:
             raise RuntimeError(
-                "No database connection configured. Set SQLALCHEMY_DATABASE_URL, or all of: "
-                + ", ".join(missing)
+                "No database connection configured. Set SQLALCHEMY_DATABASE_URL, or all of: " + ", ".join(missing)
             )
         user = os.environ["POSTGRES_USER"]
         password = os.environ["POSTGRES_PASSWORD"]

--- a/sms_api/version.py
+++ b/sms_api/version.py
@@ -50,4 +50,12 @@
 #          experiment_id (comma-separated) + tag (predefined bundle, e.g. cd1) query
 #          params (union, backwards-compatible), a GET /simulations/tags discovery
 #          endpoint, and the atlantis CLI --tag/--experiment-id + `simulation tags` (#163)
-__version__ = "0.9.18"
+# 0.9.19 — self-diagnosing DB reconciliation (sms_api/simulation/db_reconcile.py +
+#          scripts/db_analyze.py|db_reconcile.py): adopts legacy create_all-bootstrapped
+#          databases into Alembic (stamp matched rev -> upgrade head), upgrades managed
+#          ones, builds fresh ones from base, and refuses loudly on an inconsistent
+#          schema. The stanford-test alembic-migrate Job now runs the reconciler instead
+#          of bare `alembic upgrade head`, so migrations are safe on customer-controlled
+#          databases. Reconciling stanford-test also applies the missing 'cancelled'
+#          jobstatusdb enum value (a1c3e5f7b9d2, never stamped there under create_all).
+__version__ = "0.9.19"

--- a/tests/simulation/test_db_reconcile.py
+++ b/tests/simulation/test_db_reconcile.py
@@ -1,0 +1,80 @@
+"""Unit tests for the pure classification logic in db_reconcile.
+
+These cover the state machine without touching a database. End-to-end
+stamp/upgrade behavior is exercised against a real Postgres by the migration
+Job in deployment; here we lock down the decision logic that drives it.
+"""
+
+from sms_api.simulation.db_reconcile import DbState, classify
+
+HEAD = "a1c3e5f7b9d2"
+# Mirrors LEGACY_FINGERPRINTS ordering: baseline -> hpcrun-k8s -> cancelled-enum.
+REVS = ["fb7621a73e24", "0f991fad32ba", "a1c3e5f7b9d2"]
+
+
+def test_managed_database_takes_upgrade_path() -> None:
+    diag = classify(alembic_revision="0f991fad32ba", fingerprint=[True, True, False], head_revision=HEAD)
+    assert diag.state is DbState.MANAGED
+    assert diag.current_revision == "0f991fad32ba"
+    assert diag.matched_revision is None
+    assert diag.needs_stamp is False
+    assert diag.can_upgrade is True
+
+
+def test_managed_takes_precedence_even_with_odd_fingerprint() -> None:
+    # If alembic_version exists, we trust it regardless of fingerprint probes.
+    diag = classify(alembic_revision=HEAD, fingerprint=[False, False, False], head_revision=HEAD)
+    assert diag.state is DbState.MANAGED
+
+
+def test_fresh_database_when_no_tables_and_no_version() -> None:
+    diag = classify(alembic_revision=None, fingerprint=[False, False, False], head_revision=HEAD)
+    assert diag.state is DbState.FRESH
+    assert diag.matched_revision is None
+    assert diag.needs_stamp is False
+    assert diag.can_upgrade is True
+
+
+def test_legacy_matches_baseline_only() -> None:
+    diag = classify(alembic_revision=None, fingerprint=[True, False, False], head_revision=HEAD)
+    assert diag.state is DbState.LEGACY
+    assert diag.matched_revision == "fb7621a73e24"
+    assert diag.needs_stamp is True
+
+
+def test_legacy_matches_middle_revision() -> None:
+    # The real stanford-test state: baseline + hpcrun-k8s, but enum missing 'cancelled'.
+    diag = classify(alembic_revision=None, fingerprint=[True, True, False], head_revision=HEAD)
+    assert diag.state is DbState.LEGACY
+    assert diag.matched_revision == "0f991fad32ba"
+    assert diag.needs_stamp is True
+
+
+def test_legacy_matches_head_when_all_markers_present() -> None:
+    diag = classify(alembic_revision=None, fingerprint=[True, True, True], head_revision=HEAD)
+    assert diag.state is DbState.LEGACY
+    assert diag.matched_revision == "a1c3e5f7b9d2"
+
+
+def test_inconsistent_when_later_marker_present_but_earlier_missing() -> None:
+    # A gap (True after False) means the schema matches no single revision.
+    diag = classify(alembic_revision=None, fingerprint=[True, False, True], head_revision=HEAD)
+    assert diag.state is DbState.INCONSISTENT
+    assert diag.matched_revision is None
+    assert diag.can_upgrade is False
+
+
+def test_inconsistent_when_baseline_missing_but_later_present() -> None:
+    # baseline table absent while later markers (also created by baseline) are
+    # present is impossible for a clean create_all DB => a gap => inconsistent.
+    diag = classify(alembic_revision=None, fingerprint=[False, True, True], head_revision=HEAD)
+    assert diag.state is DbState.INCONSISTENT
+    assert diag.can_upgrade is False
+
+
+def test_markers_are_reported_with_labels() -> None:
+    diag = classify(alembic_revision=None, fingerprint=[True, True, False], head_revision=HEAD)
+    labels = [label for label, _ in diag.markers]
+    presence = [present for _, present in diag.markers]
+    assert presence == [True, True, False]
+    assert any("simulation" in label for label in labels)

--- a/uv.lock
+++ b/uv.lock
@@ -3075,7 +3075,7 @@ wheels = [
 
 [[package]]
 name = "sms-api"
-version = "0.9.18"
+version = "0.9.19"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
## Why

The app bootstraps its schema with `Base.metadata.create_all` (`tables_orm.create_db`, called at startup). `create_all` creates *missing* objects but never **alters** existing ones and never writes an `alembic_version` row. So any environment where the app pod touches the DB before the migration Job ends up in a state Alembic can't manage:

- tables exist but `alembic_version` is absent → `alembic upgrade head` runs from base and **fails** re-`CREATE`-ing existing tables;
- enums/columns added by later migrations may be missing (a frozen enum, a never-dropped column).

Because the **final deployment is customer-controlled**, we can't remotely curate each database. This PR makes the migration path self-diagnosing so it's correct on any DB state, on one code path.

## What

`sms_api/simulation/db_reconcile.py` (+ thin `scripts/db_analyze.py` read-only and `scripts/db_reconcile.py` apply wrappers) inspects the DB and does the idempotent right thing:

| State | Signal | Action |
|---|---|---|
| **FRESH** | no app tables, no `alembic_version` | `upgrade head` (build from base) |
| **MANAGED** | `alembic_version` present | `upgrade head` (no-op if current) |
| **LEGACY** | app tables exist, no `alembic_version` | `stamp <matched>` → `upgrade head` |
| **INCONSISTENT** | non-linear fingerprint (a gap) | refuse; print manual steps |

The **LEGACY** match walks a small, **frozen** fingerprint table — one detectable schema marker per pre-adoption revision:

```
fb7621a73e24 : table 'simulation' exists
0f991fad32ba : hpcrun.job_id_ext present AND hpcrun.slurmjobid dropped
a1c3e5f7b9d2 : 'cancelled' in enum jobstatusdb
```

Once a DB is stamped it's `alembic_version`-managed forever, so migrations authored *after* adoption never need a new fingerprint — the table stays frozen at today's head.

The stanford-test `alembic-migrate` Job now runs `python -m sms_api.simulation.db_reconcile --apply` instead of bare `alembic upgrade head`.

## Verified against live stanford-test RDS (read-only)

`alembic_version` is **absent** and the schema matches `0f991fad32ba` (baseline + hpcrun-k8s) but the `jobstatusdb` enum is **missing `cancelled`** (`a1c3e5f7b9d2` was never applied under `create_all`). The reconciler diagnoses this as `LEGACY → stamp 0f991fad32ba → upgrade head`, which also **fixes that latent enum gap** (any `cancel_simulation` write would currently hit an enum error on stanford-test).

Report the tool produces for that exact state:
```
state:            legacy
head revision:    a1c3e5f7b9d2
current revision: (none — no alembic_version)
matched revision: 0f991fad32ba  (stamp target)
schema markers:
  [x] baseline: table 'simulation' exists
  [x] hpcrun.job_id_ext present and hpcrun.slurmjobid dropped
  [ ] enum jobstatusdb has value 'cancelled'
```

## Scope / notes

- **stanford-test only**: bumps the app + db-migration overlays to **0.9.19** (Job command + tag together, since the Job image must contain the module). The other `*-db-migration` overlays keep their old tag+command until their own deploys adopt the reconciler — they're already on independent cadences (stanford 0.7.2, rke 0.9.4, rke-dev 0.9.1). Follow-up: the version-sync checklist in CLAUDE.md omits the migration overlays, which is why they drift.
- **No new migration/column** in this PR, so the 0.9.19 app is schema-compatible with any current DB — safe to roll before/after the Job.
- `create_all` stays for the SQLite/testcontainer fixtures (migrations use PG-only ops). Whether to guard the startup `create_db` behind an env flag in prod is a fast-follow.
- Pure `classify()` state machine is unit-tested (9 cases). End-to-end stamp/upgrade runs against real Postgres via the Job at deploy.
- `make check` green (lock, pre-commit, mypy 185 files, deptry).

## Deploy runbook (after merge → build 0.9.19)
```
# migration FIRST (Jobs are immutable — clear the old one)
kubectl delete job alembic-migrate -n sms-api-stanford-test --ignore-not-found
kubectl apply -k kustomize/overlays/sms-api-stanford-test-db-migration
kubectl wait --for=condition=complete job/alembic-migrate -n sms-api-stanford-test --timeout=300s
kubectl logs -n sms-api-stanford-test job/alembic-migrate   # expect: stamp 0f991fad32ba + upgrade a1c3e5f7b9d2

# then roll the app
kubectl apply -k kustomize/overlays/sms-api-stanford-test
kubectl rollout status deployment/api -n sms-api-stanford-test
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
