### PR TITLE
deploy(stanford prod): workbench 0.3.22 -> 0.3.23 (analyses control moved to a reachable page)

### DIFF
--- a/kustomize/overlays/sms-api-stanford/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford/kustomization.yaml
@@ -63,9 +63,12 @@ images:
   # navigation (iframe, typed URL) fell back to the stale cookie and
   # silently loaded the wrong workspace. Found opening the study created
   # while fixing 0.3.21: the JSON API returned it, but the UI still said
-  # "Study not found."
+  # "Study not found." 0.3.23 (workbench #667) moves the study-analyses
+  # authoring control (from 0.3.20) off a legacy panel that no navigation
+  # path actually opened — dead UI — onto the Study page's Model tab,
+  # reachable for every study, grouped or ungrouped.
   - name: ghcr.io/vivarium-collective/vivarium-workbench
-    newTag: 0.3.22
+    newTag: 0.3.23
 
 replicas:
   - count: 1


### PR DESCRIPTION
## Summary
- Bumps the stanford overlay's vivarium-workbench image tag 0.3.22 -> 0.3.23.
- workbench v0.3.23 moves the "Analyses" study-authoring control off a legacy panel that no navigation path actually opened (dead UI, shipped in 0.3.20) onto the Study page's Model tab, reachable for every study, grouped or ungrouped.

See vivarium-collective/vivarium-workbench#667 / release v0.3.23 for the full fix + regression tests.

## Test plan
- [x] vivarium-workbench CI green on the fix PR (all suites + types + js)
- [ ] `kubectl set image` on `workbench` deployment in `sms-api-stanford`, poll readiness
- [ ] Verify via SSM tunnel `/workbench/health`
- [ ] Re-verify via real UI: the Study page's Model tab shows the Analyses textarea and saves successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)