### PR TITLE
deploy(stanford prod): workbench 0.3.26 -> 0.3.27 (multi-seed landing fix)

### DIFF
--- a/kustomize/overlays/sms-api-stanford/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford/kustomization.yaml
@@ -86,9 +86,15 @@ images:
   # self-healing on every switch since build-cache lives on ephemeral pod
   # storage. Also bumps the git-push timeout 120s -> 600s: a switched
   # build's first push carries the whole materialized tree as one
-  # brand-new commit with no shared history with origin.
+  # brand-new commit with no shared history with origin. 0.3.27
+  # (workbench #674) fixes landing a multi-seed remote run: land_remote_run()
+  # defaulted seed=0 and no caller ever overrode it, so every multi-seed
+  # GovCloud run silently kept only its first seed on landing — found live
+  # backlog-verifying a real dispatch (S3 confirmed both seeds computed
+  # correctly and in parallel; only the local landing step dropped one).
+  # Now unions every seed_NN/store.zarr found in the tar into one destination.
   - name: ghcr.io/vivarium-collective/vivarium-workbench
-    newTag: 0.3.26
+    newTag: 0.3.27
 
 replicas:
   - count: 1


### PR DESCRIPTION
## Summary

- Bumps the `vivarium-workbench` image tag on `sms-api-stanford` from 0.3.26 to 0.3.27.
- Ships vivarium-collective/vivarium-workbench#674: `land_remote_run()` defaulted `seed=0` with no caller ever overriding it, so every multi-seed GovCloud run silently kept only its first seed when landed locally. Found live while backlog-verifying a real dispatch — S3 confirmed both seeds computed correctly in parallel; only the landing step dropped one. Now unions every `seed_NN/store.zarr` found in the tar.

## Test plan

- [x] vivarium-workbench CI green on the source PR (#674) — 5/5 new+existing landing tests, 67/67 across the broader suite
- [x] `build-and-push.yml` succeeded for v0.3.27
- [ ] Surgical `kubectl set image` rollout on `workbench` in `sms-api-stanford`, poll pod readiness, verify health

🤖 Generated with [Claude Code](https://claude.com/claude-code)