### PR TITLE
deploy(stanford prod): workbench 0.3.13 -> 0.3.14

### DIFF
--- a/kustomize/overlays/sms-api-stanford/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford/kustomization.yaml
@@ -22,8 +22,12 @@ images:
   # base-path fix (workbench #476): the wiring explorer's "test run" posted a
   # root-absolute /api/composite-test-run, which escaped the /workbench prefix and
   # matched the ALB's /api/* rule -> routed to sms-api, 404. (matches stanford-test).
+  # 0.3.14 (workbench #658) applies the same fix to the main dashboard page's
+  # session.js spawn-bind (the Source panel's "Open" button), which had the
+  # identical late-shim-injection bug — found while trying to bind a session to
+  # the sms-ecoli pilot build.
   - name: ghcr.io/vivarium-collective/vivarium-workbench
-    newTag: 0.3.13
+    newTag: 0.3.14
 
 replicas:
   - count: 1


### PR DESCRIPTION
## Summary
- Bumps the `vivarium-workbench` image tag to 0.3.14 in `sms-api-stanford`.
- Ships vivarium-collective/vivarium-workbench#658: the base-path URL-rewriting shim now runs before `session.js`, fixing the Source panel's "Open" button (previously 404'd silently when binding a new tab to a remote sms-api build or local workspace, in any base-path deployment like this one).

## Test plan
- [ ] Apply surgically to the `workbench` Deployment only (not the full overlay, per the shared-namespace convention)
- [ ] Verify rollout + version via `/api/workspaces` or similar
- [ ] Verify the Open button actually binds a new tab to a remote sms-ecoli build via real UI click

🤖 Generated with [Claude Code](https://claude.com/claude-code)