### PR TITLE
deploy(stanford prod): workbench 0.3.24 -> 0.3.25 (fix baseline-composite replace ordering)

### DIFF
--- a/kustomize/overlays/sms-api-stanford/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford/kustomization.yaml
@@ -72,8 +72,13 @@ images:
   # during the Model/Build panel merge, orphaning its JS handler and the
   # study-baseline-add/-remove endpoints; there was no way to fix a
   # "+ Study" blank scaffold's placeholder composite ref through the UI.
+  # 0.3.25 (workbench #670) fixes the 0.3.24 control itself: it called
+  # remove-then-add, but study_baseline_remove refuses to leave baseline[]
+  # empty (400) — every single-entry study (any fresh blank scaffold) hit
+  # that guard on the first call. Now adds the replacement under a new name
+  # first, then removes the old one.
   - name: ghcr.io/vivarium-collective/vivarium-workbench
-    newTag: 0.3.24
+    newTag: 0.3.25
 
 replicas:
   - count: 1


### PR DESCRIPTION
## Summary
- Bumps the stanford overlay's vivarium-workbench image tag 0.3.24 -> 0.3.25.
- workbench v0.3.25 fixes the 0.3.24 "Set composite" control: it called remove-then-add, but study_baseline_remove refuses to leave baseline[] empty (400) — every single-entry study hit that guard on the first call. Now adds the replacement under a new name first, then removes the old one.

See vivarium-collective/vivarium-workbench#670 / release v0.3.25 for the full fix + regression test.

## Test plan
- [x] vivarium-workbench CI green on the fix PR (all suites + types + js)
- [ ] `kubectl set image` on `workbench` deployment in `sms-api-stanford`, poll readiness
- [ ] Verify via SSM tunnel `/workbench/health`
- [ ] Re-verify via real UI: set a real composite ref and dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)