### PR TITLE
deploy(stanford prod): workbench 0.3.25 -> 0.3.26 (switched-build git-remote fix)

### DIFF
--- a/kustomize/overlays/sms-api-stanford/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford/kustomization.yaml
@@ -76,9 +76,19 @@ images:
   # remove-then-add, but study_baseline_remove refuses to leave baseline[]
   # empty (400) — every single-entry study (any fresh blank scaffold) hit
   # that guard on the first call. Now adds the replacement under a new name
-  # first, then removes the old one.
+  # first, then removes the old one. 0.3.26 (workbench #671) fixes a
+  # switched/materialized sms-api build (switch_build()'s tarball
+  # extraction, deliberately not a git repo) never being able to dispatch:
+  # the non-pinned "Run on remote" push-based path requires a real git
+  # working copy with an origin remote. New ensure_git_workspace() makes
+  # every switched build push-ready (git init + remote add + a commit
+  # under a new workbench/sim<id>-<commit> branch) right at switch time,
+  # self-healing on every switch since build-cache lives on ephemeral pod
+  # storage. Also bumps the git-push timeout 120s -> 600s: a switched
+  # build's first push carries the whole materialized tree as one
+  # brand-new commit with no shared history with origin.
   - name: ghcr.io/vivarium-collective/vivarium-workbench
-    newTag: 0.3.25
+    newTag: 0.3.26
 
 replicas:
   - count: 1


### PR DESCRIPTION
## Summary

- Bumps the `vivarium-workbench` image tag on `sms-api-stanford` from 0.3.25 to 0.3.26.
- Ships vivarium-collective/vivarium-workbench#671: switched/materialized sms-api builds (e.g. an sms-ecoli pilot build bound via the workspace-switcher) were never real git repos, so the non-pinned "Run on remote" dispatch path always 409'd with "no GitHub remote configured." New `ensure_git_workspace()` makes every switched build push-ready at switch time. Also bumps the git-push timeout 120s -> 600s for the same first-push-is-a-full-tree-commit reason.

## Test plan

- [x] vivarium-workbench CI green on the source PR (vivarium-collective/vivarium-workbench#671) — full suite split 4 ways, types, JS all pass
- [x] `build-and-push.yml` succeeded for v0.3.26 (ghcr.io/vivarium-collective/vivarium-workbench:0.3.26 pushed)
- [ ] Surgical `kubectl set image` rollout on `workbench` in `sms-api-stanford`, poll pod readiness, verify health
- [ ] Live GovCloud dispatch retry against a switched sms-ecoli build

🤖 Generated with [Claude Code](https://claude.com/claude-code)