### PR TITLE
fix: unify ray_num_nodes / compose_ray_num_nodes into one setting

### DIFF
--- a/kustomize/config/sms-api-stanford/shared.env
+++ b/kustomize/config/sms-api-stanford/shared.env
@@ -53,11 +53,11 @@ COMPOSE_PARCA_CACHE_DIR=/app/v2ecoli/out/cache
 # The workspace's own core builder — registers ECOLI_TYPES, without which
 # v2ecoli's documents don't resolve on the generic run_pbg core.
 COMPOSE_PBG_CORE_BUILDER=v2ecoli.core:build_core
-# Compose MNP node count — fan seed lineages across N r5 worker nodes. Must be
-# <= CDK rayBatch.numNodes (sms-cdk#29 deployed 24). 24 x 16 = 384 vCPU <= CE
-# maxvCpus (512). Deregister the derived smscdk-ray-mnp-<tag> job-def after a
-# CDK numNodes change so the next submit re-clones at the new count.
-COMPOSE_RAY_NUM_NODES=24
+# RAY_NUM_NODES (above) now covers compose runs too -- COMPOSE_RAY_NUM_NODES was a
+# second, independent setting feeding the same shared _submit_mnp() call, and its
+# existence is exactly why RAY_NUM_NODES got left behind at 4 when the CDK-side
+# capacity scale-up to 24 nodes (sms-cdk#29) only ever updated this one. See
+# backlog item 26.
 
 MARIMO_API_SERVER=http://api:8000
 DEPLOYMENT_NAMESPACE=sms-api-stanford

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sms_api"
-version = "0.9.33"
+version = "0.9.34"
 description = "This is the api server for Vivarium simulation services."
 authors = [{ name = "Alex Patrie", email = "alexanderpatrie@gmail.com" }, { name = "Jim Schaff", email = "jschaff@gmail.com" }]
 requires-python = ">=3.13,<3.14"

--- a/sms_api/compose/simulation_service_ray.py
+++ b/sms_api/compose/simulation_service_ray.py
@@ -162,7 +162,7 @@ class ComposeSimulationServiceRay(ComposeSimulationService):
         batch_job_id = self._ray._submit_mnp(
             job_name=f"compose-{experiment_id}"[:128],
             job_definition=job_def,
-            num_nodes=get_settings().compose_ray_num_nodes,
+            num_nodes=get_settings().ray_num_nodes,
             ray_job_cmd=self._compose_command(doc_s3_uri, runner_s3_uri, steps),
             out_s3=data_layout.RayLayout.results_uri(experiment_id),
             out_dir=COMPOSE_OUT_DIR,

--- a/sms_api/config.py
+++ b/sms_api/config.py
@@ -237,11 +237,17 @@ class Settings(BaseSettings):
     # Provisioned by sms-cdk lib/ray-batch-stack.ts (the <prefix>-ray-mnp queue/job-def).
     ray_mnp_queue: str = ""  # Batch MNP job queue (e.g. "smscdk-ray-mnp")
     ray_mnp_job_definition: str = ""  # Batch MNP job definition (e.g. "smscdk-ray-mnp")
-    ray_num_nodes: int = 3  # MNP node count for the simulation job (1 head + N-1 workers)
-    # MNP node count for COMPOSE runs; 1 = single node (head is also worker, per the
-    # ray-batch-entrypoint --num-cpus conditional). Raise to fan seed lineages across
-    # N worker nodes for large sweeps (must be <= CDK rayBatch.numNodes).
-    compose_ray_num_nodes: int = 1
+    # MNP node count for BOTH the vEcoli ensemble sim and generic compose runs (1 head
+    # + N-1 workers; single node = head is also worker, per the ray-batch-entrypoint
+    # --num-cpus conditional). One setting, not two: compose and the ensemble sim
+    # submit through the same shared _submit_mnp() on the same MNP queue/job-def (see
+    # ComposeSimulationServiceRay.__init__ / _submit_mnp's docstring), so a single
+    # node-count knob is the only shape that can't silently drift between them again
+    # (was ray_num_nodes + compose_ray_num_nodes, two independent settings feeding the
+    # same call -- the CDK's 24-node capacity scale-up only ever updated the compose
+    # one, leaving the actually-used ensemble sim path stuck at 4; see backlog item 26).
+    # Must be <= CDK rayBatch.numNodes.
+    ray_num_nodes: int = 3
     ray_ecr_repository: str = "v2ecoli"  # ECR repo for the workload-owned Ray image (built by submit_build_image_job)
     ray_parca_mode: str = "full"  # v2ecoli-parca --mode (fast for debug, full for production)
     ray_parca_cpus: int = 8  # v2ecoli-parca --cpus

--- a/sms_api/version.py
+++ b/sms_api/version.py
@@ -136,4 +136,17 @@
 #          'multiseed'" — live-reproduced against a completed pilot simulation,
 #          5 separate K8s Job attempts over 22h, all Failed. Default now nests
 #          under "single".
-__version__ = "0.9.33"
+# 0.9.34 — fix: unify ray_num_nodes / compose_ray_num_nodes into a single
+#          ray_num_nodes setting. Both the ensemble sim path (simulation/
+#          simulation_service_ray.py) and the compose path (compose/
+#          simulation_service_ray.py) submit through the SAME shared
+#          SimulationServiceRay._submit_mnp() -- compose is a thin wrapper
+#          around it, not a separate subsystem -- but each read an independent
+#          node-count setting. The CDK-side 24-node capacity scale-up
+#          (sms-cdk#29) only ever updated compose_ray_num_nodes, silently
+#          leaving the actually-used ensemble sim path stuck at ray_num_nodes=4.
+#          Live-reproduced: the real 1000x10 baseline job ran on 4 nodes
+#          instead of 24 (~14-15 min/gen vs ~8 measured at low contention on
+#          the same instance type), extrapolated ~24-27h total, had to be
+#          killed. One setting now, can't drift apart again.
+__version__ = "0.9.34"

--- a/tests/compose/test_simulation_service_ray.py
+++ b/tests/compose/test_simulation_service_ray.py
@@ -1,11 +1,20 @@
 """ComposeSimulationServiceRay unit tests (no AWS): command shape + backend flags."""
 
 import types
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from sms_api.common.models import JobBackend
 from sms_api.compose import simulation_service_ray as mod
+from sms_api.compose.container_def import ContainerizationFileRepr
+from sms_api.compose.models import (
+    ComposeSimulation,
+    ComposeSimulationRequest,
+    ComposeSimulatorVersion,
+    SimulationFileType,
+)
 from sms_api.compose.simulation_service_ray import ComposeSimulationServiceRay
 
 
@@ -115,3 +124,52 @@ def test_compose_command_omits_core_builder_when_unset(monkeypatch: pytest.Monke
     monkeypatch.setattr(mod, "get_settings", lambda: _settings(compose_pbg_core_builder=""))
     cmd = ComposeSimulationServiceRay()._compose_command("s3://b/i.pbg", "s3://b/run_pbg.py", steps=3)
     assert "PBG_CORE_BUILDER" not in cmd
+
+
+@pytest.mark.asyncio
+async def test_submit_simulation_job_uses_the_unified_ray_num_nodes_setting(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Regression: compose used to read its OWN compose_ray_num_nodes setting,
+    independent of the ensemble sim path's ray_num_nodes -- both ultimately call the
+    same shared SimulationServiceRay._submit_mnp(), so two settings could (and did)
+    drift apart. The CDK-side 24-node capacity scale-up only ever updated
+    compose_ray_num_nodes, silently leaving the actually-used ensemble sim path stuck
+    at 4 (live-reproduced 2026-08-05: a real 1000x10 baseline job ran on 4 nodes
+    instead of 24, ~14-15 min/gen instead of ~8, had to be killed). Now there is only
+    ray_num_nodes; this proves the compose path actually reads it."""
+    monkeypatch.setattr(mod, "get_settings", lambda: _settings(ray_num_nodes=24, compose_parca_cache_dir=""))
+
+    doc_path = tmp_path / "input.pbg"
+    doc_path.write_text("{}")
+    simulation = ComposeSimulation(
+        database_id=1,
+        sim_request=ComposeSimulationRequest(
+            request_file_path=doc_path, simulation_file_type=SimulationFileType.PBG, is_batch=False
+        ),
+        simulator_version=ComposeSimulatorVersion(
+            database_id=1,
+            singularity_def=ContainerizationFileRepr(representation="Bootstrap: docker\n"),
+            singularity_def_hash="x",
+            packages=None,
+        ),
+    )
+
+    svc = ComposeSimulationServiceRay()
+    svc._ray._ensure_mnp_job_def = lambda image, tag: "smscdk-ray-mnp:1"
+
+    captured: dict[str, object] = {}
+
+    def _capture_submit_mnp(**kwargs: object) -> str:
+        captured.update(kwargs)
+        return "batch-job-id"
+
+    svc._ray._submit_mnp = _capture_submit_mnp
+
+    fake_file_service = AsyncMock()
+    fake_file_service.upload_file = AsyncMock()
+
+    with patch("sms_api.dependencies.get_file_service", return_value=fake_file_service):
+        await svc.submit_simulation_job(simulation, experiment_id="exp-1")
+
+    assert captured["num_nodes"] == 24

--- a/tests/compose/test_simulation_service_ray.py
+++ b/tests/compose/test_simulation_service_ray.py
@@ -156,7 +156,7 @@ async def test_submit_simulation_job_uses_the_unified_ray_num_nodes_setting(
     )
 
     svc = ComposeSimulationServiceRay()
-    svc._ray._ensure_mnp_job_def = lambda image, tag: "smscdk-ray-mnp:1"
+    monkeypatch.setattr(svc._ray, "_ensure_mnp_job_def", lambda image, commit: "smscdk-ray-mnp:1")
 
     captured: dict[str, object] = {}
 
@@ -164,7 +164,7 @@ async def test_submit_simulation_job_uses_the_unified_ray_num_nodes_setting(
         captured.update(kwargs)
         return "batch-job-id"
 
-    svc._ray._submit_mnp = _capture_submit_mnp
+    monkeypatch.setattr(svc._ray, "_submit_mnp", _capture_submit_mnp)
 
     fake_file_service = AsyncMock()
     fake_file_service.upload_file = AsyncMock()


### PR DESCRIPTION
## Summary
- \`sms_api/simulation/simulation_service_ray.py\` (the vEcoli ensemble/batch_baseline dispatch) and \`sms_api/compose/simulation_service_ray.py\` (the generic process-bigraph composite dispatch) both submit jobs through the SAME shared \`SimulationServiceRay._submit_mnp()\` — compose is a thin wrapper around it (\`ComposeSimulationServiceRay.__init__\` does \`self._ray = SimulationServiceRay()\`), not an independent subsystem. But each path read its own independent node-count setting (\`ray_num_nodes\` vs \`compose_ray_num_nodes\`).
- Real, expensive consequence: the CDK-side 24-node capacity scale-up (sms-cdk PR #31/#29) only ever updated \`compose_ray_num_nodes\`, silently leaving the actually-used ensemble sim path stuck at \`ray_num_nodes=4\`. The real 1000×10 cd1 baseline dispatch (job \`e876bd44\`) ran across only 4 nodes and measured ~14-15 min/gen vs. ~8 min/gen validated on the same instance type at low contention — extrapolated ~24-27h total, job terminated. PR #217 fixed the immediate deploy-config value; this PR fixes the underlying duplication that let it happen.

## Fix
One \`ray_num_nodes\` setting, read by both dispatch paths. Removes \`compose_ray_num_nodes\` entirely (\`config.py\`, \`compose/simulation_service_ray.py\`, \`kustomize/config/sms-api-stanford/shared.env\`) rather than leaving a redundant second knob that could drift again.

## Test plan
- [x] New regression test \`test_submit_simulation_job_uses_the_unified_ray_num_nodes_setting\` calls the real \`submit_simulation_job()\` end-to-end (mocked Batch/file-service boundary only) and asserts the captured \`_submit_mnp(num_nodes=...)\` matches \`ray_num_nodes\`.
- [x] \`uv run pytest tests/compose/\` — 115 passed.
- [x] \`uv run ruff check\` + \`uv run mypy\` on all touched files — clean.