### PR TITLE
deploy(stanford prod): api 0.9.38 -> 0.9.39 (Array jobs for canonical)

### DIFF
--- a/kustomize/config/sms-api-stanford/shared.env
+++ b/kustomize/config/sms-api-stanford/shared.env
@@ -31,6 +31,12 @@ BATCH_TASK_ARCH=arm64
 # (smscdk-ray-batch / smscdk-ray).
 RAY_MNP_QUEUE=smscdk-ray-mnp
 RAY_MNP_JOB_DEFINITION=smscdk-ray-mnp
+# Array jobs for canonical multiseed/multigen dispatch (n_seeds>1, n_generations>1, no
+# composite override) -- separate from RAY_MNP_*, which stays for colonies. Queue is
+# BatchStack's existing vecoli-task-amd64 (same as BATCH_AMD64_QUEUE above), reused
+# deliberately per the smscdk-ray-batch stack's own design (see sms-cdk PR #33).
+RAY_ARRAY_QUEUE=smscdk-vecoli-task-amd64
+RAY_ARRAY_JOB_DEFINITION=smscdk-ray-array
 RAY_LOG_S3_PREFIX=s3://smscdk-shared-sharedbucket60d199d6-2u7sguagdihi/ray-logs/
 RAY_ECR_REPOSITORY=v2ecoli
 RAY_NUM_NODES=24

--- a/kustomize/overlays/sms-api-stanford/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford/kustomization.yaml
@@ -52,8 +52,14 @@ images:
   # v2ecoli/composites/batch_baseline.py (name="batch_baseline"). Renamed the
   # constant to V2ECOLI_BATCH_BASELINE_COMPOSITE_ID = "v2ecoli.composites.
   # batch_baseline.batch_baseline".
+  # 0.9.39 (#226): Array-jobs-for-canonical dispatch -- batch_baseline multiseed x
+  # multigeneration sweeps (n_seeds>1, n_generations>1, no composite override) now
+  # submit as an AWS Batch Array job (N independent single-seed children) instead of
+  # an MNP Ray cluster. Ray-MNP unchanged for ParCa, phase0/comparison-ensemble, and
+  # colonies. Needs the new RAY_ARRAY_QUEUE/RAY_ARRAY_JOB_DEFINITION shared.env values
+  # (smscdk-ray-batch stack's RayArrayJobDef, sms-cdk PR #33, deployed same session).
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.9.38
+    newTag: 0.9.39
   # ptools pinned to last-known-good tag — CI only builds sms-api, so there is
   # no newer sms-ptools:0.6.x image on ghcr.io.  0.5.9 is the tag the live Stanford
   # pod has been running successfully; keeping both namespaces pointing here


### PR DESCRIPTION
Bumps the Stanford prod overlay to sms-api 0.9.39 (sms-cdk PR #33 + viva-api PR #226, Array jobs for canonical multiseed/multigen dispatch) and sets the two new RAY_ARRAY_QUEUE/RAY_ARRAY_JOB_DEFINITION shared.env values against the smscdk-ray-batch stack's RayArrayJobDef, already deployed this session. Ray-MNP config unchanged.