### PR TITLE
feat(compose): dispatch multi-gen batch via the generic run_pbg.py runner (0.9.36)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sms_api"
-version = "0.9.35"
+version = "0.9.36"
 description = "This is the api server for Vivarium simulation services."
 authors = [{ name = "Alex Patrie", email = "alexanderpatrie@gmail.com" }, { name = "Jim Schaff", email = "jschaff@gmail.com" }]
 requires-python = ">=3.13,<3.14"

--- a/sms_api/compose/run_pbg.py
+++ b/sms_api/compose/run_pbg.py
@@ -7,6 +7,19 @@ CLI contract (fixed by sms-api's ``_build_run_command``)::
 Writes results into ``/experiment/output`` (the bind-mounted, zipped dir).
 The ``-o`` value is accepted for CLI compatibility but output always lands in
 ``RESULTS_DIR`` so it matches sms-api's ``zip -r ../results.zip`` collection.
+
+A second, equally generic mode builds the document itself rather than reading
+one from disk::
+
+    python run_pbg.py --composite-id <id> --overrides '<json>' -n <steps>
+
+``<id>`` is any id resolvable by ``process_bigraph.composite_spec.get()`` (the
+single registry every ``@composite_generator``/``@composite_spec`` decorator
+registers into) — not specific to any one workspace. This is what lets a
+model-specific dispatcher (e.g. viva-api's vEcoli ensemble endpoint) submit a
+config-driven run through the exact same execution mechanism a hand-authored
+``.pbg`` document uses, instead of shelling out to a bespoke per-workspace CLI
+script. Exactly one of ``input_file`` or ``--composite-id`` is required.
 """
 
 from __future__ import annotations
@@ -139,8 +152,47 @@ def _redirect_emitters(node: Any, results_dir: Path) -> int:
     return redirected
 
 
-def run(input_file: str, steps: int, results_dir: Path = RESULTS_DIR) -> Path:
-    """Load a ``.pbg`` document, run it ``steps`` times, write ``final_state.json``.
+def _resolve_document(
+    input_file: str | None, composite_id: str | None, overrides: dict[str, Any] | None, core: Any
+) -> dict:
+    """Load a static ``.pbg`` document, or build one from a registered composite.
+
+    The composite-id branch resolves through ``process_bigraph.composite_spec`` —
+    the same registry ``vivarium_workbench.lib.pbg_export.export_composite_pbg``
+    already resolves composites through for the Composites-tab / remote-run path.
+    Building the document HERE (in-process, same call that constructs ``Composite``
+    below) never crosses a serialization boundary, so unlike a document loaded from
+    disk, realized-edge fields (a live ``instance``, resolved port schemas) are
+    exactly what the generator function returns — nothing to strip or rewrite.
+    """
+    if composite_id:
+        from process_bigraph.composite_spec import get as get_spec, discover_specs
+
+        spec = get_spec(composite_id)
+        if spec is None:
+            # The defining module may not have been imported yet (its
+            # @composite_generator/@composite_spec decorator only fires on
+            # import) — discover_specs() walks every installed
+            # bigraph-schema-dependent package to force that, then retry once.
+            discover_specs()
+            spec = get_spec(composite_id)
+        if spec is None:
+            raise SystemExit(f"run_pbg: no composite registered as {composite_id!r}")
+        return spec.to_document(overrides=overrides or {}, core=core)
+    assert input_file is not None  # enforced by main()'s mutual-exclusion check
+    return json.loads(Path(input_file).read_text())
+
+
+def run(
+    input_file: str | None,
+    steps: int,
+    results_dir: Path = RESULTS_DIR,
+    *,
+    composite_id: str | None = None,
+    overrides: dict[str, Any] | None = None,
+) -> Path:
+    """Get a document (static file, or built from ``composite_id`` + ``overrides``),
+    run it ``steps`` times, write ``final_state.json``.
 
     Any pbg-emitters step the document itself wires (``local:ParquetEmitter`` etc.)
     resolves via ``_build_core()`` and writes its own zarr/parquet output alongside
@@ -150,7 +202,6 @@ def run(input_file: str, steps: int, results_dir: Path = RESULTS_DIR) -> Path:
     from process_bigraph import Composite  # imported lazily so tests can stub it
 
     results_dir.mkdir(parents=True, exist_ok=True)
-    document = json.loads(Path(input_file).read_text())
     # Prefer the workspace's own core (it registers types the generic one can't know
     # about); fall back to the generic core when no builder is named. Test against
     # None explicitly — a Core is a registry-ish object that may well define
@@ -158,6 +209,7 @@ def run(input_file: str, steps: int, results_dir: Path = RESULTS_DIR) -> Path:
     core = _workspace_core()
     if core is None:
         core = _build_core()
+    document = _resolve_document(input_file, composite_id, overrides, core)
     # Emitters must write where the entrypoint syncs from, not where the authoring
     # workspace would have put them.
     _redirect_emitters(document, results_dir)
@@ -170,11 +222,16 @@ def run(input_file: str, steps: int, results_dir: Path = RESULTS_DIR) -> Path:
 
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("input_file")
+    parser.add_argument("input_file", nargs="?", default=None)
+    parser.add_argument("--composite-id", dest="composite_id", default=None)
+    parser.add_argument("--overrides", default=None, help="JSON object of composite-generator parameter overrides")
     parser.add_argument("-o", "--output", default=str(RESULTS_DIR))
     parser.add_argument("-n", "--steps", type=int, default=1)
     args = parser.parse_args(argv)
-    run(args.input_file, args.steps)
+    if bool(args.input_file) == bool(args.composite_id):
+        parser.error("exactly one of input_file or --composite-id is required")
+    overrides = json.loads(args.overrides) if args.overrides else None
+    run(args.input_file, args.steps, composite_id=args.composite_id, overrides=overrides)
 
 
 if __name__ == "__main__":

--- a/sms_api/compose/run_pbg.py
+++ b/sms_api/compose/run_pbg.py
@@ -154,7 +154,7 @@ def _redirect_emitters(node: Any, results_dir: Path) -> int:
 
 def _resolve_document(
     input_file: str | None, composite_id: str | None, overrides: dict[str, Any] | None, core: Any
-) -> dict:
+) -> dict[str, Any]:
     """Load a static ``.pbg`` document, or build one from a registered composite.
 
     The composite-id branch resolves through ``process_bigraph.composite_spec`` —
@@ -166,7 +166,8 @@ def _resolve_document(
     exactly what the generator function returns — nothing to strip or rewrite.
     """
     if composite_id:
-        from process_bigraph.composite_spec import get as get_spec, discover_specs
+        from process_bigraph.composite_spec import discover_specs
+        from process_bigraph.composite_spec import get as get_spec
 
         spec = get_spec(composite_id)
         if spec is None:
@@ -178,9 +179,12 @@ def _resolve_document(
             spec = get_spec(composite_id)
         if spec is None:
             raise SystemExit(f"run_pbg: no composite registered as {composite_id!r}")
-        return spec.to_document(overrides=overrides or {}, core=core)
-    assert input_file is not None  # enforced by main()'s mutual-exclusion check
-    return json.loads(Path(input_file).read_text())
+        document: dict[str, Any] = spec.to_document(overrides=overrides or {}, core=core)
+        return document
+    if input_file is None:
+        raise ValueError("_resolve_document: input_file is required when composite_id is not given")
+    loaded: dict[str, Any] = json.loads(Path(input_file).read_text())
+    return loaded
 
 
 def run(

--- a/sms_api/simulation/simulation_service_ray.py
+++ b/sms_api/simulation/simulation_service_ray.py
@@ -23,9 +23,14 @@ base (cloning its node properties, swapping the image to ``v2ecoli:<commit>``).
 """
 
 import copy
+import importlib.resources as _res
+import json
 import logging
 import random
+import shlex
 import string
+import tempfile
+from pathlib import Path
 from typing import Any, override
 
 import boto3
@@ -35,6 +40,7 @@ from sms_api.common.hpc.local_task_service import LocalTaskService
 from sms_api.common.models import JobBackend, JobId, JobStatus
 from sms_api.common.simulator_defaults import DEFAULT_BRANCH, DEFAULT_REPO
 from sms_api.common.storage import data_layout
+from sms_api.common.storage.file_paths import S3FilePath
 from sms_api.config import get_settings
 from sms_api.simulation import batch_build
 from sms_api.simulation.database_service import DatabaseService
@@ -54,6 +60,20 @@ from sms_api.simulation.models import (
 from sms_api.simulation.simulation_service import SimulationService
 
 logger = logging.getLogger(__name__)
+
+# The generic runner every Ray-Batch job (ensemble or compose) executes. Read once as a
+# resource (same source sms_api.compose.simulation_service_ray stages for compose jobs) so
+# the multi-generation batch path below dispatches through the identical mechanism instead
+# of a v2ecoli-specific CLI script — see backlog items 26/27.
+_RUNNER_SRC = (_res.files("sms_api.compose") / "run_pbg.py").read_text()
+
+# Registered composite id (process_bigraph.composite_spec) for v2ecoli's multi-generation
+# batch orchestrator, and the workspace core-builder that resolves its registered types
+# (e.g. "inplace_dict"). Both are inherent facts about what THIS endpoint dispatches — this
+# file already hardcodes v2ecoli-specific paths (V2ECOLI_DIR, PARCA_CACHE_DIR below); what
+# item 27 removes is the bespoke EXECUTION MECHANISM (a CLI script), not this identity.
+V2ECOLI_BASELINE_COMPOSITE_ID = "v2ecoli.composites.ecoli_baseline"
+V2ECOLI_CORE_BUILDER = "v2ecoli.core:build_core"
 
 # Absolute paths inside the v2ecoli Ray image (WORKDIR=/app/v2ecoli). The
 # entrypoint runs RAY_JOB_CMD on the head; v2ecoli reads the cache from
@@ -285,6 +305,31 @@ class SimulationServiceRay(SimulationService):
             f" --copy-to {PARCA_CACHE_DIR}"
         )
 
+    async def _stage_runner(self, experiment_id: str) -> str:
+        """Upload the generic run_pbg.py runner to S3 for this experiment; return its URI.
+
+        Mirrors ``sms_api.compose.simulation_service_ray.ComposeSimulationServiceRay``'s
+        own runner staging exactly (same source, same per-experiment S3 layout) -- the
+        multi-generation batch path below downloads and runs it the identical way a
+        compose job does. Staged (not embedded via heredoc) because AWS Batch caps a
+        container override command at 8192 bytes.
+        """
+        from sms_api.dependencies import get_file_service
+
+        file_service = get_file_service()
+        if file_service is None:
+            raise RuntimeError("FileService not initialized; cannot stage run_pbg.py to S3.")
+        exp_prefix = data_layout.RayLayout.experiment_prefix(experiment_id)
+        runner_key = f"{exp_prefix}/run_pbg.py"
+        with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as tmp:
+            tmp.write(_RUNNER_SRC)
+            runner_local = tmp.name
+        try:
+            await file_service.upload_file(Path(runner_local), S3FilePath(s3_path=Path(runner_key)))
+        finally:
+            Path(runner_local).unlink(missing_ok=True)
+        return data_layout.s3_uri(runner_key)
+
     def _sim_command(
         self,
         n_seeds: int,
@@ -296,6 +341,8 @@ class SimulationServiceRay(SimulationService):
         max_generations: int | None = None,
         vecoli_source: VecoliSource | None = None,
         n_generations: int = 1,
+        experiment_id: str | None = None,
+        runner_s3_uri: str | None = None,
     ) -> str:
         # When ``composite`` is set, run the two-engine comparison driver — both
         # engines (v2ecoli port + vEcoli imported via build_composite_native)
@@ -325,9 +372,40 @@ class SimulationServiceRay(SimulationService):
             # Real multi-generation lineage (cell division across generations) --
             # scripts/run_phase0_xarray_ensemble.py below silently ignores this
             # entirely and only ever runs one generation per seed.
+            #
+            # Dispatched as a registered process-bigraph composite (v2ecoli's
+            # BatchBaselineRunner, wired in by ecoli_baseline.baseline() whenever
+            # n_seeds>1/n_generations>1) run through the SAME generic run_pbg.py
+            # every compose-on-Batch job already uses — not a v2ecoli-specific CLI
+            # script. See backlog items 26/27: this is the one execution mechanism
+            # both the ensemble endpoint and the generic compose endpoint dispatch
+            # through; only the composite id + overrides differ per caller.
+            if not experiment_id:
+                raise RuntimeError("experiment_id is required for multi-generation batch dispatch")
+            if not runner_s3_uri:
+                raise RuntimeError(
+                    "runner_s3_uri is required for multi-generation batch dispatch "
+                    "(the generic run_pbg.py runner must be staged to S3 first)"
+                )
+            overrides = {
+                "n_seeds": int(n_seeds),
+                "n_generations": int(n_generations),
+                "cache_dir": PARCA_CACHE_DIR,
+                "out_dir": SIM_OUT_DIR,
+                "experiment_id": experiment_id,
+                # Standalone post-hoc analysis (scripts/run_standalone_analysis.py)
+                # runs the same analysis_runner.run_analyses() directly against the
+                # landed S3 sweep -- skip the composite's own inline flush here.
+                "analyses": "none",
+                "parallel": "ray",
+            }
+            env = f"PBG_RESULTS_DIR={SIM_OUT_DIR} PBG_CORE_BUILDER={V2ECOLI_CORE_BUILDER}"
             return (
-                f"cd {V2ECOLI_DIR} && python scripts/run_batch_baseline_ray.py"
-                f" --n-seeds {n_seeds} --n-generations {int(n_generations)}"
+                f"cd {V2ECOLI_DIR}"
+                f" && aws s3 cp {runner_s3_uri} /tmp/run_pbg.py"
+                f" && {env} python /tmp/run_pbg.py"
+                f" --composite-id {V2ECOLI_BASELINE_COMPOSITE_ID}"
+                f" --overrides {shlex.quote(json.dumps(overrides))} -n 1"
             )
         return (
             f"cd {V2ECOLI_DIR} && python scripts/run_phase0_xarray_ensemble.py"
@@ -476,6 +554,11 @@ bash docker/build-and-push-ecr.sh -i {commit} -r {settings.ray_ecr_repository} -
         cache_s3 = self._upstream_cache_s3_uri(commit) if is_upstream else self._cache_s3_uri(commit)
         parca_command = self._upstream_parca_command() if is_upstream else self._parca_command()
 
+        # The multi-generation batch path dispatches through the generic run_pbg.py
+        # runner (see _sim_command) instead of a hardcoded CLI script, so it alone
+        # needs the runner staged to S3 first. Every other path is unaffected.
+        runner_s3_uri = await self._stage_runner(experiment_id) if n_generations > 1 else None
+
         # Cost-allocation tags (propagate to ECS tasks → payer-account Cost
         # Explorer attributes spend per run/engine/condition). Values must be
         # tag-safe strings.
@@ -513,6 +596,8 @@ bash docker/build-and-push-ecr.sh -i {commit} -r {settings.ray_ecr_repository} -
                 max_generations=max_generations,
                 vecoli_source=vecoli_source,
                 n_generations=n_generations,
+                experiment_id=str(experiment_id),
+                runner_s3_uri=runner_s3_uri,
             ),
             out_s3=self._results_s3_uri(experiment_id),
             out_dir=SIM_OUT_DIR,

--- a/sms_api/version.py
+++ b/sms_api/version.py
@@ -160,4 +160,19 @@
 #          20+ minutes after the K8s pod had genuinely completed with a valid
 #          manifest already in S3. New data_layout.key_from_uri() strips the
 #          s3://<bucket>/ prefix before constructing S3FilePath.
-__version__ = "0.9.35"
+# 0.9.36 — the multi-generation batch dispatch (previously a hardcoded CLI
+#          script, scripts/run_batch_baseline_ray.py) now builds a process-
+#          bigraph document and runs it through the SAME generic run_pbg.py
+#          runner the compose-on-Batch path already uses, instead of shelling
+#          out to a v2ecoli-specific script (backlog items 26/27 — the two Ray
+#          job-submission paths never had duplicated submission code, only a
+#          duplicated job COMMAND; this closes that gap too, since there is no
+#          longer a second execution mechanism to unify). run_pbg.py gains a
+#          --composite-id/--overrides mode (process_bigraph.composite_spec
+#          resolution, same as vivarium_workbench.lib.pbg_export already uses)
+#          alongside its existing static-file mode. Also fixes a real bug this
+#          surfaced: the multi-gen dispatch never threaded the real
+#          experiment_id through — every batch's zarr/parquet output was
+#          silently stamped with the literal "batch_baseline" regardless of
+#          the actual request.
+__version__ = "0.9.36"

--- a/tests/compose/test_run_pbg.py
+++ b/tests/compose/test_run_pbg.py
@@ -216,7 +216,9 @@ def test_resolve_document_composite_id_unresolvable_raises_clearly(monkeypatch: 
         run_pbg._resolve_document(None, "missing.id", None, core=FakeCore())
 
 
-def test_main_requires_exactly_one_of_input_file_or_composite_id(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_main_requires_exactly_one_of_input_file_or_composite_id(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     captured: dict[str, Any] = {}
     monkeypatch.setattr(run_pbg, "run", lambda *a, **kw: captured.update(kw) or Path("x"))
 

--- a/tests/compose/test_run_pbg.py
+++ b/tests/compose/test_run_pbg.py
@@ -138,3 +138,140 @@ def test_a_falsy_workspace_core_is_still_used(monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setitem(sys.modules, "fake_falsy_ws", mod)
     monkeypatch.setenv("PBG_CORE_BUILDER", "fake_falsy_ws:build_core")
     assert run_pbg._workspace_core() is sentinel
+
+
+# --- _resolve_document / composite-id mode (backlog items 26/27) -----------------
+# A model-specific dispatcher (e.g. viva-api's vEcoli ensemble endpoint) can submit
+# a config-driven run through this SAME generic runner instead of a bespoke CLI
+# script, by naming a registered composite id + overrides. Verified against a fake
+# process_bigraph.composite_spec module so this stays testable without the real
+# (container-only) process-bigraph install, matching test_run_writes_final_state's
+# module-injection style above.
+
+
+class FakeSpec:
+    def __init__(self, doc: dict[str, Any]) -> None:
+        self._doc = doc
+        self.overrides_received: dict[str, Any] | None = None
+        self.core_received: Any = None
+
+    def to_document(self, overrides: dict[str, Any] | None = None, core: Any = None) -> dict[str, Any]:
+        self.overrides_received = overrides
+        self.core_received = core
+        return self._doc
+
+
+def _install_fake_composite_spec(monkeypatch: pytest.MonkeyPatch, registry: dict[str, Any]) -> list[str]:
+    """Inject a fake process_bigraph.composite_spec module; returns discover_specs() call count."""
+    discover_calls: list[str] = []
+    fake_mod = types.ModuleType("process_bigraph.composite_spec")
+    fake_mod.get = lambda spec_id: registry.get(spec_id)  # type: ignore[attr-defined]
+    fake_mod.discover_specs = lambda: discover_calls.append("called")  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "process_bigraph.composite_spec", fake_mod)
+    return discover_calls
+
+
+def test_resolve_document_static_file_mode_unchanged(tmp_path: Path) -> None:
+    """No composite_id: behaves exactly as before — reads the JSON file verbatim."""
+    pbg = tmp_path / "m.pbg"
+    pbg.write_text(json.dumps({"state": {"x": 1}}))
+    doc = run_pbg._resolve_document(str(pbg), None, None, core=FakeCore())
+    assert doc == {"state": {"x": 1}}
+
+
+def test_resolve_document_composite_id_mode_builds_via_registered_spec(monkeypatch: pytest.MonkeyPatch) -> None:
+    spec = FakeSpec({"state": {"batch_runner": {}}})
+    _install_fake_composite_spec(monkeypatch, {"v2ecoli.composites.ecoli_baseline": spec})
+    core = FakeCore()
+    overrides = {"n_seeds": 1000, "n_generations": 10}
+
+    doc = run_pbg._resolve_document(None, "v2ecoli.composites.ecoli_baseline", overrides, core=core)
+
+    assert doc == {"state": {"batch_runner": {}}}
+    assert spec.overrides_received == overrides
+    assert spec.core_received is core
+
+
+def test_resolve_document_composite_id_retries_after_discover_specs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The composite's defining module may not be imported yet — its decorator only
+    fires on import. discover_specs() forces that; a second lookup then succeeds."""
+    spec = FakeSpec({"state": {}})
+    registry: dict[str, Any] = {}
+    discover_calls = _install_fake_composite_spec(monkeypatch, registry)
+
+    def _discover_and_populate() -> None:
+        discover_calls.append("called")
+        registry["late.module.ecoli_baseline"] = spec
+
+    sys.modules["process_bigraph.composite_spec"].discover_specs = _discover_and_populate  # type: ignore[attr-defined]
+
+    doc = run_pbg._resolve_document(None, "late.module.ecoli_baseline", {}, core=FakeCore())
+    assert doc == {"state": {}}
+    assert discover_calls == ["called"]
+
+
+def test_resolve_document_composite_id_unresolvable_raises_clearly(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_fake_composite_spec(monkeypatch, {})
+    with pytest.raises(SystemExit, match="no composite registered as 'missing.id'"):
+        run_pbg._resolve_document(None, "missing.id", None, core=FakeCore())
+
+
+def test_main_requires_exactly_one_of_input_file_or_composite_id(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(run_pbg, "run", lambda *a, **kw: captured.update(kw) or Path("x"))
+
+    with pytest.raises(SystemExit):
+        run_pbg.main([])  # neither given
+
+    pbg = tmp_path / "m.pbg"
+    pbg.write_text("{}")
+    with pytest.raises(SystemExit):
+        run_pbg.main([str(pbg), "--composite-id", "x.y"])  # both given
+
+
+def test_main_composite_id_mode_parses_overrides_json_and_calls_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(run_pbg, "run", lambda *a, **kw: captured.update(args=a, kwargs=kw) or Path("out"))
+
+    run_pbg.main(["--composite-id", "v2ecoli.composites.ecoli_baseline", "--overrides", '{"n_seeds": 2}', "-n", "1"])
+
+    assert captured["kwargs"]["composite_id"] == "v2ecoli.composites.ecoli_baseline"
+    assert captured["kwargs"]["overrides"] == {"n_seeds": 2}
+
+
+def test_run_composite_id_mode_end_to_end(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Full run() path: composite-id resolves to a document, Composite runs it, and
+    final_state.json still lands — the composite-id branch is a drop-in alternative
+    to the file branch, not a separate code path downstream of document acquisition."""
+
+    class FakeComposite:
+        def __init__(self, doc: Any, core: Any = None) -> None:
+            self.doc = doc
+
+        def run(self, n: int) -> None:
+            pass
+
+        def serialize_state(self) -> dict[str, Any]:
+            return {"doc_seen": self.doc}
+
+    fake_pbg_mod = types.ModuleType("process_bigraph")
+    fake_pbg_mod.Composite = FakeComposite  # type: ignore[attr-defined]
+    fake_pbg_mod.register_types = lambda core: core  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "process_bigraph", fake_pbg_mod)
+    fake_schema_mod = types.ModuleType("bigraph_schema")
+    fake_schema_mod.allocate_core = FakeCore  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "bigraph_schema", fake_schema_mod)
+
+    spec = FakeSpec({"state": {"batch_runner": {}}})
+    _install_fake_composite_spec(monkeypatch, {"v2ecoli.composites.ecoli_baseline": spec})
+
+    out = run_pbg.run(
+        None,
+        steps=1,
+        results_dir=tmp_path / "output",
+        composite_id="v2ecoli.composites.ecoli_baseline",
+        overrides={"n_seeds": 2, "n_generations": 3},
+    )
+
+    assert json.loads(out.read_text())["doc_seen"] == {"state": {"batch_runner": {}}}
+    assert spec.overrides_received == {"n_seeds": 2, "n_generations": 3}

--- a/tests/simulation/test_ray_backend.py
+++ b/tests/simulation/test_ray_backend.py
@@ -1,6 +1,8 @@
 """Tests for the Ray-on-Batch backend: JobId.ray, Batch state mapping, ComputeBackend.RAY,
 and SimulationServiceRay submission/status/cancel (boto3 mocked, Postgres via testcontainers)."""
 
+import json
+import shlex
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -225,29 +227,49 @@ class TestSimulationServiceRaySubmit:
         """config.generations > 1 (a real SimulationConfig field, not an "extra"
         comparison knob) must reach the sim job's command -- previously dropped
         entirely, so every GovCloud dispatch silently ran one generation only
-        regardless of what was requested."""
+        regardless of what was requested. Dispatched through the generic
+        run_pbg.py runner (backlog items 26/27), not a v2ecoli-specific script,
+        so the real request's own experiment_id must land in the overrides too
+        (previously silently defaulted to the script's own "batch_baseline")."""
         setattr(experiment_request.config, "n_init_sims", 2)  # noqa: B010
         experiment_request.config.generations = 3
         simulation = await database_service.insert_simulation(sim_request=experiment_request)
 
         mock_batch = _fake_batch(["parca-123", "sim-456"])
+        fake_file_service = AsyncMock()
+        fake_file_service.upload_file = AsyncMock()
 
         service = SimulationServiceRay()
         with (
             patch("sms_api.simulation.simulation_service_ray.get_settings", _ray_settings),
             patch("sms_api.common.storage.data_layout.get_settings", _ray_settings),
             patch("sms_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
+            patch("sms_api.dependencies.get_file_service", return_value=fake_file_service),
         ):
             await service.submit_ecoli_simulation_job(
                 ecoli_simulation=simulation, database_service=database_service, correlation_id="corr-2"
             )
 
+        # The generic runner is staged to S3 exactly once (per-experiment, mirroring
+        # ComposeSimulationServiceRay's own staging) before the sim job is built.
+        fake_file_service.upload_file.assert_awaited_once()
+
         _, sim_call = mock_batch.submit_job.call_args_list
         sim_env = _env_of(sim_call)
-        assert "run_batch_baseline_ray.py" in sim_env["RAY_JOB_CMD"]
-        assert "--n-seeds 2" in sim_env["RAY_JOB_CMD"]
-        assert "--n-generations 3" in sim_env["RAY_JOB_CMD"]
-        assert "run_phase0_xarray_ensemble.py" not in sim_env["RAY_JOB_CMD"]
+        cmd = sim_env["RAY_JOB_CMD"]
+        assert "run_batch_baseline_ray.py" not in cmd
+        assert "run_phase0_xarray_ensemble.py" not in cmd
+        assert "aws s3 cp" in cmd and "/tmp/run_pbg.py" in cmd
+        assert "--composite-id v2ecoli.composites.ecoli_baseline" in cmd
+        assert "PBG_CORE_BUILDER=v2ecoli.core:build_core" in cmd
+
+        tokens = shlex.split(cmd)
+        overrides = json.loads(tokens[tokens.index("--overrides") + 1])
+        assert overrides["n_seeds"] == 2
+        assert overrides["n_generations"] == 3
+        # The request's REAL experiment_id, not a hardcoded/implicit placeholder.
+        assert overrides["experiment_id"] == simulation.config.experiment_id
+        assert overrides["analyses"] == "none"
 
 
 @pytest.mark.asyncio
@@ -347,15 +369,51 @@ class TestSimulationServiceRayBuild:
 
     def test_sim_command_routes_to_batch_baseline_when_multi_generation_requested(self) -> None:
         """config.generations > 1 must route to the real multi-generation
-        LineageProcess/batch_baseline_runner pipeline, not the single-generation
-        script that silently ignores generation count."""
+        LineageProcess/batch_baseline_runner pipeline, dispatched as a registered
+        process-bigraph composite through the generic run_pbg.py runner -- not a
+        v2ecoli-specific CLI script (backlog items 26/27), and not the
+        single-generation script that silently ignores generation count."""
         service = SimulationServiceRay()
         with patch("sms_api.simulation.simulation_service_ray.get_settings", _ray_settings):
-            cmd = service._sim_command(n_seeds=2, n_steps=600, chunk=60, n_generations=3)
-        assert "run_batch_baseline_ray.py" in cmd
-        assert "--n-seeds 2" in cmd
-        assert "--n-generations 3" in cmd
+            cmd = service._sim_command(
+                n_seeds=2,
+                n_steps=600,
+                chunk=60,
+                n_generations=3,
+                experiment_id="sim47-real-experiment",
+                runner_s3_uri="s3://mybucket/vecoli-output/sim47-real-experiment/run_pbg.py",
+            )
+        assert "run_batch_baseline_ray.py" not in cmd
         assert "run_phase0_xarray_ensemble.py" not in cmd
+        assert "aws s3 cp s3://mybucket/vecoli-output/sim47-real-experiment/run_pbg.py /tmp/run_pbg.py" in cmd
+        assert "python /tmp/run_pbg.py" in cmd
+        assert "--composite-id v2ecoli.composites.ecoli_baseline" in cmd
+        assert "PBG_CORE_BUILDER=v2ecoli.core:build_core" in cmd
+        assert "-n 1" in cmd
+
+        # The overrides are a real, single-quoted JSON blob -- unpack it via shlex to
+        # assert on structured content rather than substring-matching a hand-escaped string.
+        tokens = shlex.split(cmd)
+        overrides = json.loads(tokens[tokens.index("--overrides") + 1])
+        assert overrides == {
+            "n_seeds": 2,
+            "n_generations": 3,
+            "cache_dir": PARCA_CACHE_DIR,
+            "out_dir": SIM_OUT_DIR,
+            "experiment_id": "sim47-real-experiment",
+            "analyses": "none",
+            "parallel": "ray",
+        }
+
+    def test_sim_command_multi_generation_requires_experiment_id_and_runner_uri(self) -> None:
+        """No silent placeholder default -- both must be supplied explicitly or the
+        dispatch fails loudly instead of running against the wrong experiment_id."""
+        service = SimulationServiceRay()
+        with patch("sms_api.simulation.simulation_service_ray.get_settings", _ray_settings):
+            with pytest.raises(RuntimeError, match="experiment_id"):
+                service._sim_command(n_seeds=2, n_steps=600, chunk=60, n_generations=3, runner_s3_uri="s3://x/y.py")
+            with pytest.raises(RuntimeError, match="runner_s3_uri"):
+                service._sim_command(n_seeds=2, n_steps=600, chunk=60, n_generations=3, experiment_id="exp-1")
 
     def test_sim_command_composite_takes_precedence_over_n_generations(self) -> None:
         """The comparison driver's own --max-generations flag is a separate knob

--- a/tests/simulation/test_ray_backend.py
+++ b/tests/simulation/test_ray_backend.py
@@ -259,7 +259,7 @@ class TestSimulationServiceRaySubmit:
         cmd = sim_env["RAY_JOB_CMD"]
         assert "run_batch_baseline_ray.py" not in cmd
         assert "run_phase0_xarray_ensemble.py" not in cmd
-        assert "aws s3 cp" in cmd and "/tmp/run_pbg.py" in cmd
+        assert "aws s3 cp" in cmd and "/tmp/run_pbg.py" in cmd  # noqa: S108
         assert "--composite-id v2ecoli.composites.ecoli_baseline" in cmd
         assert "PBG_CORE_BUILDER=v2ecoli.core:build_core" in cmd
 

--- a/uv.lock
+++ b/uv.lock
@@ -3075,7 +3075,7 @@ wheels = [
 
 [[package]]
 name = "sms-api"
-version = "0.9.27"
+version = "0.9.36"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
## Summary

- The multi-generation batch dispatch (previously `scripts/run_batch_baseline_ray.py`, a hardcoded v2ecoli-specific CLI script) now builds a process-bigraph document and runs it through the SAME generic `run_pbg.py` runner the compose-on-Batch path already uses.
- `run_pbg.py` gains a `--composite-id`/`--overrides` mode, resolving via `process_bigraph.composite_spec` — the same mechanism `vivarium_workbench.lib.pbg_export` already uses for the Composites tab. Its existing static-file mode is unchanged.
- Fixes a real bug this surfaced: the multi-gen dispatch never threaded the real `experiment_id` through — every batch's zarr/parquet output was silently stamped with the literal `"batch_baseline"` regardless of the actual request.
- Closes backlog items 26 and 27: the two Ray job-submission paths never had duplicated submission code (they already shared it via composition), only a duplicated job *command* — this removes the second execution mechanism entirely, so there's nothing left to unify.
- Version bump 0.9.35 → 0.9.36.

## Test plan

- [x] `uv run pytest tests/simulation/test_ray_backend.py -v` — 32 passed (new/updated multi-gen tests included)
- [x] `uv run pytest tests/compose/ -v` — 115 passed
- [x] `uv run pytest -q` (full suite) — no regressions attributable to this change
- [ ] One small real pilot dispatch on GovCloud before this is trusted for the actual 1000×10 baseline run

🤖 Generated with [Claude Code](https://claude.com/claude-code)