### PR TITLE
deploy(stanford prod): workbench 0.3.18 -> 0.3.19

### DIFF
--- a/kustomize/overlays/sms-api-stanford/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford/kustomization.yaml
@@ -43,9 +43,11 @@ images:
   # framework's own render pipeline nor the external
   # viva_superpowers.TimeSeriesFromObservables class has ever had a
   # non-SQLite code path — new lib.zarr_default_viz renders real charts
-  # directly from a run's zarr store instead.
+  # directly from a run's zarr store instead. 0.3.19 (workbench #663) merges
+  # remote sms-api builds into the top-left workspace-switcher dropdown
+  # (previously reachable only through the separate Source panel).
   - name: ghcr.io/vivarium-collective/vivarium-workbench
-    newTag: 0.3.18
+    newTag: 0.3.19
 
 replicas:
   - count: 1


### PR DESCRIPTION
Bumps the vivarium-workbench image tag to 0.3.19 — vivarium-collective/vivarium-workbench#663 (workspace-switcher remote builds).