### PR TITLE
deploy(stanford prod): workbench 0.3.23 -> 0.3.24 (restore baseline-composite replace UI)

### DIFF
--- a/kustomize/overlays/sms-api-stanford/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford/kustomization.yaml
@@ -66,9 +66,14 @@ images:
   # "Study not found." 0.3.23 (workbench #667) moves the study-analyses
   # authoring control (from 0.3.20) off a legacy panel that no navigation
   # path actually opened — dead UI — onto the Study page's Model tab,
-  # reachable for every study, grouped or ungrouped.
+  # reachable for every study, grouped or ungrouped. 0.3.24 (workbench #669)
+  # restores a UI path to set/replace a study's baseline composite ref —
+  # the pre-unification "+ Add baseline" form was removed from the template
+  # during the Model/Build panel merge, orphaning its JS handler and the
+  # study-baseline-add/-remove endpoints; there was no way to fix a
+  # "+ Study" blank scaffold's placeholder composite ref through the UI.
   - name: ghcr.io/vivarium-collective/vivarium-workbench
-    newTag: 0.3.23
+    newTag: 0.3.24
 
 replicas:
   - count: 1


### PR DESCRIPTION
## Summary
- Bumps the stanford overlay's vivarium-workbench image tag 0.3.23 -> 0.3.24.
- workbench v0.3.24 restores a UI path to set/replace a study's baseline composite — the pre-unification "+ Add baseline" form was removed from the template during the Model/Build panel merge, orphaning its JS handler and the study-baseline-add/-remove endpoints. There was no way to fix a "+ Study" blank scaffold's placeholder composite ref through the UI until now.

See vivarium-collective/vivarium-workbench#669 / release v0.3.24 for the full fix + regression test.

## Test plan
- [x] vivarium-workbench CI green on the fix PR (all suites + types + js)
- [ ] `kubectl set image` on `workbench` deployment in `sms-api-stanford`, poll readiness
- [ ] Verify via SSM tunnel `/workbench/health`
- [ ] Re-verify via real UI: set a real composite ref on the test study and dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)