### PR TITLE
fix: Ray-native standalone analysis config missing analysis_options (v0.9.31)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "viva_api"
-version = "0.9.29"
+version = "0.9.31"
 description = "This is the api server for Vivarium simulation services."
 authors = [{ name = "Alex Patrie", email = "alexanderpatrie@gmail.com" }, { name = "Jim Schaff", email = "jschaff@gmail.com" }]
 requires-python = ">=3.13,<3.14"

--- a/tests/common/handlers/test_simulations_handler.py
+++ b/tests/common/handlers/test_simulations_handler.py
@@ -26,6 +26,7 @@ from viva_api.config import get_settings
 from viva_api.dependencies import get_file_service, set_file_service
 from viva_api.simulation.models import Simulation, SimulationConfig, SimulatorVersion
 from viva_api.simulation.simulation_service_k8s import SimulationServiceK8s
+from viva_api.simulation.tables_orm import ORMAnalysis
 
 
 @pytest.mark.integration
@@ -299,6 +300,14 @@ async def test_run_standalone_analysis_ray_native_routes_to_v2ecoli_job() -> Non
     assert call_kwargs["params"]["out_uri"] == "s3://bucket/vecoli-output/exp123"
     assert call_kwargs["params"]["n_seeds"] == 2
     assert call_kwargs["params"]["modules"] == {"multiseed": {"doubling_time_distribution": {}}}
+    # regression: ORMAnalysis.to_dto() unconditionally reads config["analysis_options"]
+    # (AnalysisConfigOptions requires experiment_id) -- this producer must write that
+    # shape too, matching the legacy Batch/SLURM producers in run_standalone_analysis(),
+    # or GET /analyses/{id} 500s with a raw KeyError for every Ray-native analysis.
+    assert call_kwargs["params"]["analysis_options"] == {
+        "experiment_id": ["exp123"],
+        "multiseed": {"doubling_time_distribution": {}},
+    }
     assert result["config"] == call_kwargs["params"]
     assert result["database_id"] == 42
 
@@ -309,6 +318,18 @@ async def test_run_standalone_analysis_ray_native_routes_to_v2ecoli_job() -> Non
     assert record_kwargs["backend"] == "ray"
     assert record_kwargs["job_id_ext"] == "ana-exp123"
     assert record_kwargs["result_uri"].startswith("s3://bucket/vecoli-output/exp123/analyses/")
+    # The actual reported bug: to_dto() must not raise on this producer's config shape.
+    orm_row = ORMAnalysis(
+        id=42,
+        name="ana-exp123",
+        config=call_kwargs["params"],
+        last_updated=datetime.now(UTC).isoformat(),
+        experiment_id="exp123",
+        simulation_id=115,
+        backend="ray",
+    )
+    dto = orm_row.to_dto()
+    assert dto.config.analysis_options.experiment_id == ["exp123"]
 
 
 @pytest.mark.asyncio

--- a/viva_api/common/handlers/simulations.py
+++ b/viva_api/common/handlers/simulations.py
@@ -1501,6 +1501,14 @@ async def _run_standalone_analysis_ray_native(
         "n_seeds": n_seeds,
         "modules": modules,
         "analysis_name": analysis_name,
+        # ORMAnalysis.to_dto() unconditionally reads config["analysis_options"]
+        # (AnalysisConfigOptions requires experiment_id) -- the legacy Batch/SLURM
+        # producers below already write this shape (experiment_id + each domain
+        # spread as a top-level key); match it so to_dto() doesn't KeyError. The
+        # v2ecoli-side consumer (run_standalone_analysis.py) only reads out_uri/
+        # n_seeds/modules/analysis_name and ignores unknown keys, so this is inert
+        # for it -- purely for the DTO contract.
+        "analysis_options": {"experiment_id": [experiment_id], **modules},
     }
     job_id = await sim_service.submit_ray_native_analysis(
         experiment_id=experiment_id,

--- a/viva_api/version.py
+++ b/viva_api/version.py
@@ -112,4 +112,17 @@
 #          stuck at QUEUED forever even after the Batch job SUCCEEDED and results
 #          landed in S3. Now polls every NON-TERMINAL state so a job traverses
 #          queued->running->completed. Found by the same stanford-test smoke test.
-__version__ = "0.9.29"
+# 0.9.30 — skipped here on purpose: already used (untagged) on the deploy trunk
+#          (feat/multi-generation-dispatch, the branch actually live on
+#          sms-api-stanford prod, diverged from main by the sms_api->viva_api
+#          rename). Not retroactively reconciled onto main today - see
+#          backlog/memory "viva-api deploy-trunk reconciliation debt". Skipping
+#          the number here avoids two different tags/releases both claiming 0.9.30.
+# 0.9.31 — fix: Ray-native standalone analysis (_run_standalone_analysis_ray_native)
+#          never wrote config["analysis_options"], which ORMAnalysis.to_dto()
+#          unconditionally reads (AnalysisConfigOptions requires experiment_id) -
+#          every GET /analyses/{id} for a Ray-native analysis 500'd with a raw
+#          KeyError. Fixed to match the shape the legacy Batch/SLURM producers
+#          already write (experiment_id + each analysis domain spread as a
+#          top-level key).
+__version__ = "0.9.31"


### PR DESCRIPTION
## Summary
- `atlantis simulation analysis <id>` (the standalone-analysis endpoint) 500s unconditionally with a raw `{"detail":"'analysis_options'"}` `KeyError`, reproduced whether or not a custom `--modules` JSON is passed.
- Root cause: `ORMAnalysis.to_dto()` (`viva_api/simulation/tables_orm.py:262`) unconditionally does `AnalysisConfigOptions(**self.config["analysis_options"])` — `AnalysisConfigOptions` requires `experiment_id`. The legacy Batch/SLURM producers in `run_standalone_analysis()` already write this exact shape (`experiment_id` + each analysis domain spread as a top-level key), but `_run_standalone_analysis_ray_native`'s `params` dict never included an `analysis_options` key at all — a schema mismatch between one producer and the one hardcoded reader.
- Fix matches the existing shape rather than inventing a new one: `params["analysis_options"] = {"experiment_id": [experiment_id], **modules}`. Confirmed inert for the v2ecoli-side consumer (`scripts/run_standalone_analysis.py`), which only reads `out_uri`/`n_seeds`/`modules`/`analysis_name` and ignores unknown keys.

**Scope note**: also investigated whether `simulation run --analysis-options` should execute inline for the Ray/MNP dispatch path (it currently doesn't — `simulation_service_ray.py` never reads that field). This turned out to be intentional, not a bug: `run_batch_baseline_ray.py`'s own comments confirm analysis is deliberately deferred to this separate standalone-analysis call (`analyses="none"` at dispatch time), matching this repo's own documented EUTE workflow (step 7 in `CLAUDE.md` — analysis is an optional, separate POST after simulation completes). No change needed there.

## Test plan
- [x] New regression test asserting `params["analysis_options"]` has the right shape (`test_run_standalone_analysis_ray_native_routes_to_v2ecoli_job`)
- [x] New regression test constructing a real `ORMAnalysis` row with this producer's exact config shape and calling `.to_dto()` — reproduces the original bug (would `KeyError` before the fix) and confirms it's fixed
- [x] Full `tests/simulation/` + `tests/common/handlers/` pass (176 passed; 15 errors are pre-existing local-Docker-unavailable testcontainers failures, unrelated to this change)
- [x] `ruff check` + `ruff format --check` clean on both touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)