### PR TITLE
deploy(stanford prod): sms-api 0.9.33 -> 0.9.36, workbench 0.3.34 -> 0.3.36

### DIFF
--- a/kustomize/overlays/sms-api-stanford/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford/kustomization.yaml
@@ -29,8 +29,16 @@ images:
   # default-modules (--modules omitted) analysis dispatch failed at the
   # analysis-runner boundary (live-reproduced against sim db id 125, 5 failed
   # K8s Job attempts over 22h before root-caused).
+  # 0.9.36 (backlog items 26/27, #221): the multi-generation batch dispatch no
+  # longer shells out to the hardcoded scripts/run_batch_baseline_ray.py -- it
+  # stages the same generic run_pbg.py runner the /compose/v1 path already uses
+  # and dispatches a registered composite through it instead. Also fixes the
+  # multi-gen dispatch never threading the request's real experiment_id through
+  # (every batch's output was silently stamped "batch_baseline" regardless of
+  # what was actually requested). Supersedes 0.9.34/0.9.35, whose own tags were
+  # never cut on this branch at release time -- a real gap, not a skip.
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.9.33
+    newTag: 0.9.36
   # ptools pinned to last-known-good tag — CI only builds sms-api, so there is
   # no newer sms-ptools:0.6.x image on ghcr.io.  0.5.9 is the tag the live Stanford
   # pod has been running successfully; keeping both namespaces pointing here
@@ -134,8 +142,21 @@ images:
   # remote-pinned deployment (this one) it dispatches to AWS Batch via the
   # existing /api/remote-run-submit instead of always running locally. One
   # button, no new button; deployment mode decides the behavior.
+  # 0.3.35 (workbench #748): baseline.step runs can expose a downloadable JSON
+  # artifact under their run (analysis_out_dir injected into the Step's config,
+  # .json allowed as an analysis-output extension scoped to files under
+  # analyses/ so viewer/config packs are never surfaced as downloads).
+  # 0.3.36 (workbench #749/#750): recognizes the native per-lineage zarr naming
+  # (<experiment_id>_v<variant>_s<seed>.zarr) when landing a remote run,
+  # alongside the existing seed_NN/store.zarr convention -- a batch dispatched
+  # via the generic run_pbg.py runner (viva-api 0.9.36, same items 26/27) never
+  # restructures into seed_NN/store.zarr, and every lineage in the batch shares
+  # the same experiment_id=X/variant=Y prefix, so the prior top-level union
+  # would have kept only the first-processed lineage -- same class of bug as
+  # #674, recurring one level deeper. _merge_zarr_tree recurses into a
+  # collision instead of skipping it, for both zarr conventions.
   - name: ghcr.io/vivarium-collective/vivarium-workbench
-    newTag: 0.3.34
+    newTag: 0.3.36
 
 replicas:
   - count: 1


### PR DESCRIPTION
## Summary
- Bumps the Stanford-prod kustomize overlay's `sms-api` image tag 0.9.33 → 0.9.36 (backlog items 26/27: unified batch-baseline Ray dispatch via the generic `run_pbg.py` runner, real `experiment_id`-threading fix — see viva-api#221).
- Bumps `vivarium-workbench` 0.3.34 → 0.3.36 in the same overlay (recognizes the native per-lineage zarr naming when landing a remote run — see vivarium-workbench#749/#750). Both fixes are needed together for a real end-to-end validation of the new dispatch path: the workbench fix is what correctly lands a batch dispatched via the new viva-api path.
- Also documents 0.3.35's change in this file's changelog comments (was never deployed, so had no comment here yet — would otherwise be a silent skip).

## Test plan
- [x] `kubectl kustomize kustomize/overlays/sms-api-stanford` dry-run confirms both images resolve to the new tags.
- [ ] After merge: `kubectl diff` against the live cluster, then `kubectl apply -k`, then verify the live pod's `api` and `workbench` containers both actually contain the new code (grep a marker), not just a green rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)