### PR TITLE
deploy(stanford prod): workbench 0.3.20 -> 0.3.21 (study-create blank-shape fix)

### DIFF
--- a/kustomize/overlays/sms-api-stanford/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford/kustomization.yaml
@@ -49,8 +49,15 @@ images:
   # (workbench #664) adds the study-analyses UI control + backend endpoint
   # that was still missing after 0.3.17: nothing could author spec.analyses
   # at all, even though the remote dispatch path already reads it correctly.
+  # 0.3.21 (workbench #665) fixes study_create()'s no-source ("blank study")
+  # branch: it scaffolded spec.yaml under studies/<name>/, but
+  # iter_study_dirs() only recognizes study.yaml there (spec.yaml is legacy,
+  # honored only under investigations/<name>/). Every blank study created via
+  # the "+ Study" modal returned 200 yet was permanently invisible to
+  # /api/investigations and /api/study/{slug} — found live on this deployment
+  # while trying to author a study to attach analyses config to.
   - name: ghcr.io/vivarium-collective/vivarium-workbench
-    newTag: 0.3.20
+    newTag: 0.3.21
 
 replicas:
   - count: 1


### PR DESCRIPTION
## Summary
- Bumps the stanford overlay's vivarium-workbench image tag 0.3.20 -> 0.3.21.
- workbench v0.3.21 fixes `study_create()`'s no-source ("blank study") branch: it scaffolded `spec.yaml` under `studies/<name>/`, but `iter_study_dirs()` only recognizes `study.yaml` there. Every blank study created via the "+ Study" modal returned 200 yet was permanently invisible to `/api/investigations` and `/api/study/{slug}`.
- Found live on this deployment while trying to author a study to attach `analyses:` config to, for an sms-ecoli remote-dispatch roundtrip verification.

See vivarium-collective/vivarium-workbench#665 / release v0.3.21 for the full fix + regression test.

## Test plan
- [x] vivarium-workbench CI green on the fix PR (all suites + types + js)
- [ ] `kubectl set image` on `workbench` deployment in `sms-api-stanford`, poll readiness
- [ ] Verify via SSM tunnel `/workbench/health`
- [ ] Re-verify via real UI: "+ Study" modal creates a study that's actually visible afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)