### PR TITLE
chore(workbench): pin dev overlay to vivarium-workbench 0.3.3

### DIFF
--- a/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
@@ -28,7 +28,7 @@ images:
   # image needs (allowed-origins / REMOTE_PINNED / DASHBOARD_PUBLIC_BASE_URL) is set
   # on the workbench Deployment below.
   - name: ghcr.io/vivarium-collective/vivarium-workbench
-    newTag: 0.3.1
+    newTag: 0.3.3
 
 replicas:
   - count: 1


### PR DESCRIPTION
Points the **stanford-test (dev)** overlay at the freshly-released workbench **v0.3.3**, to deploy:
- **session-per-tab** — open-in-new-tab by name/build, per-tab `X-VW-Session` identity, favicon-by-status
- the **sys.path / statelessness** cleanup (no `/api/*` path imports workspace Python into the HTTP process)

`ghcr.io/vivarium-collective/vivarium-workbench:0.3.3` is built by the workbench repo's Build-and-Push workflow (release `v0.3.3`).

⚠️ **Reconcile the source of truth:** `main` pinned `0.3.1` here, but the `fix/compose-batch-driver-swap` branch had `0.3.2`. Confirm which branch stanford-test actually deploys from before rolling out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)