### PR TITLE
deploy(stanford prod): add vivarium-workbench (parity with stanford-test)

### DIFF
--- a/kustomize/overlays/sms-api-stanford/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford/kustomization.yaml
@@ -16,6 +16,10 @@ images:
   # avoids an ErrImagePull ReplicaSet while api iterates independently.
   - name: ghcr.io/vivarium-collective/sms-ptools
     newTag: 0.5.9
+  # vivarium-workbench: pin the workbench GitHub Release tag (build-and-push.yml ->
+  # ghcr:<version>). 0.2.0 = the demo-migration release (matches stanford-test).
+  - name: ghcr.io/vivarium-collective/vivarium-workbench
+    newTag: 0.2.0
 
 replicas:
   - count: 1
@@ -32,6 +36,11 @@ resources:
   - target-group-binding.yaml
   - secret-ghcr.yaml
   - secret-shared.yaml
+  # vivarium-workbench: peer Deployment+Service (base/workbench referenced directly,
+  # NOT via base/kustomization.yaml, so it deploys ONLY on Stanford) + its EBS PVC.
+  # Its TargetGroupBinding (workbench-binding) is in target-group-binding.yaml above.
+  - ../../base/workbench
+  - workbench-pvc.yaml
   - ../../config/sms-api-stanford
   - ../../base
 
@@ -87,3 +96,28 @@ patches:
     target:
       kind: Deployment
       name: api
+  # Browser-reachable PTools base for the pbg-ptools Omics Viewer. The seed
+  # initContainer stamps this into the served workspace.yaml (ui.ptools_server_url).
+  # Tunnel value (sms-proxy -s smscdk -> localhost:8080, PTools at the ALB root).
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: workbench
+      spec:
+        template:
+          spec:
+            initContainers:
+              - name: seed-workspace
+                env:
+                  - name: PTOOLS_SERVER_URL
+                    value: "http://localhost:8080"
+                  # Omics Viewer DATA overlay: the in-cluster ptools pod fetches
+                  # the study TSV from this workbench Service URL (same namespace,
+                  # incl. the /workbench base path the container serves under).
+                  # The seed also clears ui.ptools_data_dir so HTTP delivery is used.
+                  - name: DASHBOARD_PUBLIC_BASE_URL
+                    value: "http://workbench.sms-api-stanford.svc.cluster.local:8000/workbench"
+    target:
+      kind: Deployment
+      name: workbench

--- a/kustomize/overlays/sms-api-stanford/target-group-binding.yaml
+++ b/kustomize/overlays/sms-api-stanford/target-group-binding.yaml
@@ -17,3 +17,16 @@ spec:
     name: ptools
     port: 1555
   targetGroupARN: arn:aws-us-gov:elasticloadbalancing:us-gov-west-1:476270107793:targetgroup/smscdkinternalalb-ptools/fa951d772cbeeae1
+---
+# Binds the workbench Service to the sms-cdk workbench target group. The two
+# listener rules /workbench/* and /bigraph-loom/* both forward to this one TG.
+# ARN = `WorkbenchTargetGroupArn` output of the `smscdk-internal-alb` stack.
+apiVersion: elbv2.k8s.aws/v1beta1
+kind: TargetGroupBinding
+metadata:
+  name: workbench-binding
+spec:
+  serviceRef:
+    name: workbench
+    port: 8000
+  targetGroupARN: arn:aws-us-gov:elasticloadbalancing:us-gov-west-1:476270107793:targetgroup/smscdkinternalalb-workbench/209905395673c80f

--- a/kustomize/overlays/sms-api-stanford/workbench-pvc.yaml
+++ b/kustomize/overlays/sms-api-stanford/workbench-pvc.yaml
@@ -1,0 +1,16 @@
+# Private EBS gp3 volume for the workbench's workspace (git working copy / YAML /
+# SQLite) + caches. RWO — one writer, matches the single-replica Deployment.
+# `gp3-retain` (Retain reclaim policy) keeps the volume if the PVC is deleted, so
+# the workspace survives a redeploy; the SC is present on the smscdk cluster.
+# NOT shared with the compute — run outputs arrive from S3 via sms-api.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: workbench-workspace
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: gp3-retain
+  resources:
+    requests:
+      storage: 20Gi


### PR DESCRIPTION
Wires the **workbench** stack into the prod (`sms-api-stanford`) overlay — it was previously stanford-test-only.

A comprehensive overlay+config diff (dev vs prod) confirmed **workbench was the only non-trivial gap**: db-migration command, config `.env` keys/values, api/ptools setup, and patch structure are all in sync (modulo expected env-specific ARNs/namespace/hostnames/image tags/sealed secrets).

## Adds to the prod overlay
- image `ghcr.io/vivarium-collective/vivarium-workbench:0.2.0`
- resources `../../base/workbench` + new `workbench-pvc.yaml` (20Gi `gp3-retain`)
- seed initContainer patch: `PTOOLS_SERVER_URL=http://localhost:8080` (sms-proxy tunnel) + `DASHBOARD_PUBLIC_BASE_URL=http://workbench.sms-api-stanford.svc.cluster.local:8000/workbench`
- `workbench-binding` TargetGroupBinding → `smscdkinternalalb-workbench/209905395673c80f`

## Prereqs verified present on prod
- ✅ `WorkbenchTargetGroupArn` output on `smscdk-internal-alb`
- ✅ `gp3-retain` StorageClass on the prod cluster
- ✅ `ghcr-secret` (can pull the ~5.2GB workbench image)

Rendered resource set now matches stanford-test. Config-only change (no code); deploys to prod after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)