### PR TITLE
release: 0.9.22 — vivarium-workbench 0.3.0 integration

### DIFF
--- a/kustomize/overlays/sms-api-stanford-db-migration/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-db-migration/kustomization.yaml
@@ -7,7 +7,7 @@ images:
   - name: ghcr.io/vivarium-collective/sms-api
     # Must contain sms_api/simulation/db_reconcile.py (the Job runs it). Keep in
     # sync with the app overlay's sms-api tag; do not lower below 0.9.19.
-    newTag: 0.9.21
+    newTag: 0.9.22
 
 resources:
   - alembic-job.yaml

--- a/kustomize/overlays/sms-api-stanford-test-db-migration/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-test-db-migration/kustomization.yaml
@@ -7,7 +7,7 @@ images:
   - name: ghcr.io/vivarium-collective/sms-api
     # Must contain sms_api/simulation/db_reconcile.py (the Job runs it). Keep in
     # sync with the app overlay's sms-api tag; do not lower below 0.9.19.
-    newTag: 0.9.21
+    newTag: 0.9.22
 
 resources:
   - alembic-job.yaml

--- a/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: sms-api-stanford-test
 
 images:
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.9.21
+    newTag: 0.9.22
   # ptools pinned to last-known-good tag — CI only builds sms-api, so there is
   # no newer sms-ptools:0.6.x image on ghcr.io.  0.5.9 is the tag the live Stanford
   # pod has been running successfully; keeping both namespaces pointing here

--- a/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
@@ -16,16 +16,16 @@ images:
     newTag: 0.5.9
   # vivarium-workbench: published by cutting a GitHub Release in the workbench
   # repo (build-and-push.yml → ghcr:<version>); pin that release tag here.
-  # 0.2.0 = the demo-migration release (workbench PR #453 + #466): v2ecoli dashboard
-  # demo migrated into the workbench repo + the product code backing it — pinned-build
-  # remote runs, CSRF allowlist + reverse-proxy support, /reports/ + study-detail
-  # base-path fixes, composite-resolve graceful degradation, and the pbg-ptools viewer
-  # plugin against decoupled v2ecoli. Functionally identical to the temporary demo
-  # build build/demo-v2ecoli/7a9620c (only docs changed after that SHA), now on an
-  # immutable release tag. The env this image needs (allowed-origins / REMOTE_PINNED /
-  # DASHBOARD_PUBLIC_BASE_URL) is set on the workbench Deployment below.
+  # 0.3.0 builds on the 0.2.0 demo-migration release (workbench PR #453 + #466:
+  # v2ecoli dashboard demo migrated into the workbench repo — pinned-build remote
+  # runs, CSRF allowlist + reverse-proxy support, /reports/ + study-detail base-path
+  # fixes, composite-resolve graceful degradation, pbg-ptools viewer against
+  # decoupled v2ecoli) and adds the pinned-run progress bar (#467) + report-rendering
+  # fixes for the v4 study renderer and PR-attached reports (#468/#470). The env this
+  # image needs (allowed-origins / REMOTE_PINNED / DASHBOARD_PUBLIC_BASE_URL) is set
+  # on the workbench Deployment below.
   - name: ghcr.io/vivarium-collective/vivarium-workbench
-    newTag: 0.2.0
+    newTag: 0.3.0
 
 replicas:
   - count: 1

--- a/kustomize/overlays/sms-api-stanford/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: sms-api-stanford
 
 images:
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.9.21
+    newTag: 0.9.22
   # ptools pinned to last-known-good tag — CI only builds sms-api, so there is
   # no newer sms-ptools:0.6.x image on ghcr.io.  0.5.9 is the tag the live Stanford
   # pod has been running successfully; keeping both namespaces pointing here

--- a/kustomize/overlays/sms-api-stanford/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford/kustomization.yaml
@@ -17,9 +17,10 @@ images:
   - name: ghcr.io/vivarium-collective/sms-ptools
     newTag: 0.5.9
   # vivarium-workbench: pin the workbench GitHub Release tag (build-and-push.yml ->
-  # ghcr:<version>). 0.2.0 = the demo-migration release (matches stanford-test).
+  # ghcr:<version>). 0.3.0 = 0.2.0 demo-migration image + pinned-run progress bar
+  # (#467) and report-rendering fixes (#468/#470) (matches stanford-test).
   - name: ghcr.io/vivarium-collective/vivarium-workbench
-    newTag: 0.2.0
+    newTag: 0.3.0
 
 replicas:
   - count: 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sms_api"
-version = "0.9.21"
+version = "0.9.22"
 description = "This is the api server for Vivarium simulation services."
 authors = [{ name = "Alex Patrie", email = "alexanderpatrie@gmail.com" }, { name = "Jim Schaff", email = "jschaff@gmail.com" }]
 requires-python = ">=3.13,<3.14"

--- a/sms_api/version.py
+++ b/sms_api/version.py
@@ -77,4 +77,4 @@
 #          scripts/backfill_analysis_results.py records READY rows for existing S3
 #          analysis dirs (both nestings). n_tp sampling + nonblocking submit are a
 #          separate future track. Reconciler fingerprint extended (analysis.n_tp).
-__version__ = "0.9.21"
+__version__ = "0.9.22"

--- a/uv.lock
+++ b/uv.lock
@@ -3075,7 +3075,7 @@ wheels = [
 
 [[package]]
 name = "sms-api"
-version = "0.9.21"
+version = "0.9.22"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
sms-api **0.9.22** — marks the vivarium-workbench **0.3.0** integration.

## Changes
- **Workbench 0.2.0 → 0.3.0** in both app overlays (`sms-api-stanford`, `sms-api-stanford-test`): pinned-run progress bar (#467) + report-rendering fixes for the v4 study renderer / PR-attached reports (#468/#470).
- **Version bump 0.9.21 → 0.9.22** (`sms_api/version.py`, `pyproject.toml`, `uv.lock`) — no sms-api code change; this release documents the workbench integration point.
- **sms-api tag → 0.9.22** in the four Stanford overlays (app + db-migration, prod + test).

## Scope
- Only the two app overlays carry the workbench image; the `*-db-migration` overlays run only the sms-api alembic Job.
- `rke`/`eks`/`local` overlays are on a separate, long-diverged track (0.9.4/0.9.1/0.4.x) and are intentionally left untouched.
- No new Alembic migration in 0.9.22 → the migration Job is a reconciler no-op (prod already MANAGED at `d3f9a1c72b84`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)