### PR TITLE
deploy(stanford prod): workbench 0.3.16 -> 0.3.17

### DIFF
--- a/kustomize/overlays/sms-api-stanford/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford/kustomization.yaml
@@ -34,8 +34,12 @@ images:
   # existing S3-streaming /data endpoint when a run's local materialization
   # is gone (the normal state for a GovCloud-dispatched run after a pod
   # restart, or one recorded via the sms-api-backed remote-simulations list).
+  # 0.3.17 (workbench #661) fixes the reason a remote-dispatched run's
+  # analysis_options always came out empty: remote_run_submit() never read
+  # spec.analyses at all, for any run, ever — now threads
+  # build_analysis_options(spec.analyses) into the dispatch payload.
   - name: ghcr.io/vivarium-collective/vivarium-workbench
-    newTag: 0.3.16
+    newTag: 0.3.17
 
 replicas:
   - count: 1


### PR DESCRIPTION
Bumps the vivarium-workbench image tag to 0.3.17 — vivarium-collective/vivarium-workbench#661 (thread analysis_options into remote dispatch).