### PR TITLE
Route to real multi-generation dispatch when generations > 1

### DIFF
--- a/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: sms-api-stanford-test
 
 images:
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.9.28
+    newTag: 0.9.29
   # ptools pinned to last-known-good tag — CI only builds sms-api, so there is
   # no newer sms-ptools:0.6.x image on ghcr.io.  0.5.9 is the tag the live Stanford
   # pod has been running successfully; keeping both namespaces pointing here

--- a/kustomize/overlays/sms-api-stanford/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford/kustomization.yaml
@@ -14,8 +14,12 @@ images:
   # this pipeline (confirmed live via ImagePullBackOff) -- the 14th-bug fix.
   # Also fixes a K8s job-name collision on repeat analysis triggers and wires
   # real DB-tracked status (GET /analyses/{id}/status) for these jobs.
+  # 0.9.29: routes to a real multi-generation LineageProcess/batch_baseline_runner
+  # dispatch (scripts/run_batch_baseline_ray.py) when a simulation requests
+  # generations > 1 -- the default single-generation script silently ignored
+  # this entirely. First real dispatch of this pipeline on any infrastructure.
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.9.28
+    newTag: 0.9.29
   # ptools pinned to last-known-good tag — CI only builds sms-api, so there is
   # no newer sms-ptools:0.6.x image on ghcr.io.  0.5.9 is the tag the live Stanford
   # pod has been running successfully; keeping both namespaces pointing here

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sms_api"
-version = "0.9.28"
+version = "0.9.29"
 description = "This is the api server for Vivarium simulation services."
 authors = [{ name = "Alex Patrie", email = "alexanderpatrie@gmail.com" }, { name = "Jim Schaff", email = "jschaff@gmail.com" }]
 requires-python = ">=3.13,<3.14"

--- a/sms_api/simulation/simulation_service_ray.py
+++ b/sms_api/simulation/simulation_service_ray.py
@@ -295,11 +295,14 @@ class SimulationServiceRay(SimulationService):
         condition: str | None = None,
         max_generations: int | None = None,
         vecoli_source: VecoliSource | None = None,
+        n_generations: int = 1,
     ) -> str:
         # When ``composite`` is set, run the two-engine comparison driver — both
         # engines (v2ecoli port + vEcoli imported via build_composite_native)
         # as bigraph composites on Ray, emitting only the compact XArray view →
-        # zarr/S3. Otherwise the original phase0 single-generation ensemble.
+        # zarr/S3. Otherwise: single-generation phase0 by default, or the real
+        # multi-generation LineageProcess/batch_baseline_runner pipeline when
+        # the caller actually requested more than one generation.
         #
         # Engine selection is decoupled from generation count: ``max_generations``
         # defaults to 1 (the phase0 single-gen baseline), so picking an engine
@@ -317,6 +320,14 @@ class SimulationServiceRay(SimulationService):
                 f" --composite {composite} --condition {condition or 'basal'}"
                 f" --n-seeds {n_seeds} --max-generations {int(max_generations or 1)}"
                 f" --chunk {chunk} --out-root {SIM_OUT_DIR} --mode ray{src}"
+            )
+        if int(n_generations) > 1:
+            # Real multi-generation lineage (cell division across generations) --
+            # scripts/run_phase0_xarray_ensemble.py below silently ignores this
+            # entirely and only ever runs one generation per seed.
+            return (
+                f"cd {V2ECOLI_DIR} && python scripts/run_batch_baseline_ray.py"
+                f" --n-seeds {n_seeds} --n-generations {int(n_generations)}"
             )
         return (
             f"cd {V2ECOLI_DIR} && python scripts/run_phase0_xarray_ensemble.py"
@@ -452,6 +463,10 @@ bash docker/build-and-push-ecr.sh -i {commit} -r {settings.ray_ecr_repository} -
         condition = getattr(config, "condition", None)
         max_generations = getattr(config, "max_generations", None)
         vecoli_source = getattr(config, "vecoli_source", None)
+        # config.generations is a real (non-"extra") SimulationConfig field, unlike
+        # the comparison knobs above -- read directly, not via getattr. Only the
+        # non-composite path branches on it (see _sim_command).
+        n_generations = int(config.generations or 1)
 
         # Engine-specific ParCa source: the pristine upstream wrapper (--composite
         # vecoli) stages an UPSTREAM-built simData (separate cache + build cmd);
@@ -497,6 +512,7 @@ bash docker/build-and-push-ecr.sh -i {commit} -r {settings.ray_ecr_repository} -
                 condition=condition,
                 max_generations=max_generations,
                 vecoli_source=vecoli_source,
+                n_generations=n_generations,
             ),
             out_s3=self._results_s3_uri(experiment_id),
             out_dir=SIM_OUT_DIR,

--- a/sms_api/version.py
+++ b/sms_api/version.py
@@ -112,4 +112,4 @@
 #          stuck at QUEUED forever even after the Batch job SUCCEEDED and results
 #          landed in S3. Now polls every NON-TERMINAL state so a job traverses
 #          queued->running->completed. Found by the same stanford-test smoke test.
-__version__ = "0.9.28"
+__version__ = "0.9.29"

--- a/tests/simulation/test_ray_backend.py
+++ b/tests/simulation/test_ray_backend.py
@@ -217,6 +217,38 @@ class TestSimulationServiceRaySubmit:
         reg_images = {nr["container"]["image"] for nr in reg.kwargs["nodeProperties"]["nodeRangeProperties"]}
         assert reg_images == {f"476270107793.dkr.ecr.us-gov-west-1.amazonaws.com/v2ecoli:{commit}"}
 
+    async def test_submit_routes_to_batch_baseline_when_generations_requested(
+        self,
+        experiment_request: "SimulationRequest",
+        database_service: "DatabaseServiceSQL",
+    ) -> None:
+        """config.generations > 1 (a real SimulationConfig field, not an "extra"
+        comparison knob) must reach the sim job's command -- previously dropped
+        entirely, so every GovCloud dispatch silently ran one generation only
+        regardless of what was requested."""
+        setattr(experiment_request.config, "n_init_sims", 2)  # noqa: B010
+        experiment_request.config.generations = 3
+        simulation = await database_service.insert_simulation(sim_request=experiment_request)
+
+        mock_batch = _fake_batch(["parca-123", "sim-456"])
+
+        service = SimulationServiceRay()
+        with (
+            patch("sms_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("sms_api.common.storage.data_layout.get_settings", _ray_settings),
+            patch("sms_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
+        ):
+            await service.submit_ecoli_simulation_job(
+                ecoli_simulation=simulation, database_service=database_service, correlation_id="corr-2"
+            )
+
+        _, sim_call = mock_batch.submit_job.call_args_list
+        sim_env = _env_of(sim_call)
+        assert "run_batch_baseline_ray.py" in sim_env["RAY_JOB_CMD"]
+        assert "--n-seeds 2" in sim_env["RAY_JOB_CMD"]
+        assert "--n-generations 3" in sim_env["RAY_JOB_CMD"]
+        assert "run_phase0_xarray_ensemble.py" not in sim_env["RAY_JOB_CMD"]
+
 
 @pytest.mark.asyncio
 class TestSimulationServiceRayStatusCancel:
@@ -303,6 +335,36 @@ class TestSimulationServiceRayBuild:
         with patch("sms_api.simulation.simulation_service_ray.get_settings", _ray_settings):
             cmd = service._sim_command(n_seeds=1, n_steps=10, chunk=4, composite="v2ecoli", max_generations=5)
         assert "--max-generations 5" in cmd
+
+    def test_sim_command_defaults_to_single_generation_phase0(self) -> None:
+        """No composite, no generations requested: unchanged, verified-working
+        single-generation dispatch -- must not regress by default."""
+        service = SimulationServiceRay()
+        with patch("sms_api.simulation.simulation_service_ray.get_settings", _ray_settings):
+            cmd = service._sim_command(n_seeds=2, n_steps=600, chunk=60)
+        assert "run_phase0_xarray_ensemble.py" in cmd
+        assert "run_batch_baseline_ray.py" not in cmd
+
+    def test_sim_command_routes_to_batch_baseline_when_multi_generation_requested(self) -> None:
+        """config.generations > 1 must route to the real multi-generation
+        LineageProcess/batch_baseline_runner pipeline, not the single-generation
+        script that silently ignores generation count."""
+        service = SimulationServiceRay()
+        with patch("sms_api.simulation.simulation_service_ray.get_settings", _ray_settings):
+            cmd = service._sim_command(n_seeds=2, n_steps=600, chunk=60, n_generations=3)
+        assert "run_batch_baseline_ray.py" in cmd
+        assert "--n-seeds 2" in cmd
+        assert "--n-generations 3" in cmd
+        assert "run_phase0_xarray_ensemble.py" not in cmd
+
+    def test_sim_command_composite_takes_precedence_over_n_generations(self) -> None:
+        """The comparison driver's own --max-generations flag is a separate knob
+        from plain n_generations -- composite selection wins regardless."""
+        service = SimulationServiceRay()
+        with patch("sms_api.simulation.simulation_service_ray.get_settings", _ray_settings):
+            cmd = service._sim_command(n_seeds=1, n_steps=10, chunk=4, composite="v2ecoli", n_generations=3)
+        assert "run_comparison_ensemble.py" in cmd
+        assert "run_batch_baseline_ray.py" not in cmd
 
     def test_sim_command_vecoli_source_only_appended_for_upstream_vecoli(self) -> None:
         """--vecoli-source is meaningful only for --composite vecoli."""


### PR DESCRIPTION
Stacked on #201 (merge that first).

## Summary
- `config.generations` was read nowhere in the default GovCloud dispatch path — every simulation ran the single-generation script regardless of what was requested
- `_sim_command` now branches: composite selection still wins; otherwise `n_generations > 1` routes to the new `scripts/run_batch_baseline_ray.py` (v2ecoli#428/sms-ecoli#26), wrapping v2ecoli's real LineageProcess/batch_baseline_runner pipeline
- `n_generations == 1` (the default) is byte-identical dispatch to before — must not regress the now-verified-working single-gen path
- **This is the first real dispatch of this pipeline on any infrastructure** — previously only unit-tested against a stubbed `run_workflow`. Real end-to-end validation is the actual proof this works, not yet done

## Test plan
- [x] `uv run pytest tests/simulation/test_ray_backend.py -q` (sim_command tests) — 6/6 pass; full-suite DB tests blocked locally by no Docker (same pre-existing gap as #201)
- [x] `make check` — fully green
- [ ] CI green
- [ ] **Real GovCloud dispatch** — the actual validation this pipeline works at all (follow-up, in progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)