### PR TITLE
deploy(stanford prod): workbench 0.3.21 -> 0.3.22 (session cookie staleness fix)

### DIFF
--- a/kustomize/overlays/sms-api-stanford/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford/kustomization.yaml
@@ -55,9 +55,17 @@ images:
   # honored only under investigations/<name>/). Every blank study created via
   # the "+ Study" modal returned 200 yet was permanently invisible to
   # /api/investigations and /api/study/{slug} — found live on this deployment
-  # while trying to author a study to attach analyses config to.
+  # while trying to author a study to attach analyses config to. 0.3.22
+  # (workbench #666) fixes a stale vw_session cookie: it was only ever set
+  # when absent, so a browser that already had a cookie from an earlier,
+  # different session never converged to a later bind — fetch() calls
+  # (session.js's X-VW-Session header) resolved correctly, but any plain
+  # navigation (iframe, typed URL) fell back to the stale cookie and
+  # silently loaded the wrong workspace. Found opening the study created
+  # while fixing 0.3.21: the JSON API returned it, but the UI still said
+  # "Study not found."
   - name: ghcr.io/vivarium-collective/vivarium-workbench
-    newTag: 0.3.21
+    newTag: 0.3.22
 
 replicas:
   - count: 1


### PR DESCRIPTION
## Summary
- Bumps the stanford overlay's vivarium-workbench image tag 0.3.21 -> 0.3.22.
- workbench v0.3.22 fixes a stale `vw_session` cookie: it was only ever set when absent, so a browser that already had a cookie from an earlier, different session never converged to a later bind. `fetch()` calls (which carry `session.js`'s `X-VW-Session` header) resolved correctly, but any plain navigation (`<iframe src>`, a typed URL) fell back to the stale cookie and silently loaded the wrong workspace.
- Found live on this deployment: after fixing the v0.3.21 study-create bug and creating a new study, the JSON API correctly returned it via `fetch()`, but opening it through the UI (embedded iframe / plain page load) still said "Study not found."

See vivarium-collective/vivarium-workbench#666 / release v0.3.22 for the full fix + regression tests.

## Test plan
- [x] vivarium-workbench CI green on the fix PR (all suites + types + js)
- [ ] `kubectl set image` on `workbench` deployment in `sms-api-stanford`, poll readiness
- [ ] Verify via SSM tunnel `/workbench/health`
- [ ] Re-verify via real UI: opening a study through the sidebar/porthole actually loads its content

🤖 Generated with [Claude Code](https://claude.com/claude-code)