### PR TITLE
fix: default ptools_* analysis modules use scale=single, not multiseed

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -461,7 +461,7 @@ def simulation_run(
     ),
     analysis_options: str | None = Option(
         default=None,
-        help='JSON string of vEcoli analysis module config. E.g. \'{"multiseed": {"ptools_rna": {"n_tp": 10}}}\'.'
+        help='JSON string of vEcoli analysis module config. E.g. \'{"single": {"ptools_rna": {"n_tp": 10}}}\'.'
         " Keys are analysis categories (single, multiseed, multigeneration, etc.);"
         " values map module names to params. If omitted, defaults depend on the simulator repo.",
     ),
@@ -771,7 +771,7 @@ def simulation_analysis(
     simulation_id: int = Argument(help="Simulation database ID (must be completed)."),
     modules: str | None = Option(
         default=None,
-        help='JSON string of analysis modules. E.g. \'{"multiseed": {"ptools_rna": {"n_tp": 10}}}\'.'
+        help='JSON string of analysis modules. E.g. \'{"single": {"ptools_rna": {"n_tp": 10}}}\'.'
         " If omitted, runs default ptools modules.",
     ),
     base_url: ApiBaseUrl = Option(default=API_BASE_URL, help="API server base URL."),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sms_api"
-version = "0.9.32"
+version = "0.9.33"
 description = "This is the api server for Vivarium simulation services."
 authors = [{ name = "Alex Patrie", email = "alexanderpatrie@gmail.com" }, { name = "Jim Schaff", email = "jschaff@gmail.com" }]
 requires-python = ">=3.13,<3.14"

--- a/sms_api/api/routers/sms.py
+++ b/sms_api/api/routers/sms.py
@@ -416,7 +416,7 @@ async def run_simulation_analysis(
     modules: str | None = Query(
         default=None,
         description="JSON object mapping analysis domains to module configs. "
-        'E.g. \'{"multiseed": {"ptools_rna": {"n_tp": 10}}}\'.'
+        'E.g. \'{"single": {"ptools_rna": {"n_tp": 10}}}\'.'
         " If omitted, runs default ptools modules.",
     ),
 ) -> dict:  # type: ignore[type-arg]

--- a/sms_api/common/handlers/simulations.py
+++ b/sms_api/common/handlers/simulations.py
@@ -1548,7 +1548,7 @@ async def run_standalone_analysis(
         database_service: DB service for looking up the simulation.
         simulation_id: Database ID of a completed simulation.
         modules: Analysis modules to run, keyed by domain.
-            E.g. ``{"multiseed": {"ptools_rna": {"n_tp": 10}, "ptools_rxns": {"n_tp": 10}}}``
+            E.g. ``{"single": {"ptools_rna": {"n_tp": 10}, "ptools_rxns": {"n_tp": 10}}}``
             If None, uses a default set of ptools modules.
     """
     settings = get_settings()
@@ -1561,7 +1561,7 @@ async def run_standalone_analysis(
     # Default analysis modules if none specified
     if modules is None:
         modules = {
-            "multiseed": {
+            "single": {
                 "ptools_rna": {"n_tp": 10},
                 "ptools_rxns": {"n_tp": 10},
                 "ptools_proteins": {"n_tp": 10},

--- a/sms_api/version.py
+++ b/sms_api/version.py
@@ -128,4 +128,12 @@
 #          unconditionally reading config["analysis_options"], which this
 #          producer never wrote, so GET /analyses/{id} 500'd for every
 #          Ray-native analysis.
-__version__ = "0.9.32"
+# 0.9.33 — fix: run_standalone_analysis()'s default ptools_* module set (used
+#          whenever --modules is omitted) nested ptools_rna/ptools_rxns/
+#          ptools_proteins under "multiseed", but those modules are registered
+#          scale="single" in v2ecoli/sms-ecoli's ANALYSIS_REGISTRY. Every
+#          default-modules dispatch failed with "is scale='single', not
+#          'multiseed'" — live-reproduced against a completed pilot simulation,
+#          5 separate K8s Job attempts over 22h, all Failed. Default now nests
+#          under "single".
+__version__ = "0.9.33"

--- a/tests/common/handlers/test_simulations_handler.py
+++ b/tests/common/handlers/test_simulations_handler.py
@@ -22,7 +22,7 @@ from sms_api.common.simulator_defaults import RepoUrl
 from sms_api.common.ssh.ssh_service import SSHSessionService
 from sms_api.common.storage.file_paths import HPCFilePath, S3FilePath
 from sms_api.common.storage.file_service import FileService, ListingItem
-from sms_api.config import get_settings
+from sms_api.config import ComputeBackend, get_settings
 from sms_api.dependencies import get_file_service, set_file_service
 from sms_api.simulation.models import Simulation, SimulationConfig, SimulatorVersion
 from sms_api.simulation.simulation_service_k8s import SimulationServiceK8s
@@ -330,6 +330,49 @@ async def test_run_standalone_analysis_ray_native_routes_to_v2ecoli_job() -> Non
     )
     dto = orm_row.to_dto()
     assert dto.config.analysis_options.experiment_id == ["exp123"]
+
+
+@pytest.mark.asyncio
+async def test_run_standalone_analysis_default_modules_use_single_scale() -> None:
+    """Regression: the ptools_* default (when modules=None) nested all three
+    modules under "multiseed", but ptools_rna/ptools_rxns/ptools_proteins are
+    registered scale="single" in v2ecoli/sms-ecoli's ANALYSIS_REGISTRY. Every
+    real standalone-analysis dispatch that relied on the default (no --modules
+    passed) failed with "is scale='single', not 'multiseed'" -- live-reproduced
+    2026-08-05 against a completed pilot simulation, 5 separate K8s Job attempts
+    over 22h, all Failed. This calls the real default-selection path (modules=None)
+    end to end, not a hand-constructed payload, so it would have caught the bug."""
+    from sms_api.common.handlers.simulations import run_standalone_analysis
+
+    simulation = _make_ray_simulation()
+    simulator = SimulatorVersion(
+        database_id=53,
+        git_commit_hash="deadbeef",
+        git_repo_url=RepoUrl.SMS_ECOLI_REPO_URL,
+        git_branch="main",
+    )
+
+    mock_k8s_service = AsyncMock(spec=SimulationServiceK8s)
+    mock_k8s_service.submit_ray_native_analysis.return_value = "ana-exp123"
+    mock_db_service = AsyncMock()
+    mock_db_service.get_simulation.return_value = simulation
+    mock_db_service.get_simulator.return_value = simulator
+    mock_db_service.record_analysis.return_value = SimpleNamespace(database_id=42)
+
+    with (
+        patch("sms_api.common.handlers.simulations.get_job_backend", return_value=ComputeBackend.BATCH),
+        patch("sms_api.common.handlers.simulations.get_simulation_service", return_value=mock_k8s_service),
+    ):
+        result = await run_standalone_analysis(
+            database_service=mock_db_service,
+            simulation_id=115,
+            modules=None,
+        )
+
+    modules_sent = result["config"]["modules"]
+    assert "single" in modules_sent
+    assert set(modules_sent["single"]) == {"ptools_rna", "ptools_rxns", "ptools_proteins"}
+    assert "multiseed" not in modules_sent
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`run_standalone_analysis()`'s default module set — used by the live GovCloud stanford deployment whenever `--modules` is omitted from `atlantis simulation analysis <id>` (the CLI-driven analysis-firing path) — nested `ptools_rna`/`ptools_rxns`/`ptools_proteins` under `"multiseed"`. Those three modules are registered `scale="single"` in v2ecoli/sms-ecoli's `ANALYSIS_REGISTRY` (`v2ecoli/workflow/analyses/ptools_rna.py:169` etc., confirmed by direct read), so every default-modules dispatch failed at the analysis-runner boundary.

**Live-reproduced, not theoretical.** Fired `atlantis simulation analysis 125` (via `--base-url http://localhost:8080` through the `sms-proxy.sh` SSM tunnel to smscdk prod) against a completed 2-seed pilot simulation (`sim55-route-d-cli-verify-pilot-08-04-efba`, db id 125). The K8s Job it dispatched (`ana-analysis-sim55-route-d-cli-ve-4466`) failed immediately with:

```json
{
  "written": [],
  "errors": [
    {"name": "ptools_rna", "error": "ptools_rna is scale='single', not 'multiseed'"},
    {"name": "ptools_rxns", "error": "ptools_rxns is scale='single', not 'multiseed'"},
    {"name": "ptools_proteins", "error": "ptools_proteins is scale='single', not 'multiseed'"}
  ],
  "status": "failed"
}
```

`kubectl get jobs -n sms-api-stanford` showed this had already failed identically **4 prior times over the preceding 22 hours** (`ana-analysis-sim55-route-d-cli-ve-0ff7`, `-7027`, `-e4e4`, `-0fdb`) — every default-modules analysis attempt against this deploy, silently retried and exhausted by K8s backoff (`"Job has reached the specified backoff limit"` is the only signal surfaced back through `atlantis analysis status`, which is why this went unnoticed: the real error only shows up in `kubectl logs` on the Job's pod, not through the CLI/API status path).

## Fix

- `sms_api/common/handlers/simulations.py` — default `modules` dict now nests the three ptools modules under `"single"` instead of `"multiseed"`.
- `app/cli.py` (x2) and `sms_api/api/routers/sms.py` — corrected the matching `--modules`/`analysis_options` help-text examples, which carried the same wrong `"multiseed"` shape and would have propagated the mistake back into future manual `--modules` invocations via copy-paste.
- `sms_api/version.py` / `pyproject.toml` — 0.9.32 -> 0.9.33, changelog entry added.

## Why this matters for the deliverable

This is the standalone-analysis path that will be used manually against the real 1000x10 `baseline-1000x10-remote` run (`job e876bd44-16ee-468c-8af9-f77051ca2b84`, currently RUNNING on AWS Batch) once it completes, since the true DAG-native sim->analysis auto-trigger (backlog item 24, process-bigraph composability) isn't built yet. Without this fix, firing analysis against that run's real output would fail the same way sim125's did.

## Test plan

- [x] New regression test `test_run_standalone_analysis_default_modules_use_single_scale` (`tests/common/handlers/test_simulations_handler.py`) calls the real `modules=None` default-selection path end-to-end — not a hand-constructed payload — so it reproduces the exact live failure and would have caught it.
- [x] `uv run pytest tests/common/handlers/test_simulations_handler.py -k "default_modules or ray_native"` — 3 passed locally.
- [x] `uv run pytest tests/common/handlers/test_simulations_handler.py` (full file) — same 2 pre-existing failures as on `feat/multi-generation-dispatch` before this change (`test_get_available_omics_output_paths`, `test_fetch_simulation_omics_outputs` — both require a real SLURM SSH key not present in this environment; confirmed identical failures on the base branch via `git stash`), no new failures.
- [x] `uv run ruff check` + `uv run mypy` on all touched files — clean.
- [x] CI (`quality`, `tests-and-type-check`, `check-docs`) — see checks below.
- [ ] Post-merge: tag `v0.9.33`, build+push `ghcr.io/vivarium-collective/sms-api:0.9.33` (`build-and-push.yml` workflow_dispatch), bump `kustomize/overlays/sms-api-stanford/kustomization.yaml` `newTag: 0.9.32 -> 0.9.33`, `kubectl diff` then `kubectl apply -k` (kustomize-only, no surgical kubectl), then re-fire `atlantis simulation analysis 125` live and confirm the K8s Job succeeds with real TSV output in S3.