### PR TITLE
deploy(stanford prod): sms-api 0.9.36 -> 0.9.37

### DIFF
--- a/kustomize/overlays/sms-api-stanford/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford/kustomization.yaml
@@ -37,8 +37,15 @@ images:
   # (every batch's output was silently stamped "batch_baseline" regardless of
   # what was actually requested). Supersedes 0.9.34/0.9.35, whose own tags were
   # never cut on this branch at release time -- a real gap, not a skip.
+  # 0.9.37 (#223): fixes V2ECOLI_BASELINE_COMPOSITE_ID, which was missing the
+  # trailing ".ecoli_baseline" that process_bigraph.composite_spec's own
+  # f"{fn.__module__}.{name}" id scheme requires -- every real 0.9.36 multi-gen
+  # dispatch failed with "no composite registered as
+  # 'v2ecoli.composites.ecoli_baseline'", caught by a live pilot dispatch
+  # against this exact deployment (2026-08-06), never caught by unit tests
+  # (they mock the whole registry).
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.9.36
+    newTag: 0.9.37
   # ptools pinned to last-known-good tag — CI only builds sms-api, so there is
   # no newer sms-ptools:0.6.x image on ghcr.io.  0.5.9 is the tag the live Stanford
   # pod has been running successfully; keeping both namespaces pointing here


### PR DESCRIPTION
## Summary
- Bumps the Stanford-prod kustomize overlay's `sms-api` image tag 0.9.36 → 0.9.37: fixes the wrong `V2ECOLI_BASELINE_COMPOSITE_ID` that caused every real multi-gen dispatch to fail (see #223).
- `vivarium-workbench` unchanged at 0.3.36 — not affected by this fix.

## Test plan
- [x] `kubectl kustomize kustomize/overlays/sms-api-stanford` dry-run confirms the image resolves to 0.9.37.
- [ ] After merge: `kubectl diff` against the live cluster, then `kubectl apply -k`, then verify the live pod and re-run the pilot dispatch to confirm the fix actually works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)