### PR TITLE
release: 0.9.23 (workbench 0.3.1 — bigraph-loom base-path fix)

### DIFF
--- a/kustomize/overlays/sms-api-stanford-db-migration/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-db-migration/kustomization.yaml
@@ -7,7 +7,7 @@ images:
   - name: ghcr.io/vivarium-collective/sms-api
     # Must contain sms_api/simulation/db_reconcile.py (the Job runs it). Keep in
     # sync with the app overlay's sms-api tag; do not lower below 0.9.19.
-    newTag: 0.9.22
+    newTag: 0.9.23
 
 resources:
   - alembic-job.yaml

--- a/kustomize/overlays/sms-api-stanford-test-db-migration/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-test-db-migration/kustomization.yaml
@@ -7,7 +7,7 @@ images:
   - name: ghcr.io/vivarium-collective/sms-api
     # Must contain sms_api/simulation/db_reconcile.py (the Job runs it). Keep in
     # sync with the app overlay's sms-api tag; do not lower below 0.9.19.
-    newTag: 0.9.22
+    newTag: 0.9.23
 
 resources:
   - alembic-job.yaml

--- a/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: sms-api-stanford-test
 
 images:
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.9.22
+    newTag: 0.9.23
   # ptools pinned to last-known-good tag — CI only builds sms-api, so there is
   # no newer sms-ptools:0.6.x image on ghcr.io.  0.5.9 is the tag the live Stanford
   # pod has been running successfully; keeping both namespaces pointing here
@@ -21,11 +21,14 @@ images:
   # runs, CSRF allowlist + reverse-proxy support, /reports/ + study-detail base-path
   # fixes, composite-resolve graceful degradation, pbg-ptools viewer against
   # decoupled v2ecoli) and adds the pinned-run progress bar (#467) + report-rendering
-  # fixes for the v4 study renderer and PR-attached reports (#468/#470). The env this
+  # fixes for the v4 study renderer and PR-attached reports (#468/#470). 0.3.1 adds
+  # the bigraph-loom base-path fix (workbench #476): the wiring explorer's "test run"
+  # posted a root-absolute /api/composite-test-run, which escaped the /workbench
+  # prefix and matched the ALB's /api/* rule -> routed to sms-api, 404. The env this
   # image needs (allowed-origins / REMOTE_PINNED / DASHBOARD_PUBLIC_BASE_URL) is set
   # on the workbench Deployment below.
   - name: ghcr.io/vivarium-collective/vivarium-workbench
-    newTag: 0.3.0
+    newTag: 0.3.1
 
 replicas:
   - count: 1

--- a/kustomize/overlays/sms-api-stanford/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: sms-api-stanford
 
 images:
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.9.22
+    newTag: 0.9.23
   # ptools pinned to last-known-good tag — CI only builds sms-api, so there is
   # no newer sms-ptools:0.6.x image on ghcr.io.  0.5.9 is the tag the live Stanford
   # pod has been running successfully; keeping both namespaces pointing here
@@ -18,9 +18,12 @@ images:
     newTag: 0.5.9
   # vivarium-workbench: pin the workbench GitHub Release tag (build-and-push.yml ->
   # ghcr:<version>). 0.3.0 = 0.2.0 demo-migration image + pinned-run progress bar
-  # (#467) and report-rendering fixes (#468/#470) (matches stanford-test).
+  # (#467) and report-rendering fixes (#468/#470). 0.3.1 adds the bigraph-loom
+  # base-path fix (workbench #476): the wiring explorer's "test run" posted a
+  # root-absolute /api/composite-test-run, which escaped the /workbench prefix and
+  # matched the ALB's /api/* rule -> routed to sms-api, 404. (matches stanford-test).
   - name: ghcr.io/vivarium-collective/vivarium-workbench
-    newTag: 0.3.0
+    newTag: 0.3.1
 
 replicas:
   - count: 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sms_api"
-version = "0.9.22"
+version = "0.9.23"
 description = "This is the api server for Vivarium simulation services."
 authors = [{ name = "Alex Patrie", email = "alexanderpatrie@gmail.com" }, { name = "Jim Schaff", email = "jschaff@gmail.com" }]
 requires-python = ">=3.13,<3.14"

--- a/sms_api/version.py
+++ b/sms_api/version.py
@@ -77,4 +77,13 @@
 #          scripts/backfill_analysis_results.py records READY rows for existing S3
 #          analysis dirs (both nestings). n_tp sampling + nonblocking submit are a
 #          separate future track. Reconciler fingerprint extended (analysis.n_tp).
-__version__ = "0.9.22"
+# 0.9.23 — pin vivarium-workbench 0.3.1 (bigraph-loom base-path fix). The wiring
+#          explorer's "test run" posted a root-absolute /api/composite-test-run;
+#          bigraph-loom is a third-party bundle the workbench serves but does not
+#          render, so it never received the workbench's base-path URL shim. Under
+#          `serve --base-path /workbench` the call escaped the prefix and matched
+#          the ALB's /api/* rule -> routed to THIS service, which 404'd it
+#          (`POST /api/composite-test-run -> 404` in the api log). The workbench
+#          now injects the shim into the loom's HTML entry (workbench #476),
+#          covering both the prefixed and the unprefixed /bigraph-loom/* paths.
+__version__ = "0.9.23"

--- a/uv.lock
+++ b/uv.lock
@@ -3075,7 +3075,7 @@ wheels = [
 
 [[package]]
 name = "sms-api"
-version = "0.9.22"
+version = "0.9.23"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
Repoints the workbench onto **0.3.1** and bumps sms-api to **0.9.23** so a release can be cut after merge. Follows the established 7-file release convention (`pyproject.toml` + `sms_api/version.py` + `uv.lock` + the sms-api pin in the 4 stanford overlays), matching `2de193fe` (the 0.9.22 release).

## 1. vivarium-workbench `0.3.0 → 0.3.1` (stanford + stanford-test)
Fixes the wiring explorer's **"test run"** in the *deployed* workbench.

`bigraph-loom` is a third-party bundle the workbench **serves but does not render**, so it never received the workbench's base-path URL shim. Its bundled JS posts a **root-absolute `/api/composite-test-run`** — under `serve --base-path /workbench` that escaped the prefix and matched the ALB's **`/api/*`** rule, so it was routed to **this service**, which 404'd it. Observed live in the api pod log:
```
POST /api/composite-test-run  ->  404 Not Found
```
Workbench #476 injects the shim into the loom's HTML entry, covering **both** the prefixed `/workbench/bigraph-loom/*` and the unprefixed `/bigraph-loom/*` paths the ALB routes here. No bigraph-loom change needed.

**`ghcr.io/vivarium-collective/vivarium-workbench:0.3.1` is already built and published**, so this pin is deploy-ready.

## 2. sms-api `0.9.22 → 0.9.23`
Version bump only (no API changes) so a `v0.9.23` release + image can be cut after merging.

## ⚠️ Sequencing
The overlays now pin **`sms-api:0.9.23`, which does not exist until the release is cut and built**. **Do not deploy between merging this and that build** — the api pods would `ImagePullBackOff`. (The workbench pin is already safe; `0.3.1` is published.)

Suggested order: **merge → cut `v0.9.23` → wait for the image → sync stanford/stanford-test.**

## Verified
`kustomize build` passes for both `sms-api-stanford` and `sms-api-stanford-test`; the resolved stanford manifest yields:
```
ghcr.io/vivarium-collective/sms-api:0.9.23
ghcr.io/vivarium-collective/sms-ptools:0.5.9
ghcr.io/vivarium-collective/vivarium-workbench:0.3.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)