### PR TITLE
fix: Ray-native standalone analysis config missing analysis_options — deploy trunk (v0.9.32)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sms_api"
-version = "0.9.30"
+version = "0.9.32"
 description = "This is the api server for Vivarium simulation services."
 authors = [{ name = "Alex Patrie", email = "alexanderpatrie@gmail.com" }, { name = "Jim Schaff", email = "jschaff@gmail.com" }]
 requires-python = ">=3.13,<3.14"

--- a/sms_api/common/handlers/simulations.py
+++ b/sms_api/common/handlers/simulations.py
@@ -1501,6 +1501,14 @@ async def _run_standalone_analysis_ray_native(
         "n_seeds": n_seeds,
         "modules": modules,
         "analysis_name": analysis_name,
+        # ORMAnalysis.to_dto() unconditionally reads config["analysis_options"]
+        # (AnalysisConfigOptions requires experiment_id) -- the legacy Batch/SLURM
+        # producers below already write this shape (experiment_id + each domain
+        # spread as a top-level key); match it so to_dto() doesn't KeyError. The
+        # v2ecoli-side consumer (run_standalone_analysis.py) only reads out_uri/
+        # n_seeds/modules/analysis_name and ignores unknown keys, so this is inert
+        # for it -- purely for the DTO contract.
+        "analysis_options": {"experiment_id": [experiment_id], **modules},
     }
     job_id = await sim_service.submit_ray_native_analysis(
         experiment_id=experiment_id,

--- a/sms_api/version.py
+++ b/sms_api/version.py
@@ -118,4 +118,14 @@
 #          sweep paths). Closes the deploy gap on this branch specifically —
 #          main already had this fix (PR #207); this branch (the real Stanford
 #          deploy trunk) did not.
-__version__ = "0.9.30"
+# 0.9.31 — skipped here on purpose: used on `main` for the same underlying fix
+#          (cherry-picked onto this branch instead of merging main's full
+#          sms_api->viva_api rename). Skipping avoids two different tags/
+#          releases both claiming 0.9.31 for genuinely different commits.
+# 0.9.32 — fix: Ray-native standalone analysis config missing analysis_options
+#          (cherry-pick of main's 0.9.31 fix onto this deploy trunk — see that
+#          release's notes for the full root cause). ORMAnalysis.to_dto() was
+#          unconditionally reading config["analysis_options"], which this
+#          producer never wrote, so GET /analyses/{id} 500'd for every
+#          Ray-native analysis.
+__version__ = "0.9.32"

--- a/tests/common/handlers/test_simulations_handler.py
+++ b/tests/common/handlers/test_simulations_handler.py
@@ -26,6 +26,7 @@ from sms_api.config import get_settings
 from sms_api.dependencies import get_file_service, set_file_service
 from sms_api.simulation.models import Simulation, SimulationConfig, SimulatorVersion
 from sms_api.simulation.simulation_service_k8s import SimulationServiceK8s
+from sms_api.simulation.tables_orm import ORMAnalysis
 
 
 @pytest.mark.integration
@@ -299,6 +300,14 @@ async def test_run_standalone_analysis_ray_native_routes_to_v2ecoli_job() -> Non
     assert call_kwargs["params"]["out_uri"] == "s3://bucket/vecoli-output/exp123"
     assert call_kwargs["params"]["n_seeds"] == 2
     assert call_kwargs["params"]["modules"] == {"multiseed": {"doubling_time_distribution": {}}}
+    # regression: ORMAnalysis.to_dto() unconditionally reads config["analysis_options"]
+    # (AnalysisConfigOptions requires experiment_id) -- this producer must write that
+    # shape too, matching the legacy Batch/SLURM producers in run_standalone_analysis(),
+    # or GET /analyses/{id} 500s with a raw KeyError for every Ray-native analysis.
+    assert call_kwargs["params"]["analysis_options"] == {
+        "experiment_id": ["exp123"],
+        "multiseed": {"doubling_time_distribution": {}},
+    }
     assert result["config"] == call_kwargs["params"]
     assert result["database_id"] == 42
 
@@ -309,6 +318,18 @@ async def test_run_standalone_analysis_ray_native_routes_to_v2ecoli_job() -> Non
     assert record_kwargs["backend"] == "ray"
     assert record_kwargs["job_id_ext"] == "ana-exp123"
     assert record_kwargs["result_uri"].startswith("s3://bucket/vecoli-output/exp123/analyses/")
+    # The actual reported bug: to_dto() must not raise on this producer's config shape.
+    orm_row = ORMAnalysis(
+        id=42,
+        name="ana-exp123",
+        config=call_kwargs["params"],
+        last_updated=datetime.now(UTC).isoformat(),
+        experiment_id="exp123",
+        simulation_id=115,
+        backend="ray",
+    )
+    dto = orm_row.to_dto()
+    assert dto.config.analysis_options.experiment_id == ["exp123"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Cherry-pick of #211 onto the real prod deploy trunk (`feat/multi-generation-dispatch`), not `main`. Deliberately NOT a merge/rebase of main's `sms_api`->`viva_api` rename onto this branch — that reconciliation is real, necessary work, but is its own separate, larger, scoped task (tracked separately), not something to bundle into an unrelated bug fix under time pressure. This PR is intentionally minimal: exactly the one fix commit, nothing else.

See #211 for the full root-cause writeup — same fix, same tests, same reasoning. This PR exists only because `feat/multi-generation-dispatch` (confirmed via live `kubectl` image tag match, not assumption) is what's actually deployed to `sms-api-stanford` prod, and `main` is not.

## Test plan
- [x] Same two regression tests as #211, passing on this branch's own (pre-rename) `sms_api.*` module layout
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)