### PR TITLE
feat(analysis): analysis-result read endpoints (list + fetch-by-id) + backfill [0.9.21]

### DIFF
--- a/alembic/versions/d3f9a1c72b84_add_analysis_query_columns.py
+++ b/alembic/versions/d3f9a1c72b84_add_analysis_query_columns.py
@@ -1,0 +1,70 @@
+"""add query/result columns to analysis
+
+Revision ID: d3f9a1c72b84
+Revises: c1a2b3d4e5f6
+Create Date: 2026-07-14
+
+Generalizes the ``analysis`` table for the analysis-result endpoints
+(analysis-results-design.md): adds nullable, indexed query columns
+(experiment_id, n_tp, simulation_id) plus status/result/audit columns. The
+existing ``config`` JSONB remains the authoritative store; legacy rows keep the
+new columns NULL. Introduces the ``analysisstatusdb`` enum (labels match the
+ORM member names).
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d3f9a1c72b84"
+down_revision: str | Sequence[str] | None = "c1a2b3d4e5f6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Enum labels match the AnalysisStatusDB member names (create_all uses member names).
+_analysis_status = postgresql.ENUM("COMPUTING", "READY", "FAILED", name="analysisstatusdb")
+
+
+def upgrade() -> None:
+    _analysis_status.create(op.get_bind(), checkfirst=True)
+    op.add_column("analysis", sa.Column("experiment_id", sa.String(), nullable=True))
+    op.add_column("analysis", sa.Column("n_tp", sa.Integer(), nullable=True))
+    op.add_column("analysis", sa.Column("status", _analysis_status, nullable=True))
+    op.add_column("analysis", sa.Column("result_uri", sa.String(), nullable=True))
+    op.add_column("analysis", sa.Column("backend", sa.String(), nullable=True, server_default="batch"))
+    op.add_column("analysis", sa.Column("simulation_id", sa.Integer(), nullable=True))
+    op.add_column("analysis", sa.Column("job_id_ext", sa.String(), nullable=True))
+    op.add_column("analysis", sa.Column("error_message", sa.String(), nullable=True))
+    op.add_column("analysis", sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=True))
+    op.add_column("analysis", sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=True))
+    op.create_foreign_key(
+        "fk_analysis_simulation_id", "analysis", "simulation", ["simulation_id"], ["id"]
+    )
+    op.create_index("ix_analysis_experiment_id", "analysis", ["experiment_id"])
+    op.create_index("ix_analysis_n_tp", "analysis", ["n_tp"])
+    op.create_index("ix_analysis_simulation_id", "analysis", ["simulation_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_analysis_simulation_id", table_name="analysis")
+    op.drop_index("ix_analysis_n_tp", table_name="analysis")
+    op.drop_index("ix_analysis_experiment_id", table_name="analysis")
+    op.drop_constraint("fk_analysis_simulation_id", "analysis", type_="foreignkey")
+    for col in (
+        "updated_at",
+        "created_at",
+        "error_message",
+        "job_id_ext",
+        "simulation_id",
+        "backend",
+        "result_uri",
+        "status",
+        "n_tp",
+        "experiment_id",
+    ):
+        op.drop_column("analysis", col)
+    _analysis_status.drop(op.get_bind(), checkfirst=True)

--- a/alembic/versions/d3f9a1c72b84_add_analysis_query_columns.py
+++ b/alembic/versions/d3f9a1c72b84_add_analysis_query_columns.py
@@ -41,9 +41,7 @@ def upgrade() -> None:
     op.add_column("analysis", sa.Column("error_message", sa.String(), nullable=True))
     op.add_column("analysis", sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=True))
     op.add_column("analysis", sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=True))
-    op.create_foreign_key(
-        "fk_analysis_simulation_id", "analysis", "simulation", ["simulation_id"], ["id"]
-    )
+    op.create_foreign_key("fk_analysis_simulation_id", "analysis", "simulation", ["simulation_id"], ["id"])
     op.create_index("ix_analysis_experiment_id", "analysis", ["experiment_id"])
     op.create_index("ix_analysis_n_tp", "analysis", ["n_tp"])
     op.create_index("ix_analysis_simulation_id", "analysis", ["simulation_id"])

--- a/kustomize/overlays/sms-api-stanford-db-migration/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-db-migration/kustomization.yaml
@@ -7,7 +7,7 @@ images:
   - name: ghcr.io/vivarium-collective/sms-api
     # Must contain sms_api/simulation/db_reconcile.py (the Job runs it). Keep in
     # sync with the app overlay's sms-api tag; do not lower below 0.9.19.
-    newTag: 0.9.20
+    newTag: 0.9.21
 
 resources:
   - alembic-job.yaml

--- a/kustomize/overlays/sms-api-stanford-test-db-migration/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-test-db-migration/kustomization.yaml
@@ -7,7 +7,7 @@ images:
   - name: ghcr.io/vivarium-collective/sms-api
     # Must contain sms_api/simulation/db_reconcile.py (the Job runs it). Keep in
     # sync with the app overlay's sms-api tag; do not lower below 0.9.19.
-    newTag: 0.9.20
+    newTag: 0.9.21
 
 resources:
   - alembic-job.yaml

--- a/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: sms-api-stanford-test
 
 images:
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.9.20
+    newTag: 0.9.21
   # ptools pinned to last-known-good tag — CI only builds sms-api, so there is
   # no newer sms-ptools:0.6.x image on ghcr.io.  0.5.9 is the tag the live Stanford
   # pod has been running successfully; keeping both namespaces pointing here

--- a/kustomize/overlays/sms-api-stanford/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: sms-api-stanford
 
 images:
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.9.20
+    newTag: 0.9.21
   # ptools pinned to last-known-good tag — CI only builds sms-api, so there is
   # no newer sms-ptools:0.6.x image on ghcr.io.  0.5.9 is the tag the live Stanford
   # pod has been running successfully; keeping both namespaces pointing here

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sms_api"
-version = "0.9.20"
+version = "0.9.21"
 description = "This is the api server for Vivarium simulation services."
 authors = [{ name = "Alex Patrie", email = "alexanderpatrie@gmail.com" }, { name = "Jim Schaff", email = "jschaff@gmail.com" }]
 requires-python = ">=3.13,<3.14"

--- a/scripts/backfill_analysis_results.py
+++ b/scripts/backfill_analysis_results.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+"""Backfill `analysis` rows for existing S3 analysis result sets.
+
+For each experiment under the output prefix that has an ``analyses/`` directory
+with output files, records a READY `analysis` row pointing at it (``result_uri``),
+so the analysis-results endpoints can list and serve pre-run results (see
+docs/source/architecture/analysis-results-design.md).
+
+Handles both S3 nestings (single ``{prefix}/{exp}/analyses`` and double
+``{prefix}/{exp}/{exp}/analyses``). ``n_tp`` is inferred from a representative TSV
+(count of ``t*`` header columns) and left NULL when not time-sampled (e.g. the
+cd1_* demo data). Idempotent: skips an experiment that already has a row with the
+same ``result_uri``.
+
+Connection: SQLALCHEMY_DATABASE_URL or POSTGRES_* (same as db_reconcile). S3:
+the app's storage settings (IAM role / env creds). Read-only against S3; only
+writes `analysis` rows. Pass --dry-run to log without writing.
+
+    uv run python scripts/backfill_analysis_results.py [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+import aioboto3
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from sms_api.analysis.models import infer_n_tp_from_tsv
+from sms_api.config import get_settings
+from sms_api.simulation.database_service import DatabaseServiceSQL
+from sms_api.simulation.db_reconcile import resolve_database_url
+from sms_api.simulation.tables_orm import AnalysisStatusDB
+
+_OUTPUT_EXTENSIONS = (".tsv", ".csv", ".txt", ".html")
+
+
+async def _analyses_prefix_with_files(client, bucket: str, prefix: str, exp: str) -> str | None:  # type: ignore[no-untyped-def]
+    """Return the bucket-relative analyses prefix (single- or double-nested) that has output files."""
+    base = prefix.rstrip("/")
+    for candidate in (f"{base}/{exp}/{exp}/analyses", f"{base}/{exp}/analyses"):
+        resp = await client.list_objects_v2(Bucket=bucket, Prefix=candidate + "/", MaxKeys=200)
+        for obj in resp.get("Contents", []):
+            if obj["Key"].lower().endswith(_OUTPUT_EXTENSIONS):
+                return candidate
+    return None
+
+
+async def _infer_n_tp(client, bucket: str, analyses_prefix: str) -> int | None:  # type: ignore[no-untyped-def]
+    """Best-effort n_tp from the first .tsv under the prefix (None if not time-sampled)."""
+    paginator = client.get_paginator("list_objects_v2")
+    async for page in paginator.paginate(Bucket=bucket, Prefix=analyses_prefix + "/"):
+        for obj in page.get("Contents", []):
+            if obj["Key"].lower().endswith(".tsv"):
+                body = await (await client.get_object(Bucket=bucket, Key=obj["Key"]))["Body"].read()
+                n_tp = infer_n_tp_from_tsv(body.decode(errors="replace"))
+                return n_tp or None
+    return None
+
+
+async def backfill(dry_run: bool) -> int:
+    settings = get_settings()
+    bucket, prefix, region = settings.s3_work_bucket, settings.s3_output_prefix, settings.storage_s3_region
+    engine = create_async_engine(resolve_database_url())
+    db = DatabaseServiceSQL(async_engine=engine)
+    recorded = 0
+    try:
+        session = aioboto3.Session(region_name=region)
+        async with session.client("s3") as client:
+            resp = await client.list_objects_v2(Bucket=bucket, Prefix=prefix.rstrip("/") + "/", Delimiter="/")
+            experiments = [cp["Prefix"].rstrip("/").split("/")[-1] for cp in resp.get("CommonPrefixes", [])]
+            print(f"scanning {len(experiments)} experiment dirs under {bucket}/{prefix}")
+            for exp in experiments:
+                analyses_prefix = await _analyses_prefix_with_files(client, bucket, prefix, exp)
+                if analyses_prefix is None:
+                    continue
+                existing = await db.list_analyses(experiment_id=exp)
+                if any(a.result_uri == analyses_prefix for a in existing):
+                    print(f"  {exp}: already recorded, skipping")
+                    continue
+                n_tp = await _infer_n_tp(client, bucket, analyses_prefix)
+                sim = await db.get_simulation_by_experiment_id(exp)
+                sim_id = sim.database_id if sim is not None else None
+                print(f"  {exp}: record READY n_tp={n_tp} sim_id={sim_id} result_uri={analyses_prefix}")
+                if not dry_run:
+                    await db.record_analysis(
+                        experiment_id=exp,
+                        n_tp=n_tp,
+                        status=AnalysisStatusDB.READY,
+                        config={"analysis_options": {"experiment_id": [exp]}},
+                        name=f"backfill-{exp}"[:200],
+                        simulation_id=sim_id,
+                        backend="batch",
+                        result_uri=analyses_prefix,
+                    )
+                recorded += 1
+    finally:
+        await engine.dispose()
+    print(f"{'(dry-run) would record' if dry_run else 'recorded'} {recorded} analysis rows")
+    return recorded
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Backfill analysis rows for existing S3 result sets.")
+    parser.add_argument("--dry-run", action="store_true", help="Log what would be recorded without writing.")
+    args = parser.parse_args()
+    asyncio.run(backfill(dry_run=args.dry_run))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sms_api/analysis/analysis_service.py
+++ b/sms_api/analysis/analysis_service.py
@@ -10,8 +10,6 @@ from pathlib import Path
 from textwrap import dedent
 from typing import Any
 
-import pandas as pd
-
 from sms_api.analysis.models import (
     AnalysisConfig,
     AnalysisJobFailedException,
@@ -19,6 +17,7 @@ from sms_api.analysis.models import (
     ExperimentAnalysisDTO,
     ExperimentAnalysisRequest,
     TsvOutputFile,
+    infer_n_tp_from_tsv,
 )
 from sms_api.common.hpc.slurm_service import SlurmService
 from sms_api.common.models import JobStatus, SSHTarget
@@ -265,9 +264,7 @@ class AnalysisServiceSlurm:
 
     @classmethod
     def _verify_result(cls, local_result_path: Path, expected_n_tp: int) -> bool:
-        tsv_data = pd.read_csv(local_result_path, sep="\t")
-        actual_cols = [col for col in tsv_data.columns if col.startswith("t")]
-        return len(actual_cols) == expected_n_tp
+        return infer_n_tp_from_tsv(local_result_path.read_text()) == expected_n_tp
 
     def _generate_slurm_script(
         self,

--- a/sms_api/analysis/models.py
+++ b/sms_api/analysis/models.py
@@ -11,6 +11,21 @@ from sms_api.config import Settings, get_settings
 
 MAX_ANALYSIS_CPUS = 3
 
+# Predetermined samplings offered by the analysis-results endpoints (see
+# analysis-results-design.md). POST only accepts an n_tp from this set.
+AVAILABLE_NTP: list[int] = [10, 50, 100]
+
+
+def infer_n_tp_from_tsv(tsv_text: str) -> int:
+    """Infer ``n_tp`` (number of timepoint columns) from a ptools analysis TSV.
+
+    Mirrors ``AnalysisServiceSlurm._verify_result``: ``n_tp`` is the count of
+    header columns whose name starts with ``"t"``. Reads only the header line, so
+    it is cheap and has no heavy dependencies.
+    """
+    header = tsv_text.split("\n", 1)[0]
+    return sum(1 for col in header.split("\t") if col.startswith("t"))
+
 
 ### -- analyses -- ###
 
@@ -270,6 +285,14 @@ class ExperimentAnalysisDTO(BaseModel):
     last_updated: str
     job_name: str | None = None
     job_id: int | None = None
+    # --- query/result fields (populated for the Batch/S3 analysis-result flow) ---
+    experiment_id: str | None = None
+    n_tp: int | None = None
+    status: JobStatus | None = None
+    result_uri: str | None = None
+    simulation_id: int | None = None
+    backend: str | None = None
+    error_message: str | None = None
 
 
 class AnalysisRun(BaseModel):

--- a/sms_api/api/client/api/analyses/get_analysis_data.py
+++ b/sms_api/api/client/api/analyses/get_analysis_data.py
@@ -1,0 +1,180 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.tsv_output_file import TsvOutputFile
+from ...types import Response
+
+
+def _get_kwargs(
+    id: int,
+) -> dict[str, Any]:
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": f"/api/v1/analyses/{id}/data",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[HTTPValidationError, list["TsvOutputFile"]]]:
+    if response.status_code == 200:
+        response_200 = []
+        _response_200 = response.json()
+        for response_200_item_data in _response_200:
+            response_200_item = TsvOutputFile.from_dict(response_200_item_data)
+
+            response_200.append(response_200_item)
+
+        return response_200
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[HTTPValidationError, list["TsvOutputFile"]]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[Union[HTTPValidationError, list["TsvOutputFile"]]]:
+    """Retrieve the output files (TSV/CSV/TXT/HTML) of an existing analysis by id
+
+     Pure retrieval of a pre-computed analysis's files by id (never computes).
+
+    Returns the same ``list[TsvOutputFile]`` shape as the legacy ``POST /analyses``.
+    409 if the analysis is not READY; 404 if the analysis id is unknown.
+
+    Args:
+        id (int): Database ID of the analysis
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[HTTPValidationError, list['TsvOutputFile']]]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[Union[HTTPValidationError, list["TsvOutputFile"]]]:
+    """Retrieve the output files (TSV/CSV/TXT/HTML) of an existing analysis by id
+
+     Pure retrieval of a pre-computed analysis's files by id (never computes).
+
+    Returns the same ``list[TsvOutputFile]`` shape as the legacy ``POST /analyses``.
+    409 if the analysis is not READY; 404 if the analysis id is unknown.
+
+    Args:
+        id (int): Database ID of the analysis
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[HTTPValidationError, list['TsvOutputFile']]
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[Union[HTTPValidationError, list["TsvOutputFile"]]]:
+    """Retrieve the output files (TSV/CSV/TXT/HTML) of an existing analysis by id
+
+     Pure retrieval of a pre-computed analysis's files by id (never computes).
+
+    Returns the same ``list[TsvOutputFile]`` shape as the legacy ``POST /analyses``.
+    409 if the analysis is not READY; 404 if the analysis id is unknown.
+
+    Args:
+        id (int): Database ID of the analysis
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[HTTPValidationError, list['TsvOutputFile']]]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[Union[HTTPValidationError, list["TsvOutputFile"]]]:
+    """Retrieve the output files (TSV/CSV/TXT/HTML) of an existing analysis by id
+
+     Pure retrieval of a pre-computed analysis's files by id (never computes).
+
+    Returns the same ``list[TsvOutputFile]`` shape as the legacy ``POST /analyses``.
+    409 if the analysis is not READY; 404 if the analysis id is unknown.
+
+    Args:
+        id (int): Database ID of the analysis
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[HTTPValidationError, list['TsvOutputFile']]
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+        )
+    ).parsed

--- a/sms_api/api/client/api/analyses/list_analyses.py
+++ b/sms_api/api/client/api/analyses/list_analyses.py
@@ -1,0 +1,193 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.experiment_analysis_dto import ExperimentAnalysisDTO
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    experiment_id: Union[None, Unset, str] = UNSET,
+    simulation_id: Union[None, Unset, int] = UNSET,
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
+
+    json_experiment_id: Union[None, Unset, str]
+    if isinstance(experiment_id, Unset):
+        json_experiment_id = UNSET
+    else:
+        json_experiment_id = experiment_id
+    params["experiment_id"] = json_experiment_id
+
+    json_simulation_id: Union[None, Unset, int]
+    if isinstance(simulation_id, Unset):
+        json_simulation_id = UNSET
+    else:
+        json_simulation_id = simulation_id
+    params["simulation_id"] = json_simulation_id
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/api/v1/analyses",
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[HTTPValidationError, list["ExperimentAnalysisDTO"]]]:
+    if response.status_code == 200:
+        response_200 = []
+        _response_200 = response.json()
+        for response_200_item_data in _response_200:
+            response_200_item = ExperimentAnalysisDTO.from_dict(response_200_item_data)
+
+            response_200.append(response_200_item)
+
+        return response_200
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[HTTPValidationError, list["ExperimentAnalysisDTO"]]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    experiment_id: Union[None, Unset, str] = UNSET,
+    simulation_id: Union[None, Unset, int] = UNSET,
+) -> Response[Union[HTTPValidationError, list["ExperimentAnalysisDTO"]]]:
+    """List all analyses across all simulations (exhaustive; filtering/paging to come)
+
+    Args:
+        experiment_id (Union[None, Unset, str]): Optional: filter by experiment_id.
+        simulation_id (Union[None, Unset, int]): Optional: filter by simulation database id.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[HTTPValidationError, list['ExperimentAnalysisDTO']]]
+    """
+
+    kwargs = _get_kwargs(
+        experiment_id=experiment_id,
+        simulation_id=simulation_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    experiment_id: Union[None, Unset, str] = UNSET,
+    simulation_id: Union[None, Unset, int] = UNSET,
+) -> Optional[Union[HTTPValidationError, list["ExperimentAnalysisDTO"]]]:
+    """List all analyses across all simulations (exhaustive; filtering/paging to come)
+
+    Args:
+        experiment_id (Union[None, Unset, str]): Optional: filter by experiment_id.
+        simulation_id (Union[None, Unset, int]): Optional: filter by simulation database id.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[HTTPValidationError, list['ExperimentAnalysisDTO']]
+    """
+
+    return sync_detailed(
+        client=client,
+        experiment_id=experiment_id,
+        simulation_id=simulation_id,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    experiment_id: Union[None, Unset, str] = UNSET,
+    simulation_id: Union[None, Unset, int] = UNSET,
+) -> Response[Union[HTTPValidationError, list["ExperimentAnalysisDTO"]]]:
+    """List all analyses across all simulations (exhaustive; filtering/paging to come)
+
+    Args:
+        experiment_id (Union[None, Unset, str]): Optional: filter by experiment_id.
+        simulation_id (Union[None, Unset, int]): Optional: filter by simulation database id.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[HTTPValidationError, list['ExperimentAnalysisDTO']]]
+    """
+
+    kwargs = _get_kwargs(
+        experiment_id=experiment_id,
+        simulation_id=simulation_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    experiment_id: Union[None, Unset, str] = UNSET,
+    simulation_id: Union[None, Unset, int] = UNSET,
+) -> Optional[Union[HTTPValidationError, list["ExperimentAnalysisDTO"]]]:
+    """List all analyses across all simulations (exhaustive; filtering/paging to come)
+
+    Args:
+        experiment_id (Union[None, Unset, str]): Optional: filter by experiment_id.
+        simulation_id (Union[None, Unset, int]): Optional: filter by simulation database id.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[HTTPValidationError, list['ExperimentAnalysisDTO']]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            experiment_id=experiment_id,
+            simulation_id=simulation_id,
+        )
+    ).parsed

--- a/sms_api/api/client/api/analyses/list_simulation_analyses.py
+++ b/sms_api/api/client/api/analyses/list_simulation_analyses.py
@@ -1,0 +1,160 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.experiment_analysis_dto import ExperimentAnalysisDTO
+from ...models.http_validation_error import HTTPValidationError
+from ...types import Response
+
+
+def _get_kwargs(
+    id: int,
+) -> dict[str, Any]:
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": f"/api/v1/simulations/{id}/analyses",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[HTTPValidationError, list["ExperimentAnalysisDTO"]]]:
+    if response.status_code == 200:
+        response_200 = []
+        _response_200 = response.json()
+        for response_200_item_data in _response_200:
+            response_200_item = ExperimentAnalysisDTO.from_dict(response_200_item_data)
+
+            response_200.append(response_200_item)
+
+        return response_200
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[HTTPValidationError, list["ExperimentAnalysisDTO"]]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[Union[HTTPValidationError, list["ExperimentAnalysisDTO"]]]:
+    """List the existing (pre-run) analyses for a simulation
+
+    Args:
+        id (int): Database ID of the simulation
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[HTTPValidationError, list['ExperimentAnalysisDTO']]]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[Union[HTTPValidationError, list["ExperimentAnalysisDTO"]]]:
+    """List the existing (pre-run) analyses for a simulation
+
+    Args:
+        id (int): Database ID of the simulation
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[HTTPValidationError, list['ExperimentAnalysisDTO']]
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[Union[HTTPValidationError, list["ExperimentAnalysisDTO"]]]:
+    """List the existing (pre-run) analyses for a simulation
+
+    Args:
+        id (int): Database ID of the simulation
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[HTTPValidationError, list['ExperimentAnalysisDTO']]]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[Union[HTTPValidationError, list["ExperimentAnalysisDTO"]]]:
+    """List the existing (pre-run) analyses for a simulation
+
+    Args:
+        id (int): Database ID of the simulation
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[HTTPValidationError, list['ExperimentAnalysisDTO']]
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+        )
+    ).parsed

--- a/sms_api/api/client/models/experiment_analysis_dto.py
+++ b/sms_api/api/client/models/experiment_analysis_dto.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..models.job_status import JobStatus
 from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
@@ -33,6 +34,13 @@ class ExperimentAnalysisDTO:
             last_updated (str):
             job_name (Union[None, Unset, str]):
             job_id (Union[None, Unset, int]):
+            experiment_id (Union[None, Unset, str]):
+            n_tp (Union[None, Unset, int]):
+            status (Union[JobStatus, None, Unset]):
+            result_uri (Union[None, Unset, str]):
+            simulation_id (Union[None, Unset, int]):
+            backend (Union[None, Unset, str]):
+            error_message (Union[None, Unset, str]):
     """
 
     database_id: int
@@ -41,6 +49,13 @@ class ExperimentAnalysisDTO:
     last_updated: str
     job_name: Union[None, Unset, str] = UNSET
     job_id: Union[None, Unset, int] = UNSET
+    experiment_id: Union[None, Unset, str] = UNSET
+    n_tp: Union[None, Unset, int] = UNSET
+    status: Union[JobStatus, None, Unset] = UNSET
+    result_uri: Union[None, Unset, str] = UNSET
+    simulation_id: Union[None, Unset, int] = UNSET
+    backend: Union[None, Unset, str] = UNSET
+    error_message: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -64,6 +79,50 @@ class ExperimentAnalysisDTO:
         else:
             job_id = self.job_id
 
+        experiment_id: Union[None, Unset, str]
+        if isinstance(self.experiment_id, Unset):
+            experiment_id = UNSET
+        else:
+            experiment_id = self.experiment_id
+
+        n_tp: Union[None, Unset, int]
+        if isinstance(self.n_tp, Unset):
+            n_tp = UNSET
+        else:
+            n_tp = self.n_tp
+
+        status: Union[None, Unset, str]
+        if isinstance(self.status, Unset):
+            status = UNSET
+        elif isinstance(self.status, JobStatus):
+            status = self.status.value
+        else:
+            status = self.status
+
+        result_uri: Union[None, Unset, str]
+        if isinstance(self.result_uri, Unset):
+            result_uri = UNSET
+        else:
+            result_uri = self.result_uri
+
+        simulation_id: Union[None, Unset, int]
+        if isinstance(self.simulation_id, Unset):
+            simulation_id = UNSET
+        else:
+            simulation_id = self.simulation_id
+
+        backend: Union[None, Unset, str]
+        if isinstance(self.backend, Unset):
+            backend = UNSET
+        else:
+            backend = self.backend
+
+        error_message: Union[None, Unset, str]
+        if isinstance(self.error_message, Unset):
+            error_message = UNSET
+        else:
+            error_message = self.error_message
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({
@@ -76,6 +135,20 @@ class ExperimentAnalysisDTO:
             field_dict["job_name"] = job_name
         if job_id is not UNSET:
             field_dict["job_id"] = job_id
+        if experiment_id is not UNSET:
+            field_dict["experiment_id"] = experiment_id
+        if n_tp is not UNSET:
+            field_dict["n_tp"] = n_tp
+        if status is not UNSET:
+            field_dict["status"] = status
+        if result_uri is not UNSET:
+            field_dict["result_uri"] = result_uri
+        if simulation_id is not UNSET:
+            field_dict["simulation_id"] = simulation_id
+        if backend is not UNSET:
+            field_dict["backend"] = backend
+        if error_message is not UNSET:
+            field_dict["error_message"] = error_message
 
         return field_dict
 
@@ -110,6 +183,77 @@ class ExperimentAnalysisDTO:
 
         job_id = _parse_job_id(d.pop("job_id", UNSET))
 
+        def _parse_experiment_id(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        experiment_id = _parse_experiment_id(d.pop("experiment_id", UNSET))
+
+        def _parse_n_tp(data: object) -> Union[None, Unset, int]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, int], data)
+
+        n_tp = _parse_n_tp(d.pop("n_tp", UNSET))
+
+        def _parse_status(data: object) -> Union[JobStatus, None, Unset]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                status_type_0 = JobStatus(data)
+
+                return status_type_0
+            except:  # noqa: E722
+                pass
+            return cast(Union[JobStatus, None, Unset], data)
+
+        status = _parse_status(d.pop("status", UNSET))
+
+        def _parse_result_uri(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        result_uri = _parse_result_uri(d.pop("result_uri", UNSET))
+
+        def _parse_simulation_id(data: object) -> Union[None, Unset, int]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, int], data)
+
+        simulation_id = _parse_simulation_id(d.pop("simulation_id", UNSET))
+
+        def _parse_backend(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        backend = _parse_backend(d.pop("backend", UNSET))
+
+        def _parse_error_message(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        error_message = _parse_error_message(d.pop("error_message", UNSET))
+
         experiment_analysis_dto = cls(
             database_id=database_id,
             name=name,
@@ -117,6 +261,13 @@ class ExperimentAnalysisDTO:
             last_updated=last_updated,
             job_name=job_name,
             job_id=job_id,
+            experiment_id=experiment_id,
+            n_tp=n_tp,
+            status=status,
+            result_uri=result_uri,
+            simulation_id=simulation_id,
+            backend=backend,
+            error_message=error_message,
         )
 
         experiment_analysis_dto.additional_properties = d

--- a/sms_api/api/routers/sms.py
+++ b/sms_api/api/routers/sms.py
@@ -436,6 +436,28 @@ async def run_simulation_analysis(
 
 
 @config.router.get(
+    path="/simulations/{id}/analyses",
+    operation_id="list-simulation-analyses",
+    tags=["Analyses"],
+    dependencies=[Depends(get_database_service)],
+    summary="List the existing (pre-run) analyses for a simulation",
+)
+async def list_simulation_analyses(
+    id: int = FastAPIPath(description="Database ID of the simulation"),
+) -> list[ExperimentAnalysisDTO]:
+    db_service = get_database_service()
+    if db_service is None:
+        raise HTTPException(status_code=500, detail="Database service is not initialized")
+    try:
+        return await handlers.analyses.list_simulation_analyses(db_service=db_service, simulation_id=id)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except Exception as e:
+        logger.exception("Error listing simulation analyses")
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@config.router.get(
     path="/simulations",
     operation_id="list-ecoli-simulations",
     tags=["Simulations"],
@@ -757,4 +779,33 @@ async def get_analysis_plots(
         return await handlers.analyses.handle_get_analysis_plots(db_service=db_service, id=id)
     except Exception as e:
         logger.exception("Error getting analysis data")
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@config.router.get(
+    path="/analyses/{id}/data",
+    tags=["Analyses"],
+    operation_id="get-analysis-data",
+    dependencies=[Depends(get_database_service)],
+    summary="Retrieve the output files (TSV/CSV/TXT/HTML) of an existing analysis by id",
+)
+async def get_analysis_data(
+    id: int = FastAPIPath(..., description="Database ID of the analysis"),
+) -> list[TsvOutputFile]:
+    """Pure retrieval of a pre-computed analysis's files by id (never computes).
+
+    Returns the same ``list[TsvOutputFile]`` shape as the legacy ``POST /analyses``.
+    409 if the analysis is not READY; 404 if the analysis id is unknown.
+    """
+    db_service = get_database_service()
+    if db_service is None:
+        raise HTTPException(status_code=404, detail="Database not found")
+    try:
+        return await handlers.analyses.fetch_analysis_data(db_service=db_service, analysis_id=id)
+    except handlers.analyses.AnalysisNotReadyError as e:
+        raise HTTPException(status_code=409, detail=str(e)) from e
+    except RuntimeError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except Exception as e:
+        logger.exception("Error retrieving analysis data")
         raise HTTPException(status_code=500, detail=str(e)) from e

--- a/sms_api/api/routers/sms.py
+++ b/sms_api/api/routers/sms.py
@@ -695,6 +695,27 @@ async def run_analysis(
 
 
 @config.router.get(
+    path="/analyses",
+    operation_id="list-analyses",
+    tags=["Analyses"],
+    dependencies=[Depends(get_database_service)],
+    summary="List all analyses across all simulations (exhaustive; filtering/paging to come)",
+)
+async def list_analyses(
+    experiment_id: str | None = Query(default=None, description="Optional: filter by experiment_id."),
+    simulation_id: int | None = Query(default=None, description="Optional: filter by simulation database id."),
+) -> list[ExperimentAnalysisDTO]:
+    db_service = get_database_service()
+    if db_service is None:
+        raise HTTPException(status_code=500, detail="Database service is not initialized")
+    try:
+        return await db_service.list_analyses(experiment_id=experiment_id, simulation_id=simulation_id)
+    except Exception as e:
+        logger.exception("Error listing analyses")
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@config.router.get(
     path="/analyses/{id}",
     operation_id="get-analysis",
     tags=["Analyses"],

--- a/sms_api/api/spec/openapi_3_1_0_generated.yaml
+++ b/sms_api/api/spec/openapi_3_1_0_generated.yaml
@@ -553,6 +553,37 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/simulations/{id}/analyses:
+    get:
+      tags:
+      - Analyses
+      summary: List the existing (pre-run) analyses for a simulation
+      operationId: list-simulation-analyses
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          description: Database ID of the simulation
+          title: Id
+        description: Database ID of the simulation
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ExperimentAnalysisDTO'
+                title: Response List-Simulation-Analyses
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v1/simulations/{id}/tags:
     post:
       tags:
@@ -758,12 +789,55 @@ paths:
           content:
             application/json:
               schema:
+                type: array
                 items:
                   anyOf:
                   - $ref: '#/components/schemas/TsvOutputFile'
                   - $ref: '#/components/schemas/OutputFileMetadata'
-                type: array
                 title: Response Run-Ecoli-Simulation-Analysis
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - Analyses
+      summary: List all analyses across all simulations (exhaustive; filtering/paging
+        to come)
+      operationId: list-analyses
+      parameters:
+      - name: experiment_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: 'Optional: filter by experiment_id.'
+          title: Experiment Id
+        description: 'Optional: filter by experiment_id.'
+      - name: simulation_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          description: 'Optional: filter by simulation database id.'
+          title: Simulation Id
+        description: 'Optional: filter by simulation database id.'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ExperimentAnalysisDTO'
+                title: Response List-Analyses
         '422':
           description: Validation Error
           content:
@@ -879,6 +953,45 @@ paths:
                 items:
                   $ref: '#/components/schemas/OutputFile'
                 title: Response Get-Analysis-Plots
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/analyses/{id}/data:
+    get:
+      tags:
+      - Analyses
+      summary: Retrieve the output files (TSV/CSV/TXT/HTML) of an existing analysis
+        by id
+      description: 'Pure retrieval of a pre-computed analysis''s files by id (never
+        computes).
+
+
+        Returns the same ``list[TsvOutputFile]`` shape as the legacy ``POST /analyses``.
+
+        409 if the analysis is not READY; 404 if the analysis id is unknown.'
+      operationId: get-analysis-data
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          description: Database ID of the analysis
+          title: Id
+        description: Database ID of the analysis
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TsvOutputFile'
+                title: Response Get-Analysis-Data
         '422':
           description: Validation Error
           content:
@@ -1008,7 +1121,7 @@ paths:
                   git_repo_url: https://github.com/CovertLabEcoli/vEcoli-private
                   git_branch: master
                   database_id: 25
-                  created_at: '2026-07-14T10:34:21.796114'
+                  created_at: '2026-07-14T16:12:39.019002'
                 parca_config:
                   outdir: /projects/SMS/sms_api/prod/sims
       responses:
@@ -2181,6 +2294,40 @@ components:
           - type: integer
           - type: 'null'
           title: Job Id
+        experiment_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Experiment Id
+        n_tp:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: N Tp
+        status:
+          anyOf:
+          - $ref: '#/components/schemas/JobStatus'
+          - type: 'null'
+        result_uri:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Result Uri
+        simulation_id:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Simulation Id
+        backend:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Backend
+        error_message:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Error Message
       type: object
       required:
       - database_id
@@ -2627,7 +2774,7 @@ components:
         last_updated:
           type: string
           title: Last Updated
-          default: '2026-07-14 10:34:21.082112'
+          default: '2026-07-14 16:12:38.947722'
         job_id:
           anyOf:
           - type: string

--- a/sms_api/common/handlers/analyses.py
+++ b/sms_api/common/handlers/analyses.py
@@ -13,7 +13,7 @@ from textwrap import dedent
 
 from starlette.requests import Request
 
-from sms_api.analysis.analysis_service import AnalysisServiceSlurm, RequestPayload
+from sms_api.analysis.analysis_service import AnalysisServiceSlurm, RequestPayload, parse_partition_metadata
 from sms_api.analysis.models import (
     AnalysisRun,
     ExperimentAnalysisDTO,
@@ -22,13 +22,66 @@ from sms_api.analysis.models import (
     OutputFileMetadata,
     TsvOutputFile,
 )
-from sms_api.common.models import SSHTarget
-from sms_api.common.storage.file_paths import HPCFilePath
+from sms_api.common.models import JobStatus, SSHTarget
+from sms_api.common.storage.file_paths import HPCFilePath, S3FilePath
 from sms_api.common.utils import get_data_id, timestamp
 from sms_api.config import get_settings
-from sms_api.dependencies import get_ssh_session_service
+from sms_api.dependencies import get_file_service, get_ssh_session_service
 from sms_api.simulation.database_service import DatabaseService
 from sms_api.simulation.models import SimulatorVersion
+
+# Text output extensions the analysis data endpoint returns (mirrors the legacy
+# SLURM path's get_available_output_paths).
+_ANALYSIS_OUTPUT_EXTENSIONS = (".tsv", ".csv", ".txt", ".html")
+
+
+class AnalysisNotReadyError(Exception):
+    """Raised when analysis data is requested but the result is not READY."""
+
+
+async def list_simulation_analyses(db_service: DatabaseService, simulation_id: int) -> list[ExperimentAnalysisDTO]:
+    """List existing analysis records for a simulation (by its experiment_id)."""
+    simulation = await db_service.get_simulation(simulation_id=simulation_id)
+    if simulation is None:
+        raise ValueError(f"Simulation {simulation_id} not found")
+    return await db_service.list_analyses(experiment_id=simulation.experiment_id)
+
+
+async def fetch_analysis_data(db_service: DatabaseService, analysis_id: int) -> list[TsvOutputFile]:
+    """Return all text output files of an existing analysis by id, as ``list[TsvOutputFile]``.
+
+    Pure retrieval: reads S3 under the analysis row's ``result_uri`` and inlines each
+    file's content with variant/lineage_seed/generation parsed from its partition
+    path — the same shape as the legacy ``POST /analyses``. Never computes: if the
+    analysis is not READY it raises ``AnalysisNotReadyError`` (mapped to 409).
+    """
+    analysis = await db_service.get_analysis(database_id=analysis_id)  # RuntimeError -> 404 at the router
+    if analysis.status != JobStatus.COMPLETED or not analysis.result_uri:
+        raise AnalysisNotReadyError(f"Analysis {analysis_id} is not ready (status={analysis.status})")
+
+    file_service = get_file_service()
+    if file_service is None:
+        raise RuntimeError("File service is not initialized")
+
+    listing = await file_service.get_listing(S3FilePath(s3_path=Path(analysis.result_uri)))
+    outputs: list[TsvOutputFile] = []
+    for item in listing:
+        if not item.Key.lower().endswith(_ANALYSIS_OUTPUT_EXTENSIONS):
+            continue
+        content = await file_service.get_file_contents(S3FilePath(s3_path=Path(item.Key)))
+        if content is None:
+            continue
+        metadata = parse_partition_metadata(Path(item.Key))
+        outputs.append(
+            TsvOutputFile(
+                filename=Path(item.Key).name,
+                content=content.decode(errors="replace"),
+                variant=metadata.get("variant", 0),
+                lineage_seed=metadata.get("lineage_seed"),
+                generation=metadata.get("generation"),
+            )
+        )
+    return outputs
 
 
 async def handle_run_analysis(

--- a/sms_api/simulation/database_service.py
+++ b/sms_api/simulation/database_service.py
@@ -2,7 +2,7 @@ import contextlib
 import datetime
 import logging
 from abc import ABC, abstractmethod
-from typing import override
+from typing import Any, override
 
 from sqlalchemy import ColumnElement, Result, and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
@@ -24,6 +24,7 @@ from sms_api.simulation.models import (
     WorkerEvent,
 )
 from sms_api.simulation.tables_orm import (
+    AnalysisStatusDB,
     JobStatusDB,
     JobTypeDB,
     ORMAnalysis,
@@ -51,8 +52,45 @@ class DatabaseService(ABC):
         pass
 
     @abstractmethod
-    async def list_analyses(self) -> list[ExperimentAnalysisDTO]:
-        """Used by the /ecoli router"""
+    async def list_analyses(
+        self, *, experiment_id: str | None = None, simulation_id: int | None = None
+    ) -> list[ExperimentAnalysisDTO]:
+        """List analyses, optionally filtered by experiment_id and/or simulation_id."""
+        pass
+
+    @abstractmethod
+    async def record_analysis(
+        self,
+        *,
+        experiment_id: str,
+        n_tp: int,
+        status: AnalysisStatusDB,
+        config: dict[str, Any],
+        name: str,
+        simulation_id: int | None = None,
+        backend: str = "batch",
+        job_name: str | None = None,
+        job_id_ext: str | None = None,
+        result_uri: str | None = None,
+        error_message: str | None = None,
+    ) -> ExperimentAnalysisDTO:
+        """Insert or update (by ``(experiment_id, n_tp)``) an analysis-result row and return it."""
+        pass
+
+    @abstractmethod
+    async def get_analysis_by_experiment_ntp(self, experiment_id: str, n_tp: int) -> ExperimentAnalysisDTO | None:
+        """Return the most recent analysis row for ``(experiment_id, n_tp)``, or None."""
+        pass
+
+    @abstractmethod
+    async def update_analysis_status(
+        self,
+        analysis_id: int,
+        status: AnalysisStatusDB,
+        result_uri: str | None = None,
+        error_message: str | None = None,
+    ) -> ExperimentAnalysisDTO:
+        """Update an analysis row's status (and optionally result_uri/error) by id."""
         pass
 
     ####################################
@@ -279,17 +317,110 @@ class DatabaseServiceSQL(DatabaseService):
             return orm_analysis.to_dto()
 
     @override
-    async def list_analyses(self) -> list[ExperimentAnalysisDTO]:
-        """Used by the /ecoli router"""
+    async def list_analyses(
+        self, *, experiment_id: str | None = None, simulation_id: int | None = None
+    ) -> list[ExperimentAnalysisDTO]:
         async with self.async_sessionmaker() as session:
+            clauses: list[ColumnElement[bool]] = []
+            if experiment_id is not None:
+                clauses.append(ORMAnalysis.experiment_id == experiment_id)
+            if simulation_id is not None:
+                clauses.append(ORMAnalysis.simulation_id == simulation_id)
             stmt = select(ORMAnalysis)
+            if clauses:
+                stmt = stmt.where(and_(*clauses))
+            stmt = stmt.order_by(ORMAnalysis.id)
             result: Result[tuple[ORMAnalysis]] = await session.execute(stmt)
-            orm_analyses = result.scalars().all()
+            return [orm_analysis.to_dto() for orm_analysis in result.scalars().all()]
 
-            versions: list[ExperimentAnalysisDTO] = []
-            for experiment in orm_analyses:
-                versions.append(experiment.to_dto())
-            return versions
+    @override
+    async def record_analysis(
+        self,
+        *,
+        experiment_id: str,
+        n_tp: int,
+        status: AnalysisStatusDB,
+        config: dict[str, Any],
+        name: str,
+        simulation_id: int | None = None,
+        backend: str = "batch",
+        job_name: str | None = None,
+        job_id_ext: str | None = None,
+        result_uri: str | None = None,
+        error_message: str | None = None,
+    ) -> ExperimentAnalysisDTO:
+        async with self.async_sessionmaker() as session, session.begin():
+            # Idempotency: update the existing row for (experiment_id, n_tp) if present.
+            stmt = (
+                select(ORMAnalysis)
+                .where(ORMAnalysis.experiment_id == experiment_id, ORMAnalysis.n_tp == n_tp)
+                .order_by(ORMAnalysis.id.desc())
+                .limit(1)
+            )
+            existing = (await session.execute(stmt)).scalars().first()
+            if existing is not None:
+                existing.status = status
+                existing.config = config
+                existing.name = name
+                existing.simulation_id = simulation_id
+                existing.backend = backend
+                existing.job_name = job_name
+                existing.job_id_ext = job_id_ext
+                existing.result_uri = result_uri
+                existing.error_message = error_message
+                existing.last_updated = str(datetime.datetime.now())
+                await session.flush()
+                return existing.to_dto()
+            orm_analysis = ORMAnalysis(
+                name=name,
+                config=config,
+                last_updated=str(datetime.datetime.now()),
+                experiment_id=experiment_id,
+                n_tp=n_tp,
+                status=status,
+                simulation_id=simulation_id,
+                backend=backend,
+                job_name=job_name,
+                job_id_ext=job_id_ext,
+                result_uri=result_uri,
+                error_message=error_message,
+            )
+            session.add(orm_analysis)
+            await session.flush()
+            return orm_analysis.to_dto()
+
+    @override
+    async def get_analysis_by_experiment_ntp(self, experiment_id: str, n_tp: int) -> ExperimentAnalysisDTO | None:
+        async with self.async_sessionmaker() as session:
+            stmt = (
+                select(ORMAnalysis)
+                .where(ORMAnalysis.experiment_id == experiment_id, ORMAnalysis.n_tp == n_tp)
+                .order_by(ORMAnalysis.id.desc())
+                .limit(1)
+            )
+            orm_analysis = (await session.execute(stmt)).scalars().first()
+            return orm_analysis.to_dto() if orm_analysis is not None else None
+
+    @override
+    async def update_analysis_status(
+        self,
+        analysis_id: int,
+        status: AnalysisStatusDB,
+        result_uri: str | None = None,
+        error_message: str | None = None,
+    ) -> ExperimentAnalysisDTO:
+        async with self.async_sessionmaker() as session, session.begin():
+            orm_analysis = await self._get_orm_analysis(session, database_id=analysis_id)
+            if orm_analysis is None:
+                raise RuntimeError(f"Analysis {analysis_id} not found")
+            orm_analysis.status = status
+            if result_uri is not None:
+                orm_analysis.result_uri = result_uri
+            if error_message is not None:
+                orm_analysis.error_message = error_message
+            orm_analysis.last_updated = str(datetime.datetime.now())
+            await session.flush()
+            return orm_analysis.to_dto()
 
     ##################################
 

--- a/sms_api/simulation/database_service.py
+++ b/sms_api/simulation/database_service.py
@@ -63,7 +63,7 @@ class DatabaseService(ABC):
         self,
         *,
         experiment_id: str,
-        n_tp: int,
+        n_tp: int | None,
         status: AnalysisStatusDB,
         config: dict[str, Any],
         name: str,
@@ -74,7 +74,7 @@ class DatabaseService(ABC):
         result_uri: str | None = None,
         error_message: str | None = None,
     ) -> ExperimentAnalysisDTO:
-        """Insert or update (by ``(experiment_id, n_tp)``) an analysis-result row and return it."""
+        """Insert an analysis-result row (dedup-updating an existing ``(experiment_id, n_tp)`` when n_tp is set)."""
         pass
 
     @abstractmethod
@@ -338,7 +338,7 @@ class DatabaseServiceSQL(DatabaseService):
         self,
         *,
         experiment_id: str,
-        n_tp: int,
+        n_tp: int | None,
         status: AnalysisStatusDB,
         config: dict[str, Any],
         name: str,
@@ -351,13 +351,17 @@ class DatabaseServiceSQL(DatabaseService):
     ) -> ExperimentAnalysisDTO:
         async with self.async_sessionmaker() as session, session.begin():
             # Idempotency: update the existing row for (experiment_id, n_tp) if present.
-            stmt = (
-                select(ORMAnalysis)
-                .where(ORMAnalysis.experiment_id == experiment_id, ORMAnalysis.n_tp == n_tp)
-                .order_by(ORMAnalysis.id.desc())
-                .limit(1)
-            )
-            existing = (await session.execute(stmt)).scalars().first()
+            # Only dedup when n_tp is set (NULL n_tp — e.g. backfilled demo data — is
+            # kept unique by the caller).
+            existing = None
+            if n_tp is not None:
+                stmt = (
+                    select(ORMAnalysis)
+                    .where(ORMAnalysis.experiment_id == experiment_id, ORMAnalysis.n_tp == n_tp)
+                    .order_by(ORMAnalysis.id.desc())
+                    .limit(1)
+                )
+                existing = (await session.execute(stmt)).scalars().first()
             if existing is not None:
                 existing.status = status
                 existing.config = config

--- a/sms_api/simulation/db_reconcile.py
+++ b/sms_api/simulation/db_reconcile.py
@@ -100,6 +100,10 @@ async def _marker_simulation_tags(conn: AsyncConnection) -> bool:
     return await _column_exists(conn, "simulation", "tags")
 
 
+async def _marker_analysis_query_columns(conn: AsyncConnection) -> bool:
+    return await _column_exists(conn, "analysis", "n_tp")
+
+
 # (revision, human-readable marker description, async predicate)
 # One marker per revision reachable by a legacy create_all database. New entries
 # are needed ONLY while create_all still bootstraps prod DBs (see module docstring):
@@ -110,12 +114,14 @@ LEGACY_FINGERPRINTS: list[tuple[str, str]] = [
     ("0f991fad32ba", "hpcrun.job_id_ext present and hpcrun.slurmjobid dropped"),
     ("a1c3e5f7b9d2", "enum jobstatusdb has value 'cancelled'"),
     ("c1a2b3d4e5f6", "simulation.tags column exists"),
+    ("d3f9a1c72b84", "analysis.n_tp column exists"),
 ]
 _LEGACY_PREDICATES = [
     _marker_baseline,
     _marker_hpcrun_k8s,
     _marker_jobstatus_cancelled,
     _marker_simulation_tags,
+    _marker_analysis_query_columns,
 ]
 
 

--- a/sms_api/simulation/tables_orm.py
+++ b/sms_api/simulation/tables_orm.py
@@ -41,6 +41,29 @@ class JobStatusDB(enum.Enum):
         return cls(status.value)
 
 
+class AnalysisStatusDB(enum.Enum):
+    """Coarse readiness of an analysis result set (see analysis-results-design.md)."""
+
+    COMPUTING = "computing"
+    READY = "ready"
+    FAILED = "failed"
+
+    def to_job_status(self) -> JobStatus:
+        return {
+            AnalysisStatusDB.COMPUTING: JobStatus.RUNNING,
+            AnalysisStatusDB.READY: JobStatus.COMPLETED,
+            AnalysisStatusDB.FAILED: JobStatus.FAILED,
+        }[self]
+
+    @classmethod
+    def from_job_status(cls, status: JobStatus) -> "AnalysisStatusDB":
+        if status == JobStatus.COMPLETED:
+            return cls.READY
+        if status in (JobStatus.FAILED, JobStatus.CANCELLED):
+            return cls.FAILED
+        return cls.COMPUTING
+
+
 class JobTypeDB(enum.Enum):
     SIMULATION = "simulation"
     PARCA = "parca"
@@ -207,7 +230,10 @@ class ORMWorkerEvent(Base):
 
 
 class ORMAnalysis(Base):
-    """Used by the /ecoli router"""
+    """General record of an analysis (any type). ``config`` (JSONB) is the
+    authoritative store of the full analysis config; the columns below are
+    denormalized/indexed only for the attributes we query on (see
+    analysis-results-design.md). Legacy SLURM rows leave the new columns NULL."""
 
     __tablename__ = "analysis"
 
@@ -215,8 +241,22 @@ class ORMAnalysis(Base):
     name: Mapped[str] = mapped_column(nullable=False)  # this should be request.analysis_name
     config: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
     last_updated: Mapped[str] = mapped_column(nullable=False)
-    job_name: Mapped[str] = mapped_column(nullable=True)
-    job_id: Mapped[int] = mapped_column(nullable=True)
+    job_name: Mapped[str | None] = mapped_column(nullable=True)
+    job_id: Mapped[int | None] = mapped_column(nullable=True)
+
+    # --- query columns (nullable; additive; backfilled for old rows) ---
+    experiment_id: Mapped[str | None] = mapped_column(nullable=True, index=True)
+    n_tp: Mapped[int | None] = mapped_column(nullable=True, index=True)
+    status: Mapped[AnalysisStatusDB | None] = mapped_column(nullable=True)
+    result_uri: Mapped[str | None] = mapped_column(nullable=True)
+    backend: Mapped[str | None] = mapped_column(nullable=True, server_default="batch")
+    simulation_id: Mapped[int | None] = mapped_column(ForeignKey("simulation.id"), nullable=True, index=True)
+    job_id_ext: Mapped[str | None] = mapped_column(nullable=True)  # K8s job name / batch id
+    error_message: Mapped[str | None] = mapped_column(nullable=True)
+    created_at: Mapped[datetime.datetime | None] = mapped_column(nullable=True, server_default=func.now())
+    updated_at: Mapped[datetime.datetime | None] = mapped_column(
+        nullable=True, server_default=func.now(), onupdate=func.now()
+    )
 
     def to_dto(self) -> ExperimentAnalysisDTO:
         options = AnalysisConfigOptions(**self.config["analysis_options"])
@@ -232,6 +272,13 @@ class ORMAnalysis(Base):
             last_updated=self.last_updated,
             job_name=self.job_name,
             job_id=self.job_id,
+            experiment_id=self.experiment_id,
+            n_tp=self.n_tp,
+            status=self.status.to_job_status() if self.status is not None else None,
+            result_uri=self.result_uri,
+            simulation_id=self.simulation_id,
+            backend=self.backend,
+            error_message=self.error_message,
         )
 
 

--- a/sms_api/version.py
+++ b/sms_api/version.py
@@ -67,4 +67,14 @@
 #          Tags are site-local data (per-site RDS), fixing the shared-S3 /
 #          independent-DB mismatch. Reconciler fingerprint extended for the new
 #          revision (frozen once create_all is guarded off in prod).
-__version__ = "0.9.20"
+# 0.9.21 — analysis-result endpoints (read side): generalize the `analysis` table
+#          (migration d3f9a1c72b84 adds nullable indexed experiment_id/n_tp/status/
+#          result_uri/... ; config JSONB stays authoritative). New GET /analyses
+#          (exhaustive list across sims, optional experiment_id/simulation_id
+#          filters), GET /simulations/{id}/analyses (per-sim list), and GET
+#          /analyses/{id}/data (pure fetch-by-id -> list[TsvOutputFile], same shape
+#          as legacy POST /analyses; 409 not-ready, 404 unknown, never computes).
+#          scripts/backfill_analysis_results.py records READY rows for existing S3
+#          analysis dirs (both nestings). n_tp sampling + nonblocking submit are a
+#          separate future track. Reconciler fingerprint extended (analysis.n_tp).
+__version__ = "0.9.21"

--- a/tests/api/ecoli/test_analysis_endpoints.py
+++ b/tests/api/ecoli/test_analysis_endpoints.py
@@ -1,0 +1,106 @@
+"""Endpoint tests for the read-side analysis-result API (list + fetch-by-id)."""
+
+import datetime
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from sms_api.common.storage.file_service import ListingItem
+from sms_api.dependencies import set_file_service
+from sms_api.simulation.database_service import DatabaseServiceSQL
+from sms_api.simulation.models import SimulationRequest
+from sms_api.simulation.tables_orm import AnalysisStatusDB
+
+_RESULT_URI = "vecoli-output/exp-ana/exp-ana/analyses"
+
+
+class _FakeFileService:
+    """Duck-typed file service returning one TSV under the result prefix."""
+
+    def __init__(self, tsv_text: str) -> None:
+        self._tsv = tsv_text
+        self._key = f"{_RESULT_URI}/variant=0/plots/analysis=cd1_proteomics/proteomics.tsv"
+
+    async def get_listing(self, s3_path: object) -> list[ListingItem]:
+        return [ListingItem(Key=self._key, LastModified=datetime.datetime(2026, 1, 1), ETag="x", Size=10)]
+
+    async def get_file_contents(self, s3_path: object) -> bytes:
+        return self._tsv.encode()
+
+
+async def _client() -> AsyncClient:
+    from sms_api.api.main import app
+
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://testserver")
+
+
+@pytest.mark.asyncio
+async def test_list_simulation_analyses(
+    base_router: str, database_service: DatabaseServiceSQL, experiment_request: SimulationRequest
+) -> None:
+    experiment_request.experiment_id = "exp-list-1"
+    experiment_request.config.experiment_id = "exp-list-1"
+    sim = await database_service.insert_simulation(experiment_request)
+    await database_service.record_analysis(
+        experiment_id="exp-list-1",
+        n_tp=None,
+        status=AnalysisStatusDB.READY,
+        config={"analysis_options": {"experiment_id": ["exp-list-1"]}},
+        name="backfill-exp-list-1",
+        simulation_id=sim.database_id,
+        result_uri=_RESULT_URI,
+    )
+    async with await _client() as client:
+        resp = await client.get(f"{base_router}/simulations/{sim.database_id}/analyses")
+        assert resp.status_code == 200
+        rows = resp.json()
+        assert len(rows) == 1
+        assert rows[0]["experiment_id"] == "exp-list-1"
+        assert rows[0]["result_uri"] == _RESULT_URI
+
+
+@pytest.mark.asyncio
+async def test_get_analysis_data_ready(base_router: str, database_service: DatabaseServiceSQL) -> None:
+    rec = await database_service.record_analysis(
+        experiment_id="exp-ana",
+        n_tp=None,
+        status=AnalysisStatusDB.READY,
+        config={"analysis_options": {"experiment_id": ["exp-ana"]}},
+        name="backfill-exp-ana",
+        result_uri=_RESULT_URI,
+    )
+    set_file_service(_FakeFileService("EcoCyc Reaction ID\tmean\tstd\nRXN1\t1.0\t0.1\n"))  # type: ignore[arg-type]
+    try:
+        async with await _client() as client:
+            resp = await client.get(f"{base_router}/analyses/{rec.database_id}/data")
+            assert resp.status_code == 200
+            files = resp.json()
+            assert len(files) == 1
+            assert files[0]["filename"] == "proteomics.tsv"
+            assert files[0]["variant"] == 0
+            assert "EcoCyc Reaction ID" in files[0]["content"]
+    finally:
+        set_file_service(None)
+
+
+@pytest.mark.asyncio
+async def test_get_analysis_data_not_ready_returns_409(
+    base_router: str, database_service: DatabaseServiceSQL
+) -> None:
+    rec = await database_service.record_analysis(
+        experiment_id="exp-computing",
+        n_tp=10,
+        status=AnalysisStatusDB.COMPUTING,
+        config={"analysis_options": {"experiment_id": ["exp-computing"]}},
+        name="c",
+    )
+    async with await _client() as client:
+        resp = await client.get(f"{base_router}/analyses/{rec.database_id}/data")
+        assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_get_analysis_data_unknown_returns_404(base_router: str, database_service: DatabaseServiceSQL) -> None:
+    async with await _client() as client:
+        resp = await client.get(f"{base_router}/analyses/99999999/data")
+        assert resp.status_code == 404

--- a/tests/api/ecoli/test_analysis_endpoints.py
+++ b/tests/api/ecoli/test_analysis_endpoints.py
@@ -84,9 +84,7 @@ async def test_get_analysis_data_ready(base_router: str, database_service: Datab
 
 
 @pytest.mark.asyncio
-async def test_get_analysis_data_not_ready_returns_409(
-    base_router: str, database_service: DatabaseServiceSQL
-) -> None:
+async def test_get_analysis_data_not_ready_returns_409(base_router: str, database_service: DatabaseServiceSQL) -> None:
     rec = await database_service.record_analysis(
         experiment_id="exp-computing",
         n_tp=10,
@@ -104,3 +102,25 @@ async def test_get_analysis_data_unknown_returns_404(base_router: str, database_
     async with await _client() as client:
         resp = await client.get(f"{base_router}/analyses/99999999/data")
         assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_list_all_analyses_exhaustive_and_filter(base_router: str, database_service: DatabaseServiceSQL) -> None:
+    for exp in ("exp-all-x", "exp-all-y"):
+        await database_service.record_analysis(
+            experiment_id=exp,
+            n_tp=None,
+            status=AnalysisStatusDB.READY,
+            config={"analysis_options": {"experiment_id": [exp]}},
+            name=f"backfill-{exp}",
+            result_uri=f"vecoli-output/{exp}/{exp}/analyses",
+        )
+    async with await _client() as client:
+        all_resp = await client.get(f"{base_router}/analyses")
+        assert all_resp.status_code == 200
+        exps = {r["experiment_id"] for r in all_resp.json()}
+        assert {"exp-all-x", "exp-all-y"} <= exps  # exhaustive across sims
+
+        filtered = await client.get(f"{base_router}/analyses", params={"experiment_id": "exp-all-x"})
+        assert filtered.status_code == 200
+        assert {r["experiment_id"] for r in filtered.json()} == {"exp-all-x"}

--- a/tests/simulation/test_analysis_result_db.py
+++ b/tests/simulation/test_analysis_result_db.py
@@ -1,0 +1,97 @@
+"""DatabaseService tests for the generalized `analysis` table (analysis-result flow).
+
+Run against the testcontainer Postgres (the enum + new columns are created by
+create_all from the ORM).
+"""
+
+from typing import Any
+
+import pytest
+
+from sms_api.common.models import JobStatus
+from sms_api.simulation.database_service import DatabaseServiceSQL
+from sms_api.simulation.tables_orm import AnalysisStatusDB
+
+
+def _config(experiment_id: str, n_tp: int) -> dict[str, Any]:
+    return {
+        "analysis_options": {
+            "experiment_id": [experiment_id],
+            "multiseed": {"ptools_rna": {"n_tp": n_tp}},
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_record_and_get_by_experiment_ntp(database_service: DatabaseServiceSQL) -> None:
+    rec = await database_service.record_analysis(
+        experiment_id="exp-a",
+        n_tp=10,
+        status=AnalysisStatusDB.COMPUTING,
+        config=_config("exp-a", 10),
+        name="analysis-exp-a-ntp10-abcd",
+        job_name="ana-exp-a-ntp10",
+        job_id_ext="ana-exp-a-ntp10",
+        result_uri="s3://bucket/vecoli-output/exp-a/exp-a/analyses/analysis-exp-a-ntp10-abcd",
+    )
+    assert rec.n_tp == 10
+    assert rec.experiment_id == "exp-a"
+    assert rec.status == JobStatus.RUNNING  # COMPUTING -> RUNNING in the DTO
+
+    fetched = await database_service.get_analysis_by_experiment_ntp("exp-a", 10)
+    assert fetched is not None
+    assert fetched.database_id == rec.database_id
+    assert fetched.result_uri and fetched.result_uri.endswith("analysis-exp-a-ntp10-abcd")
+
+
+@pytest.mark.asyncio
+async def test_record_twice_updates_in_place(database_service: DatabaseServiceSQL) -> None:
+    r1 = await database_service.record_analysis(
+        experiment_id="exp-b", n_tp=50, status=AnalysisStatusDB.COMPUTING, config=_config("exp-b", 50), name="n1"
+    )
+    r2 = await database_service.record_analysis(
+        experiment_id="exp-b",
+        n_tp=50,
+        status=AnalysisStatusDB.READY,
+        config=_config("exp-b", 50),
+        name="n1",
+        result_uri="s3://bucket/ready",
+    )
+    assert r2.database_id == r1.database_id  # same row, updated
+    assert r2.status == JobStatus.COMPLETED
+    rows = await database_service.list_analyses(experiment_id="exp-b")
+    assert len([r for r in rows if r.n_tp == 50]) == 1
+
+
+@pytest.mark.asyncio
+async def test_list_analyses_filters(database_service: DatabaseServiceSQL) -> None:
+    await database_service.record_analysis(
+        experiment_id="exp-c", n_tp=10, status=AnalysisStatusDB.READY, config=_config("exp-c", 10), name="c10",
+        simulation_id=None,
+    )
+    await database_service.record_analysis(
+        experiment_id="exp-c", n_tp=100, status=AnalysisStatusDB.READY, config=_config("exp-c", 100), name="c100"
+    )
+    await database_service.record_analysis(
+        experiment_id="exp-d", n_tp=10, status=AnalysisStatusDB.READY, config=_config("exp-d", 10), name="d10"
+    )
+    by_exp = await database_service.list_analyses(experiment_id="exp-c")
+    assert {r.n_tp for r in by_exp} == {10, 100}
+    assert all(r.experiment_id == "exp-c" for r in by_exp)
+
+
+@pytest.mark.asyncio
+async def test_update_analysis_status(database_service: DatabaseServiceSQL) -> None:
+    rec = await database_service.record_analysis(
+        experiment_id="exp-e", n_tp=10, status=AnalysisStatusDB.COMPUTING, config=_config("exp-e", 10), name="e10"
+    )
+    updated = await database_service.update_analysis_status(
+        rec.database_id, AnalysisStatusDB.READY, result_uri="s3://bucket/e10"
+    )
+    assert updated.status == JobStatus.COMPLETED
+    assert updated.result_uri == "s3://bucket/e10"
+
+
+@pytest.mark.asyncio
+async def test_get_missing_returns_none(database_service: DatabaseServiceSQL) -> None:
+    assert await database_service.get_analysis_by_experiment_ntp("nope", 10) is None

--- a/tests/simulation/test_analysis_result_db.py
+++ b/tests/simulation/test_analysis_result_db.py
@@ -66,7 +66,11 @@ async def test_record_twice_updates_in_place(database_service: DatabaseServiceSQ
 @pytest.mark.asyncio
 async def test_list_analyses_filters(database_service: DatabaseServiceSQL) -> None:
     await database_service.record_analysis(
-        experiment_id="exp-c", n_tp=10, status=AnalysisStatusDB.READY, config=_config("exp-c", 10), name="c10",
+        experiment_id="exp-c",
+        n_tp=10,
+        status=AnalysisStatusDB.READY,
+        config=_config("exp-c", 10),
+        name="c10",
         simulation_id=None,
     )
     await database_service.record_analysis(

--- a/tests/simulation/test_db_reconcile.py
+++ b/tests/simulation/test_db_reconcile.py
@@ -4,19 +4,19 @@ These cover the state machine without touching a database. End-to-end
 stamp/upgrade behavior is exercised against a real Postgres by the migration
 Job in deployment; here we lock down the decision logic that drives it.
 
-The fingerprint vectors below are length-4, matching LEGACY_FINGERPRINTS:
-    [baseline, hpcrun-k8s, cancelled-enum, simulation.tags]
+The fingerprint vectors below are length-5, matching LEGACY_FINGERPRINTS:
+    [baseline, hpcrun-k8s, cancelled-enum, simulation.tags, analysis.n_tp]
 """
 
 from sms_api.simulation.db_reconcile import DbState, classify
 
-HEAD = "c1a2b3d4e5f6"
+HEAD = "d3f9a1c72b84"
 # Mirrors LEGACY_FINGERPRINTS ordering.
-REVS = ["fb7621a73e24", "0f991fad32ba", "a1c3e5f7b9d2", "c1a2b3d4e5f6"]
+REVS = ["fb7621a73e24", "0f991fad32ba", "a1c3e5f7b9d2", "c1a2b3d4e5f6", "d3f9a1c72b84"]
 
 
 def test_managed_database_takes_upgrade_path() -> None:
-    diag = classify(alembic_revision="0f991fad32ba", fingerprint=[True, True, False, False], head_revision=HEAD)
+    diag = classify(alembic_revision="0f991fad32ba", fingerprint=[True, True, False, False, False], head_revision=HEAD)
     assert diag.state is DbState.MANAGED
     assert diag.current_revision == "0f991fad32ba"
     assert diag.matched_revision is None
@@ -25,67 +25,63 @@ def test_managed_database_takes_upgrade_path() -> None:
 
 
 def test_managed_takes_precedence_even_with_odd_fingerprint() -> None:
-    # If alembic_version exists, we trust it regardless of fingerprint probes.
-    diag = classify(alembic_revision=HEAD, fingerprint=[False, False, False, False], head_revision=HEAD)
+    diag = classify(alembic_revision=HEAD, fingerprint=[False, False, False, False, False], head_revision=HEAD)
     assert diag.state is DbState.MANAGED
 
 
 def test_fresh_database_when_no_tables_and_no_version() -> None:
-    diag = classify(alembic_revision=None, fingerprint=[False, False, False, False], head_revision=HEAD)
+    diag = classify(alembic_revision=None, fingerprint=[False, False, False, False, False], head_revision=HEAD)
     assert diag.state is DbState.FRESH
     assert diag.matched_revision is None
-    assert diag.needs_stamp is False
     assert diag.can_upgrade is True
 
 
 def test_legacy_matches_baseline_only() -> None:
-    diag = classify(alembic_revision=None, fingerprint=[True, False, False, False], head_revision=HEAD)
+    diag = classify(alembic_revision=None, fingerprint=[True, False, False, False, False], head_revision=HEAD)
     assert diag.state is DbState.LEGACY
     assert diag.matched_revision == "fb7621a73e24"
-    assert diag.needs_stamp is True
 
 
 def test_legacy_matches_middle_revision() -> None:
-    # The pre-0.9.19 stanford-test state: baseline + hpcrun-k8s, but enum missing 'cancelled'.
-    diag = classify(alembic_revision=None, fingerprint=[True, True, False, False], head_revision=HEAD)
+    diag = classify(alembic_revision=None, fingerprint=[True, True, False, False, False], head_revision=HEAD)
     assert diag.state is DbState.LEGACY
     assert diag.matched_revision == "0f991fad32ba"
-    assert diag.needs_stamp is True
 
 
 def test_legacy_matches_cancelled_revision() -> None:
-    # A create_all DB with the enum fixed but no tags column yet (no alembic_version).
-    diag = classify(alembic_revision=None, fingerprint=[True, True, True, False], head_revision=HEAD)
+    diag = classify(alembic_revision=None, fingerprint=[True, True, True, False, False], head_revision=HEAD)
     assert diag.state is DbState.LEGACY
     assert diag.matched_revision == "a1c3e5f7b9d2"
 
 
-def test_legacy_matches_head_when_all_markers_present() -> None:
-    diag = classify(alembic_revision=None, fingerprint=[True, True, True, True], head_revision=HEAD)
+def test_legacy_matches_tags_revision() -> None:
+    diag = classify(alembic_revision=None, fingerprint=[True, True, True, True, False], head_revision=HEAD)
     assert diag.state is DbState.LEGACY
     assert diag.matched_revision == "c1a2b3d4e5f6"
 
 
+def test_legacy_matches_head_when_all_markers_present() -> None:
+    diag = classify(alembic_revision=None, fingerprint=[True, True, True, True, True], head_revision=HEAD)
+    assert diag.state is DbState.LEGACY
+    assert diag.matched_revision == "d3f9a1c72b84"
+
+
 def test_inconsistent_when_later_marker_present_but_earlier_missing() -> None:
-    # A gap (True after False) means the schema matches no single revision.
-    diag = classify(alembic_revision=None, fingerprint=[True, False, True, False], head_revision=HEAD)
+    diag = classify(alembic_revision=None, fingerprint=[True, False, True, False, False], head_revision=HEAD)
     assert diag.state is DbState.INCONSISTENT
     assert diag.matched_revision is None
     assert diag.can_upgrade is False
 
 
 def test_inconsistent_when_baseline_missing_but_later_present() -> None:
-    # baseline table absent while later markers (also created by baseline) are
-    # present is impossible for a clean create_all DB => a gap => inconsistent.
-    diag = classify(alembic_revision=None, fingerprint=[False, True, True, True], head_revision=HEAD)
+    diag = classify(alembic_revision=None, fingerprint=[False, True, True, True, True], head_revision=HEAD)
     assert diag.state is DbState.INCONSISTENT
     assert diag.can_upgrade is False
 
 
 def test_markers_are_reported_with_labels() -> None:
-    diag = classify(alembic_revision=None, fingerprint=[True, True, False, False], head_revision=HEAD)
+    diag = classify(alembic_revision=None, fingerprint=[True, True, False, False, False], head_revision=HEAD)
     labels = [label for label, _ in diag.markers]
     presence = [present for _, present in diag.markers]
-    assert presence == [True, True, False, False]
-    assert any("simulation" in label for label in labels)
-    assert any("tags" in label for label in labels)
+    assert presence == [True, True, False, False, False]
+    assert any("analysis.n_tp" in label for label in labels)

--- a/tests/simulation/test_ntp_inference.py
+++ b/tests/simulation/test_ntp_inference.py
@@ -1,0 +1,30 @@
+"""Unit tests for infer_n_tp_from_tsv (pure, no DB)."""
+
+from sms_api.analysis.models import AVAILABLE_NTP, infer_n_tp_from_tsv
+
+
+def _tsv(n_tp: int) -> str:
+    # Header: a leading non-`t` label column, then n_tp columns named t0, t1, ...
+    header = "\t".join(["$"] + [f"t{i}" for i in range(n_tp)])
+    row = "\t".join(["geneA"] + ["1.0"] * n_tp)
+    return f"{header}\n{row}\n"
+
+
+def test_counts_t_columns_for_available_ntp() -> None:
+    for n in AVAILABLE_NTP:
+        assert infer_n_tp_from_tsv(_tsv(n)) == n
+
+
+def test_ignores_non_t_columns() -> None:
+    header = "\t".join(["$", "geneID", "t0", "t1", "t2", "name"])
+    assert infer_n_tp_from_tsv(f"{header}\nx\ty\t1\t2\t3\tz\n") == 3
+
+
+def test_reads_only_the_header_line() -> None:
+    # trailing data rows (even with leading 't' cells) must not affect the count
+    text = "$\tt0\tt1\ntotals\t9\t9\n"
+    assert infer_n_tp_from_tsv(text) == 2
+
+
+def test_zero_when_no_t_columns() -> None:
+    assert infer_n_tp_from_tsv("$\tgeneID\tvalue\n") == 0

--- a/uv.lock
+++ b/uv.lock
@@ -3075,7 +3075,7 @@ wheels = [
 
 [[package]]
 name = "sms-api"
-version = "0.9.20"
+version = "0.9.21"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
Implements the **read side** of the analysis-result endpoints
(docs/source/architecture/analysis-results-design.md) — the demo need: list
existing pre-run analyses and retrieve an analysis's files by id, generically.

## Endpoints (new)
| Method | Path | Returns |
|---|---|---|
| GET | `/analyses` | `list[ExperimentAnalysisDTO]` — **all** analyses across sims (exhaustive; optional `?experiment_id=`/`?simulation_id=`; paging later) |
| GET | `/simulations/{id}/analyses` | `list[ExperimentAnalysisDTO]` — analyses for one sim |
| GET | `/analyses/{id}/data` | `list[TsvOutputFile]` — pure fetch-by-id; **same shape as legacy `POST /analyses`**; 409 not-ready, 404 unknown, **never computes** |

`GET /analyses/{id}` and `/status` already existed. Legacy `POST /analyses`
retained unchanged (ptools response-parity).

## Data model
Generalize the existing `analysis` table (no new table): `config` JSONB stays the
authoritative general store; add nullable **indexed** columns `experiment_id`,
`n_tp`, `status` (new `AnalysisStatusDB` enum), `result_uri`, `simulation_id`,
`backend`, `job_id_ext`, timestamps. Migration `d3f9a1c72b84` (+ reconciler
fingerprint `analysis.n_tp`). DB methods: `record_analysis` (idempotent upsert on
`(experiment_id, n_tp)`; n_tp optional), `get_analysis_by_experiment_ntp`,
filtered `list_analyses`, `update_analysis_status`.

## Backfill
`scripts/backfill_analysis_results.py` — records one READY `analysis` row per
experiment that has an `analyses/` dir (`result_uri` = that prefix), handles both
S3 nestings, links `simulation_id`, infers `n_tp` best-effort (NULL when not
time-sampled). Idempotent.

## Key S3 findings (verified live)
- **prod (smscdk)** analyses are **double-nested** `vecoli-output/{exp}/{exp}/analyses/…`
  and are **`cd1_*` aggregate TSVs (no `n_tp`)** — the demo data.
- **dev (smsvpctest)** has both nestings. `result_uri`-per-row makes retrieval
  layout-agnostic; the fetch reuses the legacy `parse_partition_metadata`
  (regex already accepts `variant=0` and `variant[0]`).

## Scope
Read side only. **`n_tp` sampling + the nonblocking submit path are a separate
future track** (the standalone K8s path's S3 nesting needs a fix + verification
run before it's relied on).

## Tests / gate
DB-layer (5), n_tp inference (4), endpoints (5), reconciler (11). `make check`
green (mypy 189 files, ruff, deptry, lock). Version 0.9.20 -> 0.9.21; spec/client
regenerated (jim/sims fix; cosmetic client churn reverted).

## After merge
Deploy 0.9.21 to prod (reconciler applies `d3f9a1c72b84`) -> run the backfill ->
smoke-test list + fetch against `sim39-test-prod-cdad`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
