### PR TITLE
deploy(stanford prod): workbench 0.3.6 → 0.3.7 (switch-to-remote hardening)

### DIFF
--- a/kustomize/overlays/sms-api-stanford/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford/kustomization.yaml
@@ -23,7 +23,7 @@ images:
   # root-absolute /api/composite-test-run, which escaped the /workbench prefix and
   # matched the ALB's /api/* rule -> routed to sms-api, 404. (matches stanford-test).
   - name: ghcr.io/vivarium-collective/vivarium-workbench
-    newTag: 0.3.6
+    newTag: 0.3.7
 
 replicas:
   - count: 1


### PR DESCRIPTION
Promotes the hosted workbench to v0.3.7 (workbench PR #630, #1-#6): bounded/retrying remote poll, 🟢/🔴 remote health dot + version, switch-build timeout/cancel, actionable failure reasons — for Chris (hosted instance). **Applied + verified live:** pod on ghcr:0.3.7, all hardening markers present, /api/source/remote-health → 200. Rolls only the workbench deployment; separate pod from the live 1000×10 batch run.