### PR TITLE
deploy(stanford prod): workbench 0.3.29 -> 0.3.32

### DIFF
--- a/kustomize/overlays/sms-api-stanford/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford/kustomization.yaml
@@ -120,8 +120,13 @@ images:
   # drifted from the real deployed state; re-syncing it now closes that gap
   # (a plain `kubectl apply` of the stale 0.3.28 pin would otherwise silently
   # roll the live workbench pod backward on the next unrelated deploy).
+  # 0.3.32 (workbench #744): materialize_session_build preserves symlinks
+  # instead of dereferencing them -- a dangling symlink anywhere in a
+  # switched build's shared base (sms-ecoli's) was crashing every session
+  # switch to it. Supersedes 0.3.30/0.3.31, deployed surgically without a
+  # matching bump here at the time -- same drift pattern as 0.3.29 above.
   - name: ghcr.io/vivarium-collective/vivarium-workbench
-    newTag: 0.3.29
+    newTag: 0.3.32
 
 replicas:
   - count: 1


### PR DESCRIPTION
## Summary
- Bumps the pinned workbench image tag to 0.3.32 (vivarium-workbench#744 — fixes `materialize_session_build` crashing on any dangling symlink in a switched build's shared base, live-reproduced against sms-ecoli build #55).
- Also re-syncs this file's own drift: it was pinned at 0.3.29 while prod was already running 0.3.30 from a prior surgical deploy that never got a matching bump — same pattern the 0.3.29 comment above already documents once.

## Test plan
- [x] Single-line `newTag` change (plus a history comment matching the file's existing style) — no code path affected, nothing to unit test.
- [ ] Deploy surgically (`kubectl set image`, not `kubectl apply -k`, per this file's own documented gotcha) and verify the live pod after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)