### PR TITLE
fix: Ray-native analysis status polling used the wrong S3 key shape

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sms_api"
-version = "0.9.34"
+version = "0.9.35"
 description = "This is the api server for Vivarium simulation services."
 authors = [{ name = "Alex Patrie", email = "alexanderpatrie@gmail.com" }, { name = "Jim Schaff", email = "jschaff@gmail.com" }]
 requires-python = ">=3.13,<3.14"

--- a/sms_api/common/handlers/analyses.py
+++ b/sms_api/common/handlers/analyses.py
@@ -23,6 +23,7 @@ from sms_api.analysis.models import (
     TsvOutputFile,
 )
 from sms_api.common.models import JobId, JobStatus, SSHTarget
+from sms_api.common.storage import data_layout
 from sms_api.common.storage.file_paths import HPCFilePath, S3FilePath
 from sms_api.common.utils import get_data_id, timestamp
 from sms_api.config import get_settings
@@ -214,9 +215,8 @@ async def handle_get_ray_analysis_status(
     file_service = get_file_service()
     manifest_bytes = None
     if file_service is not None and record.result_uri:
-        manifest_bytes = await file_service.get_file_contents(
-            S3FilePath(s3_path=Path(f"{record.result_uri}/_manifest.json"))
-        )
+        manifest_key = data_layout.key_from_uri(f"{record.result_uri}/_manifest.json")
+        manifest_bytes = await file_service.get_file_contents(S3FilePath(s3_path=Path(manifest_key)))
     if manifest_bytes is not None:
         manifest = json.loads(manifest_bytes)
         if manifest.get("written"):

--- a/sms_api/common/storage/data_layout.py
+++ b/sms_api/common/storage/data_layout.py
@@ -48,6 +48,22 @@ def s3_uri(key: str) -> str:
     return f"s3://{_bucket()}/{key}"
 
 
+def key_from_uri(uri: str) -> str:
+    """Strip a ``s3://<bucket>/`` prefix, returning the bucket-relative key.
+
+    The inverse of ``s3_uri``. ``S3FilePath.s3_path`` is documented as bucket-relative
+    (``FileServiceS3`` resolves the bucket separately from settings) -- passing a full
+    ``s3://...`` URI into it double-prefixes the bucket into the key AND, via
+    ``Path()``'s slash-collapsing, mangles ``s3://`` into ``s3:/``, so the resulting
+    "key" never matches a real object and every existence check silently 404s. Any
+    caller building an ``S3FilePath`` from a stored full URI (e.g. a DB record's
+    ``result_uri``) must go through this first.
+    """
+    if not uri.startswith("s3://"):
+        return uri
+    return uri.removeprefix("s3://").split("/", 1)[1]
+
+
 class RayLayout:
     """v2ecoli / XArray-zarr output layout (single-nested), plus the Ray ParCa caches."""
 

--- a/sms_api/version.py
+++ b/sms_api/version.py
@@ -149,4 +149,15 @@
 #          instead of 24 (~14-15 min/gen vs ~8 measured at low contention on
 #          the same instance type), extrapolated ~24-27h total, had to be
 #          killed. One setting now, can't drift apart again.
-__version__ = "0.9.34"
+# 0.9.35 — fix: Ray-native analysis status polling used the full s3://<bucket>/...
+#          result_uri directly as S3FilePath.s3_path, which is documented (and
+#          FileServiceS3 relies on it) as BUCKET-RELATIVE -- the bucket is
+#          resolved separately from settings, so the full URI double-prefixed
+#          the bucket into the key and, via Path()'s slash-collapsing, mangled
+#          "s3://" into "s3:/". The constructed key never matched a real S3
+#          object, so the manifest-exists check silently 404'd forever.
+#          Live-reproduced: atlantis analysis status kept reporting "running"
+#          20+ minutes after the K8s pod had genuinely completed with a valid
+#          manifest already in S3. New data_layout.key_from_uri() strips the
+#          s3://<bucket>/ prefix before constructing S3FilePath.
+__version__ = "0.9.35"

--- a/tests/common/handlers/test_ray_analysis_status.py
+++ b/tests/common/handlers/test_ray_analysis_status.py
@@ -42,6 +42,40 @@ async def test_returns_terminal_status_without_any_probe() -> None:
 
 
 @pytest.mark.asyncio
+async def test_manifest_lookup_uses_a_bucket_relative_key_not_the_full_uri() -> None:
+    """Regression: record.result_uri is a full s3://<bucket>/... URI, but
+    S3FilePath.s3_path is documented (and FileServiceS3 relies on it) as
+    BUCKET-RELATIVE -- FileServiceS3 resolves the bucket separately from
+    settings and uses s3_path.s3_path as the literal object key. Passing the
+    full URI straight into S3FilePath (via Path(f"{result_uri}/_manifest.json"))
+    double-prefixed the bucket into the key AND, via Path()'s slash-collapsing,
+    mangled "s3://" into "s3:/", so the constructed key never matched a real
+    object -- every manifest existence check silently 404'd regardless of
+    whether the manifest genuinely existed. Live-reproduced 2026-08-05:
+    atlantis analysis status kept reporting "running" 20+ minutes after the
+    K8s pod had completed and written a real, valid manifest to S3. This test
+    inspects the ACTUAL key handed to get_file_contents (the prior test only
+    asserted on a hardcoded mock return value, which can't catch a wrong-key
+    bug since the mock ignores its input entirely)."""
+    record = _make_record()
+    db_service = AsyncMock()
+    manifest = (
+        b'{"written": ["s3://bucket/exp/analyses/analysis-exp1-ab12/doubling_time_distribution.json"], "errors": []}'
+    )
+    fake_file_service = AsyncMock()
+    fake_file_service.get_file_contents.return_value = manifest
+
+    with patch("sms_api.common.handlers.analyses.get_file_service", return_value=fake_file_service):
+        await handle_get_ray_analysis_status(db_service=db_service, record=record)
+
+    fake_file_service.get_file_contents.assert_called_once()
+    requested_path = str(fake_file_service.get_file_contents.call_args.args[0])
+    assert requested_path == "exp/analyses/analysis-exp1-ab12/_manifest.json"
+    assert "s3:" not in requested_path
+    assert "bucket" not in requested_path
+
+
+@pytest.mark.asyncio
 async def test_manifest_present_with_output_marks_ready() -> None:
     record = _make_record()
     db_service = AsyncMock()


### PR DESCRIPTION
## Summary
- \`handle_get_ray_analysis_status()\` passed the full \`s3://<bucket>/...\` \`result_uri\` directly into \`S3FilePath(s3_path=...)\`, but \`S3FilePath.s3_path\` is documented (and \`FileServiceS3\` relies on it) as **bucket-relative** — the bucket is resolved separately from settings, and \`s3_path.s3_path\` is used as the literal object key. Passing the full URI double-prefixed the bucket into the key and, via \`Path()\`'s slash-collapsing, mangled \`s3://\` into \`s3:/\` — the constructed key never matched a real object, so the manifest-exists check silently 404'd regardless of whether the manifest genuinely existed.
- **Live-reproduced**: \`atlantis analysis status <id>\` kept reporting \`"running"\` 20+ minutes after the backing K8s pod had genuinely completed and written a valid \`_manifest.json\` + \`analysis.json\` to S3 — confirmed via \`kubectl get pods\` (\`Completed\`) and \`kubectl logs\` (\`"status": "done"\`) while the API's own status endpoint, polled fresh, still said running.

## Fix
New \`sms_api/common/storage/data_layout.key_from_uri()\` strips the \`s3://<bucket>/\` prefix (inverse of the existing \`s3_uri()\` helper) before constructing \`S3FilePath\`.

## Test plan
- [x] New regression test asserts on the ACTUAL key handed to \`get_file_contents\` — the existing tests only asserted on a hardcoded mock return value, which can't catch a wrong-key bug since the mock ignores its input entirely.
- [x] \`uv run pytest tests/common/handlers/test_ray_analysis_status.py\` — 6 passed.
- [x] \`uv run ruff check .\` + \`uv run mypy\` (whole repo, not just touched files) — clean.
- [x] Manually verified \`key_from_uri()\` against the real manifest key that was silently failing to resolve in production.