### PR TITLE
deploy(stanford prod): workbench 0.3.7 → 0.3.9 (header workspace picker)

### DIFF
--- a/kustomize/overlays/sms-api-stanford/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford/kustomization.yaml
@@ -23,7 +23,7 @@ images:
   # root-absolute /api/composite-test-run, which escaped the /workbench prefix and
   # matched the ALB's /api/* rule -> routed to sms-api, 404. (matches stanford-test).
   - name: ghcr.io/vivarium-collective/vivarium-workbench
-    newTag: 0.3.7
+    newTag: 0.3.9
 
 replicas:
   - count: 1


### PR DESCRIPTION
Bumps the stanford-prod workbench image pin **0.3.7 → 0.3.9**. Single-line change; sms-api \`0.9.27\` and ptools untouched. Stacks on #184 (0.3.7).

**Ships** (vivarium-workbench):
- **#636 / v0.3.9** — sleek searchable header workspace switcher (top-bar \`Workspace: <name> ▾\` dropdown → session-per-tab spawn), replacing the old \`#github\` chip.
- **#634 / v0.3.8** — session-per-tab failed-materialization reason panel + Retry.

**Already applied + verified live** on stanford/smscdk prod (surgical \`kubectl set image deployment/workbench\`, not a whole-overlay apply, to avoid touching the concurrent sms-api work). Live pod serves \`:0.3.9\`; served HTML carries \`viv-workspace-picker-trigger\` + \`workspace-picker.js\` (200); \`/api/workspaces\` populates the dropdown. This PR is the tracking record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)