### PR TITLE
fix: correct V2ECOLI_BASELINE_COMPOSITE_ID's missing .ecoli_baseline suffix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sms_api"
-version = "0.9.36"
+version = "0.9.37"
 description = "This is the api server for Vivarium simulation services."
 authors = [{ name = "Alex Patrie", email = "alexanderpatrie@gmail.com" }, { name = "Jim Schaff", email = "jschaff@gmail.com" }]
 requires-python = ">=3.13,<3.14"

--- a/sms_api/simulation/simulation_service_ray.py
+++ b/sms_api/simulation/simulation_service_ray.py
@@ -72,7 +72,14 @@ _RUNNER_SRC = (_res.files("sms_api.compose") / "run_pbg.py").read_text()
 # (e.g. "inplace_dict"). Both are inherent facts about what THIS endpoint dispatches — this
 # file already hardcodes v2ecoli-specific paths (V2ECOLI_DIR, PARCA_CACHE_DIR below); what
 # item 27 removes is the bespoke EXECUTION MECHANISM (a CLI script), not this identity.
-V2ECOLI_BASELINE_COMPOSITE_ID = "v2ecoli.composites.ecoli_baseline"
+# The id is `f"{fn.__module__}.{name}"` (process_bigraph.composite_spec's own registration
+# scheme, mirrored by viva_superpowers.composite_generator) -- v2ecoli/composites/
+# ecoli_baseline.py's decorated function is `baseline`, module `v2ecoli.composites.
+# ecoli_baseline`, decorated with `name="ecoli_baseline"`, so the real id has
+# "ecoli_baseline" twice (module path ends in it, name repeats it) -- don't "simplify" this
+# back to the module path alone, a live pilot dispatch failed with exactly that mistake
+# (2026-08-06): "run_pbg: no composite registered as 'v2ecoli.composites.ecoli_baseline'".
+V2ECOLI_BASELINE_COMPOSITE_ID = "v2ecoli.composites.ecoli_baseline.ecoli_baseline"
 V2ECOLI_CORE_BUILDER = "v2ecoli.core:build_core"
 
 # Absolute paths inside the v2ecoli Ray image (WORKDIR=/app/v2ecoli). The

--- a/sms_api/version.py
+++ b/sms_api/version.py
@@ -175,4 +175,16 @@
 #          experiment_id through — every batch's zarr/parquet output was
 #          silently stamped with the literal "batch_baseline" regardless of
 #          the actual request.
-__version__ = "0.9.36"
+# 0.9.37 — fixes V2ECOLI_BASELINE_COMPOSITE_ID: was "v2ecoli.composites.
+#          ecoli_baseline", missing process_bigraph.composite_spec's own
+#          f"{fn.__module__}.{name}" id scheme's trailing ".ecoli_baseline"
+#          (the composite's decorator name=). Every 0.9.36 multi-gen dispatch
+#          failed with "no composite registered as
+#          'v2ecoli.composites.ecoli_baseline'" — never caught by the unit
+#          tests (they mock the whole registry), only by a real pilot
+#          dispatch against live GovCloud (2026-08-06). Also strengthens the
+#          two ray_backend tests that asserted this id in the constructed
+#          command: the old assertion checked a substring that the WRONG
+#          value also satisfies (it's a prefix of the real id), so it could
+#          never have caught this regression either.
+__version__ = "0.9.37"

--- a/tests/simulation/test_ray_backend.py
+++ b/tests/simulation/test_ray_backend.py
@@ -260,7 +260,12 @@ class TestSimulationServiceRaySubmit:
         assert "run_batch_baseline_ray.py" not in cmd
         assert "run_phase0_xarray_ensemble.py" not in cmd
         assert "aws s3 cp" in cmd and "/tmp/run_pbg.py" in cmd  # noqa: S108
-        assert "--composite-id v2ecoli.composites.ecoli_baseline" in cmd
+        # Exact match, not a substring check: "v2ecoli.composites.ecoli_baseline" alone is a
+        # PREFIX of the real registered id and would have silently passed the wrong constant
+        # (process_bigraph.composite_spec's id scheme is f"{fn.__module__}.{name}" -- the
+        # module already ends in "ecoli_baseline", and the composite's own name="ecoli_baseline"
+        # repeats it -- a live pilot dispatch failed on exactly this mistake, 2026-08-06).
+        assert "--composite-id v2ecoli.composites.ecoli_baseline.ecoli_baseline " in cmd
         assert "PBG_CORE_BUILDER=v2ecoli.core:build_core" in cmd
 
         tokens = shlex.split(cmd)
@@ -387,7 +392,12 @@ class TestSimulationServiceRayBuild:
         assert "run_phase0_xarray_ensemble.py" not in cmd
         assert "aws s3 cp s3://mybucket/vecoli-output/sim47-real-experiment/run_pbg.py /tmp/run_pbg.py" in cmd
         assert "python /tmp/run_pbg.py" in cmd
-        assert "--composite-id v2ecoli.composites.ecoli_baseline" in cmd
+        # Exact match, not a substring check: "v2ecoli.composites.ecoli_baseline" alone is a
+        # PREFIX of the real registered id and would have silently passed the wrong constant
+        # (process_bigraph.composite_spec's id scheme is f"{fn.__module__}.{name}" -- the
+        # module already ends in "ecoli_baseline", and the composite's own name="ecoli_baseline"
+        # repeats it -- a live pilot dispatch failed on exactly this mistake, 2026-08-06).
+        assert "--composite-id v2ecoli.composites.ecoli_baseline.ecoli_baseline " in cmd
         assert "PBG_CORE_BUILDER=v2ecoli.core:build_core" in cmd
         assert "-n 1" in cmd
 

--- a/uv.lock
+++ b/uv.lock
@@ -3075,7 +3075,7 @@ wheels = [
 
 [[package]]
 name = "sms-api"
-version = "0.9.36"
+version = "0.9.37"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
## Summary
- `V2ECOLI_BASELINE_COMPOSITE_ID` was `"v2ecoli.composites.ecoli_baseline"` — missing the trailing `.ecoli_baseline` that `process_bigraph.composite_spec`'s own `f"{fn.__module__}.{name}"` registration scheme requires (v2ecoli's `ecoli_baseline.py` decorates `baseline()` with `name="ecoli_baseline"`, so the real id repeats it).
- Real-world impact: every 0.9.36 multi-gen dispatch failed with `no composite registered as 'v2ecoli.composites.ecoli_baseline'`. Caught by a live pilot dispatch against GovCloud (sim 130, job `1b41d840-...`) — confirmed via the actual `RAY_JOB_CMD` pulled from `aws batch describe-jobs` and the real error in CloudWatch logs.
- Never caught by the unit tests: they install a fake composite-spec registry, so any id string round-trips regardless of correctness. Strengthened both `ray_backend` tests that assert this id in the constructed command — the old assertion checked a substring the WRONG value also satisfies (a literal prefix of the correct id).
- Version 0.9.36 → 0.9.37.

## Test plan
- [x] `make check` (lint/format/mypy/deptry) green.
- [x] `uv run pytest tests/simulation/test_ray_backend.py tests/compose/test_run_pbg.py` — 52 passed.
- [ ] Re-verify via a second real pilot dispatch after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)