### PR TITLE
Re-pin workbench remote-run dispatch to sms-ecoli

### DIFF
--- a/kustomize/base/workbench/workbench.yaml
+++ b/kustomize/base/workbench/workbench.yaml
@@ -170,7 +170,7 @@ spec:
             - name: VIVARIUM_WORKBENCH_REMOTE_PINNED
               value: "1"
             - name: VIVARIUM_WORKBENCH_REMOTE_REPO_URL
-              value: "https://github.com/vivarium-collective/v2ecoli"
+              value: "https://github.com/CovertLabEcoli/sms-ecoli"
             - name: VIVARIUM_WORKBENCH_REMOTE_BRANCH
               value: "main"
             # The init container's chown only runs on FIRST seed (it's guarded by


### PR DESCRIPTION
## Summary
- `VIVARIUM_WORKBENCH_REMOTE_REPO_URL` was hardcoded to `vivarium-collective/v2ecoli`
- The Studies tab's "Run on remote (pinned)" panel resolves the latest build for this repo via sms-api, so it silently targeted v2ecoli's latest build regardless of which workspace was switched in — discovered live tonight while trying to dispatch against sms-ecoli
- A prior session worked around this live via `kubectl set env VIVARIUM_WORKBENCH_REMOTE_PINNED=0` (vivarium-workbench SAVE_SLOT.md item 13b/17), but that doesn't survive a declarative `kubectl apply -k`, which silently re-pins to the wrong repo again
- Fixed at the source: point the pin at `CovertLabEcoli/sms-ecoli`, matching this deployment's actual standing mission

## Test plan
- [x] Single-line kustomize env var change, no code/tests affected
- [ ] `kubectl apply -k` + verify the pinned-build panel now shows `sms-ecoli @ <latest commit>` instead of v2ecoli's

🤖 Generated with [Claude Code](https://claude.com/claude-code)