### PR TITLE
deploy(stanford prod): promote compose-on-Batch to prod + allow-list vivarium origins (batch_baseline on GovCloud)

### DIFF
--- a/kustomize/config/sms-api-stanford/shared.env
+++ b/kustomize/config/sms-api-stanford/shared.env
@@ -46,13 +46,16 @@ RAY_CHUNK=60
 # ParCa cache key (copied from a08e20bd…, byte-identical — no reconstruction/
 # sim_data changed). The image tag has NO default (ECR is per-commit, no
 # "latest"), so blank makes compose submits fail fast naming the setting.
-COMPOSE_RAY_IMAGE_TAG=868cf2a36749996768cc31209c2a714d68a9435d
+COMPOSE_RAY_IMAGE_TAG=f7c96c07c8b86927aceee9386832e5d39062617b
 # Where the commit-keyed ParCa cache is staged before the run; v2ecoli resolves a
 # relative "out/cache" against the image WORKDIR (/app/v2ecoli).
 COMPOSE_PARCA_CACHE_DIR=/app/v2ecoli/out/cache
 # The workspace's own core builder — registers ECOLI_TYPES, without which
 # v2ecoli's documents don't resolve on the generic run_pbg core.
 COMPOSE_PBG_CORE_BUILDER=v2ecoli.core:build_core
+# Compose MNP node count — fan seed lineages across N r5 worker nodes. 4 = current
+# CDK rayBatch.numNodes (no CDK change); raise (+ bump CDK numNodes) for a larger sweep.
+COMPOSE_RAY_NUM_NODES=4
 
 MARIMO_API_SERVER=http://api:8000
 DEPLOYMENT_NAMESPACE=sms-api-stanford

--- a/kustomize/config/sms-api-stanford/shared.env
+++ b/kustomize/config/sms-api-stanford/shared.env
@@ -40,12 +40,13 @@ RAY_N_STEPS=600
 RAY_CHUNK=60
 
 # Compose (Ray-on-Batch) — image tag, ParCa cache key, and the workbench's baked
-# workspace must all describe the SAME v2ecoli commit. 6148ee54… = v2ecoli main
-# HEAD (adds the batch_baseline composite), the ECR tag, and the ParCa cache key
-# (copied from a08e20bd…, byte-identical — no reconstruction/sim_data changed).
-# The image tag has NO default (ECR is per-commit, no "latest"), so blank makes
-# compose submits fail fast naming the setting.
-COMPOSE_RAY_IMAGE_TAG=6148ee54211c3f1f180e8ed3bac01884f9388045
+# workspace must all describe the SAME v2ecoli commit. 868cf2a3… = v2ecoli main
+# after #356 (batch_baseline remote-dispatch fixes: portable .pbg serialize,
+# nest-safe Ray fan-out, sweep -> PBG_RESULTS_DIR). Also the ECR tag and the
+# ParCa cache key (copied from a08e20bd…, byte-identical — no reconstruction/
+# sim_data changed). The image tag has NO default (ECR is per-commit, no
+# "latest"), so blank makes compose submits fail fast naming the setting.
+COMPOSE_RAY_IMAGE_TAG=868cf2a36749996768cc31209c2a714d68a9435d
 # Where the commit-keyed ParCa cache is staged before the run; v2ecoli resolves a
 # relative "out/cache" against the image WORKDIR (/app/v2ecoli).
 COMPOSE_PARCA_CACHE_DIR=/app/v2ecoli/out/cache

--- a/kustomize/config/sms-api-stanford/shared.env
+++ b/kustomize/config/sms-api-stanford/shared.env
@@ -46,16 +46,18 @@ RAY_CHUNK=60
 # ParCa cache key (copied from a08e20bd…, byte-identical — no reconstruction/
 # sim_data changed). The image tag has NO default (ECR is per-commit, no
 # "latest"), so blank makes compose submits fail fast naming the setting.
-COMPOSE_RAY_IMAGE_TAG=f7c96c07c8b86927aceee9386832e5d39062617b
+COMPOSE_RAY_IMAGE_TAG=bfc9198c6b9f396627defe55103f798875d3b3bb
 # Where the commit-keyed ParCa cache is staged before the run; v2ecoli resolves a
 # relative "out/cache" against the image WORKDIR (/app/v2ecoli).
 COMPOSE_PARCA_CACHE_DIR=/app/v2ecoli/out/cache
 # The workspace's own core builder — registers ECOLI_TYPES, without which
 # v2ecoli's documents don't resolve on the generic run_pbg core.
 COMPOSE_PBG_CORE_BUILDER=v2ecoli.core:build_core
-# Compose MNP node count — fan seed lineages across N r5 worker nodes. 4 = current
-# CDK rayBatch.numNodes (no CDK change); raise (+ bump CDK numNodes) for a larger sweep.
-COMPOSE_RAY_NUM_NODES=4
+# Compose MNP node count — fan seed lineages across N r5 worker nodes. Must be
+# <= CDK rayBatch.numNodes (sms-cdk#29 deployed 24). 24 x 16 = 384 vCPU <= CE
+# maxvCpus (512). Deregister the derived smscdk-ray-mnp-<tag> job-def after a
+# CDK numNodes change so the next submit re-clones at the new count.
+COMPOSE_RAY_NUM_NODES=24
 
 MARIMO_API_SERVER=http://api:8000
 DEPLOYMENT_NAMESPACE=sms-api-stanford

--- a/kustomize/config/sms-api-stanford/shared.env
+++ b/kustomize/config/sms-api-stanford/shared.env
@@ -39,5 +39,19 @@ RAY_PARCA_CPUS=8
 RAY_N_STEPS=600
 RAY_CHUNK=60
 
+# Compose (Ray-on-Batch) — image tag, ParCa cache key, and the workbench's baked
+# workspace must all describe the SAME v2ecoli commit. 6148ee54… = v2ecoli main
+# HEAD (adds the batch_baseline composite), the ECR tag, and the ParCa cache key
+# (copied from a08e20bd…, byte-identical — no reconstruction/sim_data changed).
+# The image tag has NO default (ECR is per-commit, no "latest"), so blank makes
+# compose submits fail fast naming the setting.
+COMPOSE_RAY_IMAGE_TAG=6148ee54211c3f1f180e8ed3bac01884f9388045
+# Where the commit-keyed ParCa cache is staged before the run; v2ecoli resolves a
+# relative "out/cache" against the image WORKDIR (/app/v2ecoli).
+COMPOSE_PARCA_CACHE_DIR=/app/v2ecoli/out/cache
+# The workspace's own core builder — registers ECOLI_TYPES, without which
+# v2ecoli's documents don't resolve on the generic run_pbg core.
+COMPOSE_PBG_CORE_BUILDER=v2ecoli.core:build_core
+
 MARIMO_API_SERVER=http://api:8000
 DEPLOYMENT_NAMESPACE=sms-api-stanford

--- a/kustomize/overlays/sms-api-stanford-db-migration/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-db-migration/kustomization.yaml
@@ -7,7 +7,7 @@ images:
   - name: ghcr.io/vivarium-collective/sms-api
     # Must contain sms_api/simulation/db_reconcile.py (the Job runs it). Keep in
     # sync with the app overlay's sms-api tag; do not lower below 0.9.19.
-    newTag: 0.9.23
+    newTag: 0.9.26
 
 resources:
   - alembic-job.yaml

--- a/kustomize/overlays/sms-api-stanford/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford/kustomization.yaml
@@ -23,7 +23,7 @@ images:
   # root-absolute /api/composite-test-run, which escaped the /workbench prefix and
   # matched the ALB's /api/* rule -> routed to sms-api, 404. (matches stanford-test).
   - name: ghcr.io/vivarium-collective/vivarium-workbench
-    newTag: 0.3.4
+    newTag: 0.3.5
 
 replicas:
   - count: 1

--- a/kustomize/overlays/sms-api-stanford/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: sms-api-stanford
 
 images:
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.9.23
+    newTag: 0.9.26
   # ptools pinned to last-known-good tag — CI only builds sms-api, so there is
   # no newer sms-ptools:0.6.x image on ghcr.io.  0.5.9 is the tag the live Stanford
   # pod has been running successfully; keeping both namespaces pointing here
@@ -23,7 +23,7 @@ images:
   # root-absolute /api/composite-test-run, which escaped the /workbench prefix and
   # matched the ALB's /api/* rule -> routed to sms-api, 404. (matches stanford-test).
   - name: ghcr.io/vivarium-collective/vivarium-workbench
-    newTag: 0.3.1
+    newTag: 0.3.4
 
 replicas:
   - count: 1

--- a/kustomize/overlays/sms-api-stanford/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: sms-api-stanford
 
 images:
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.9.26
+    newTag: 0.9.27
   # ptools pinned to last-known-good tag — CI only builds sms-api, so there is
   # no newer sms-ptools:0.6.x image on ghcr.io.  0.5.9 is the tag the live Stanford
   # pod has been running successfully; keeping both namespaces pointing here

--- a/kustomize/overlays/sms-api-stanford/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford/kustomization.yaml
@@ -23,7 +23,7 @@ images:
   # root-absolute /api/composite-test-run, which escaped the /workbench prefix and
   # matched the ALB's /api/* rule -> routed to sms-api, 404. (matches stanford-test).
   - name: ghcr.io/vivarium-collective/vivarium-workbench
-    newTag: 0.3.5
+    newTag: 0.3.6
 
 replicas:
   - count: 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sms_api"
-version = "0.9.26"
+version = "0.9.27"
 description = "This is the api server for Vivarium simulation services."
 authors = [{ name = "Alex Patrie", email = "alexanderpatrie@gmail.com" }, { name = "Jim Schaff", email = "jschaff@gmail.com" }]
 requires-python = ">=3.13,<3.14"

--- a/sms_api/compose/models.py
+++ b/sms_api/compose/models.py
@@ -244,6 +244,17 @@ DEFAULT_COMPOSE_ALLOW_LIST: list[str] = [
     "pypi::scipy",
     "pypi::pb_multiscale_actin",
     "conda::readdy",
+    # vivarium-collective git origins — the framework + workspace deps the
+    # vivarium-workbench pinned-run path ships as extra_pip_deps for a v2ecoli
+    # composite (v2ecoli itself + its process-bigraph stack, pinned per the
+    # workspace uv.lock). Base URLs (no @commit): the allow-list check is a
+    # substring match, so these cover any pinned commit. Without them the
+    # workbench's POST /compose/v1/simulation/run is rejected 403.
+    "pypi::git+https://github.com/vivarium-collective/v2ecoli.git",
+    "pypi::git+https://github.com/vivarium-collective/bigraph-schema.git",
+    "pypi::git+https://github.com/vivarium-collective/pbg-emitters.git",
+    "pypi::git+https://github.com/vivarium-collective/pbg-superpowers.git",
+    "pypi::git+https://github.com/vivarium-collective/process-bigraph.git",
 ]
 
 

--- a/sms_api/version.py
+++ b/sms_api/version.py
@@ -112,4 +112,4 @@
 #          stuck at QUEUED forever even after the Batch job SUCCEEDED and results
 #          landed in S3. Now polls every NON-TERMINAL state so a job traverses
 #          queued->running->completed. Found by the same stanford-test smoke test.
-__version__ = "0.9.26"
+__version__ = "0.9.27"


### PR DESCRIPTION
Stacked on `fix/compose-batch-driver-swap` (it depends on that branch's compose-on-Batch code + 0.9.24–0.9.26; `main` is still 0.9.23). **Base this into `fix/compose-batch-driver-swap`, not `main`.**

## What & why

Brings the `sms-api-stanford` (smscdk **prod**) deployment to the point where the vivarium-workbench UI can dispatch a v2ecoli composite (`batch_baseline`) to **Ray-on-AWS-Batch** via the GovCloud tunnel — the first end-to-end exercise of the compose path on prod.

**Deploy config** (`kustomize/…/sms-api-stanford*`):
- prod overlay: `sms-api 0.9.23 → 0.9.26`, `vivarium-workbench 0.3.1 → 0.3.4`
- db-migration overlay: `→ 0.9.26` (carries the additive `compose_hpcrun` `job_id_ext`/`job_backend` migration)
- prod `shared.env`: `COMPOSE_RAY_IMAGE_TAG=6148ee54…` (v2ecoli main HEAD w/ `batch_baseline`; the ECR image + commit-keyed ParCa cache both match), `COMPOSE_PARCA_CACHE_DIR=/app/v2ecoli/out/cache`, `COMPOSE_PBG_CORE_BUILDER=v2ecoli.core:build_core`

**Allow-list** (`sms_api/compose/models.py`):
- Seed the 5 `vivarium-collective` git origins into `DEFAULT_COMPOSE_ALLOW_LIST` so a fresh deploy doesn't 403 the workbench's first composite run. Substring-matched → covers any pinned commit. Only affects `seed_if_empty`; operator-curated tables untouched.

## ⚠️ Already applied to prod (out-of-band, coordinated)

These overlay changes are **live on smscdk prod** (kubectl apply + rollout done; migration ran: `managed → head`; api `/health` = 0.9.26; workbench = 0.3.4). The prod `compose_allow_list` table was **manually curated** with the same 5 origins to unblock immediately — this PR makes that durable for the next fresh deploy. This PR captures the deployed state in git for review/merge. Coordinate the merge order with the compose-driver work.

## Verification on prod
- Workbench Run → `target=deployment` → `.pbg` export → `/compose/v1/simulation/run` → AWS Batch MNP job on `v2ecoli:6148ee54`, ParCa staged, Ray formed, `v2ecoli.core:build_core` loaded. (The composite itself needed a separate v2ecoli serialization fix — vivarium-collective/v2ecoli#356.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)