### PR TITLE
fix(deploy): V2ECOLI_SIM_DATA env var for standalone-analysis K8s jobs (gap #1, ported to real deploy trunk)

### DIFF
--- a/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-test/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: sms-api-stanford-test
 
 images:
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.9.29
+    newTag: 0.9.30
   # ptools pinned to last-known-good tag — CI only builds sms-api, so there is
   # no newer sms-ptools:0.6.x image on ghcr.io.  0.5.9 is the tag the live Stanford
   # pod has been running successfully; keeping both namespaces pointing here

--- a/kustomize/overlays/sms-api-stanford/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford/kustomization.yaml
@@ -18,8 +18,11 @@ images:
   # dispatch (scripts/run_batch_baseline_ray.py) when a simulation requests
   # generations > 1 -- the default single-generation script silently ignored
   # this entirely. First real dispatch of this pipeline on any infrastructure.
+  # 0.9.30: sets V2ECOLI_SIM_DATA on submit_ray_native_analysis()'s K8s Job spec
+  # (gap #1) so the DuckDB/cd1 analysis suite can resolve sim_data for an S3
+  # sweep -- required for the cd1 (base/vio/mec) reproduction via sms-ecoli.
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.9.29
+    newTag: 0.9.30
   # ptools pinned to last-known-good tag — CI only builds sms-api, so there is
   # no newer sms-ptools:0.6.x image on ghcr.io.  0.5.9 is the tag the live Stanford
   # pod has been running successfully; keeping both namespaces pointing here

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sms_api"
-version = "0.9.29"
+version = "0.9.30"
 description = "This is the api server for Vivarium simulation services."
 authors = [{ name = "Alex Patrie", email = "alexanderpatrie@gmail.com" }, { name = "Jim Schaff", email = "jschaff@gmail.com" }]
 requires-python = ">=3.13,<3.14"

--- a/sms_api/simulation/simulation_service_k8s.py
+++ b/sms_api/simulation/simulation_service_k8s.py
@@ -16,6 +16,7 @@ from sms_api.common.hpc.k8s_job_service import K8sJobService
 from sms_api.common.hpc.local_task_service import LocalTaskService
 from sms_api.common.models import JobBackend, JobId
 from sms_api.common.simulator_defaults import DEFAULT_BRANCH, DEFAULT_REPO
+from sms_api.common.storage import data_layout
 from sms_api.config import get_settings
 from sms_api.simulation import batch_build
 from sms_api.simulation.database_service import DatabaseService
@@ -476,6 +477,17 @@ echo "Submit image pushed: $ECR_REGISTRY/{settings.ecr_repository}:{image_tag}-s
                                     k8s_client.V1EnvVar(name="AWS_REGION", value=settings.batch_region),
                                     k8s_client.V1EnvVar(name="AWS_STS_REGIONAL_ENDPOINTS", value="regional"),
                                     k8s_client.V1EnvVar(name="USER", value="sms-api"),
+                                    # Lets run_standalone_analysis.py's DuckDB/cd1 analyses
+                                    # (v2ecoli.workflow.analysis.Analysis subclasses) resolve
+                                    # sim_data without a sweep-local pickle -- an S3 sweep has
+                                    # none to glob (analysis_runner.resolve_sim_data only globs
+                                    # local paths). The ParCa job and this analysis job derive
+                                    # the same commit-keyed cache URI independently, so this
+                                    # needs no new hand-off plumbing.
+                                    k8s_client.V1EnvVar(
+                                        name="V2ECOLI_SIM_DATA",
+                                        value=f"{data_layout.RayLayout.parca_cache_uri(commit)}simData.cPickle",
+                                    ),
                                 ],
                                 volume_mounts=[
                                     k8s_client.V1VolumeMount(name="config", mount_path="/config"),

--- a/sms_api/version.py
+++ b/sms_api/version.py
@@ -112,4 +112,10 @@
 #          stuck at QUEUED forever even after the Batch job SUCCEEDED and results
 #          landed in S3. Now polls every NON-TERMINAL state so a job traverses
 #          queued->running->completed. Found by the same stanford-test smoke test.
-__version__ = "0.9.29"
+# 0.9.30 — set V2ECOLI_SIM_DATA on submit_ray_native_analysis()'s K8s Job spec
+#          (gap #1) so the DuckDB/cd1 analysis suite can resolve sim_data for an
+#          S3 sweep (resolve_sim_data only globs a co-located pickle for LOCAL
+#          sweep paths). Closes the deploy gap on this branch specifically —
+#          main already had this fix (PR #207); this branch (the real Stanford
+#          deploy trunk) did not.
+__version__ = "0.9.30"

--- a/tests/simulation/test_k8s_backend.py
+++ b/tests/simulation/test_k8s_backend.py
@@ -543,6 +543,38 @@ class TestSimulationServiceK8s:
         written_params = json.loads(configmap_arg.data["params.json"])
         assert written_params == params
 
+    async def test_submit_ray_native_analysis_sets_sim_data_env_for_duckdb_analyses(
+        self,
+        simulation_service_k8s_mock: SimulationServiceK8s,
+        mock_k8s_job_service: MagicMock,
+    ) -> None:
+        """An S3 sweep has no co-located sim_data pickle to glob (analysis_runner
+        .resolve_sim_data only globs local paths), so the DuckDB-based Analysis
+        family (cd1/ptools) can't resolve sim_data without this env var. The
+        ParCa job and this analysis job derive the same commit-keyed cache URI
+        independently -- no new hand-off plumbing needed."""
+        from sms_api.common.storage import data_layout
+
+        params = {
+            "out_uri": "s3://bucket/vecoli-output/exp123",
+            "n_seeds": 1,
+            "modules": {"single": {"ptools_rna": {}}},
+            "analysis_name": "analysis-exp123-cd1",
+        }
+
+        await simulation_service_k8s_mock.submit_ray_native_analysis(
+            experiment_id="exp123",
+            params=params,
+            commit="deadbeef",
+        )
+
+        job_arg = mock_k8s_job_service.create_job.call_args[0][0]
+        container = job_arg.spec.template.spec.containers[0]
+        env_by_name = {e.name: e.value for e in container.env}
+        assert env_by_name["V2ECOLI_SIM_DATA"] == (
+            f"{data_layout.RayLayout.parca_cache_uri('deadbeef')}simData.cPickle"
+        )
+
     async def test_submit_ray_native_analysis_job_name_unique_per_trigger(
         self,
         simulation_service_k8s_mock: SimulationServiceK8s,


### PR DESCRIPTION
## Summary
- Ports gap #1's fix (already on `main` via #207/`ddcfc3b5`) onto `feat/multi-generation-dispatch`, which is the **actual** Stanford prod deploy trunk — it diverged from `main` before #207 landed and was never merged forward.
- `submit_ray_native_analysis()`'s K8s Job spec now sets `V2ECOLI_SIM_DATA` to the commit-keyed ParCa cache's `simData.cPickle`, so the DuckDB-based cd1/ptools analysis suite can resolve sim_data against an S3 sweep (`resolve_sim_data` only globs a co-located pickle for LOCAL sweep paths).
- Ported as an isolated 2-line diff (import + one env var), not a cherry-pick of the full squashed `ddcfc3b5` commit — that commit bundles ~190 unrelated files from the `sms_api`→`viva_api` rename, which this branch hasn't taken and shouldn't for this fix.
- Adds the one missing test from #207 (`test_submit_ray_native_analysis_sets_sim_data_env_for_duckdb_analyses`); the sibling test already existed on this branch.
- Bumps `sms-api` 0.9.29 → 0.9.30 in the `sms-api-stanford` and `sms-api-stanford-test` kustomize overlays.

## Why
Needed to reproduce the cd1 (base/vio/mec) datasets via sms-ecoli on GovCloud — without this, a completed baseline sweep has no way to actually produce the cd1 DuckDB analyses.

## Test plan
- [x] `uv run pytest tests/simulation/test_k8s_backend.py -q` — 34 passed (2 pre-existing docker/testcontainers errors, no local Docker daemon — same as prior sessions)
- [x] `ruff check` / `ruff format --check` clean under both the repo's uv-managed ruff and the pre-commit-pinned `v0.11.5`
- [x] `mypy` clean
- [ ] Deploy to Stanford prod + verify live (next step after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)