### PR TITLE
feat(compose): make num_nodes configurable for multi-node seed fan-out

### DIFF
--- a/sms_api/compose/simulation_service_ray.py
+++ b/sms_api/compose/simulation_service_ray.py
@@ -162,7 +162,7 @@ class ComposeSimulationServiceRay(ComposeSimulationService):
         batch_job_id = self._ray._submit_mnp(
             job_name=f"compose-{experiment_id}"[:128],
             job_definition=job_def,
-            num_nodes=1,
+            num_nodes=get_settings().compose_ray_num_nodes,
             ray_job_cmd=self._compose_command(doc_s3_uri, runner_s3_uri, steps),
             out_s3=data_layout.RayLayout.results_uri(experiment_id),
             out_dir=COMPOSE_OUT_DIR,

--- a/sms_api/config.py
+++ b/sms_api/config.py
@@ -238,6 +238,7 @@ class Settings(BaseSettings):
     ray_mnp_queue: str = ""  # Batch MNP job queue (e.g. "smscdk-ray-mnp")
     ray_mnp_job_definition: str = ""  # Batch MNP job definition (e.g. "smscdk-ray-mnp")
     ray_num_nodes: int = 3  # MNP node count for the simulation job (1 head + N-1 workers)
+    compose_ray_num_nodes: int = 1  # MNP node count for COMPOSE runs; 1 = single node (head is also worker, per the ray-batch-entrypoint --num-cpus conditional). Raise to fan seed lineages across N worker nodes for large sweeps (must be <= CDK rayBatch.numNodes).
     ray_ecr_repository: str = "v2ecoli"  # ECR repo for the workload-owned Ray image (built by submit_build_image_job)
     ray_parca_mode: str = "full"  # v2ecoli-parca --mode (fast for debug, full for production)
     ray_parca_cpus: int = 8  # v2ecoli-parca --cpus


### PR DESCRIPTION
## What
Make the compose driver's `num_nodes` configurable via a new `compose_ray_num_nodes` setting (default `1`), replacing the hardcoded `num_nodes=1` at `compose/simulation_service_ray.py:165`.

## Why
Single-node compose runs are memory-bound to ~16 concurrent seeds. The full `batch_baseline` 1,000 × 10 sweep is **~8 days / ~$200–250 on one node** (measured: ~18 min per generation for a 16-seed wave). Fanning seed lineages across N MNP worker nodes scales ~linearly — **4 nodes ≈ ~2 days, 8 nodes ≈ ~1 day**. Follows the coordination in #181.

## Change
```diff
# config.py
+ compose_ray_num_nodes: int = 1  # MNP node count for COMPOSE runs (<= CDK rayBatch.numNodes)

# compose/simulation_service_ray.py:165
- num_nodes=1,
+ num_nodes=get_settings().compose_ray_num_nodes,
```

**Default `1` = today's single-node behavior, unchanged.** A sweep raises it in `shared.env`. The derived MNP job-def already clones the CDK base (`numNodes=4`), so `num_nodes ≤ 4` works with current infra; **>4 needs a CDK `rayBatch.numNodes` bump** (I'll handle that separately, same isolated single-stack deploy as sms-cdk#26). The entrypoint's head/worker split already handles N>1 (head `--num-cpus=0`, workers supply CPUs), and the single-node path stays correct via the `--num-cpus` conditional (v2ecoli#364 / sms-cdk#25).

## Validation plan
The multi-node compose flow has never been exercised (every run so far was single-node), so before the full sweep I'll fire one multi-node pilot (~4 nodes × 40 seeds × 1 gen) to confirm the worker fan-out.

Base is `fix/compose-batch-driver-swap` (the compose stack). @jschaff — flag if `num_nodes=1` was pinned for a reason worth preserving (MNP startup cost, a Ray assumption, a cost guardrail).

Context / full validation write-up: https://claude.ai/code/artifact/9a2c8a38-1e75-41e8-957e-30460d1cd53e
