### PR TITLE
fix: _submit_array dependsOn rejected by real AWS Batch (v0.9.40)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sms_api"
-version = "0.9.39"
+version = "0.9.40"
 description = "This is the api server for Vivarium simulation services."
 authors = [{ name = "Alex Patrie", email = "alexanderpatrie@gmail.com" }, { name = "Jim Schaff", email = "jschaff@gmail.com" }]
 requires-python = ">=3.13,<3.14"

--- a/sms_api/simulation/simulation_service_ray.py
+++ b/sms_api/simulation/simulation_service_ray.py
@@ -372,7 +372,13 @@ class SimulationServiceRay(SimulationService):
             "containerOverrides": {"environment": env},
         }
         if depends_on:
-            kwargs["dependsOn"] = [{"jobId": jid, "type": "SEQUENTIAL"} for jid in depends_on]
+            # Plain job dependency (no "type") -- NOT "SEQUENTIAL", unlike _submit_mnp above.
+            # AWS Batch rejects {"jobId": ..., "type": "SEQUENTIAL"} for a job that also sets
+            # arrayProperties: real error, hit live 2026-08-06, "Job Id cannot be set when
+            # dependency type is SEQUENTIAL". SEQUENTIAL is for an array job depending on
+            # itself/other array-shaped dependents, not a targeted jobId wait -- it doesn't
+            # apply here, we just need "don't start any array child until ParCa succeeds".
+            kwargs["dependsOn"] = [{"jobId": jid} for jid in depends_on]
         if tags:
             kwargs["tags"] = tags
             kwargs["propagateTags"] = True

--- a/sms_api/version.py
+++ b/sms_api/version.py
@@ -224,4 +224,17 @@
 #          adds the RayArrayJobDef job definition + batch-array-entrypoint.sh
 #          -- see the ray-vs-batch-array-jobs-investigation decision: Array
 #          jobs for canonical, Ray-MNP stays for colonies.
-__version__ = "0.9.39"
+# 0.9.40 — fix _submit_array's dependsOn: real AWS Batch rejected the array pilot's
+#          first live dispatch with "Job Id cannot be set when dependency type is
+#          SEQUENTIAL" -- _submit_array had copy-pasted _submit_mnp's dependsOn
+#          shape ({"jobId": jid, "type": "SEQUENTIAL"}) verbatim, but SEQUENTIAL
+#          is invalid alongside an explicit jobId for a job that also sets
+#          arrayProperties (which every array submission does). Fixed to a plain
+#          {"jobId": jid} dependency (no "type"). _submit_mnp is untouched --
+#          the MNP path has real successful dispatch history with the SEQUENTIAL
+#          shape and was never in question. The mocked unit test for the array
+#          path had asserted the buggy shape as correct (classic green-mock-as-
+#          go-signal: the mock never validates against AWS's real API rules) --
+#          strengthened to assert the correct type-less shape, with a comment
+#          explaining why so it can't be silently "simplified" back.
+__version__ = "0.9.40"

--- a/tests/simulation/test_ray_backend.py
+++ b/tests/simulation/test_ray_backend.py
@@ -294,7 +294,12 @@ class TestSimulationServiceRaySubmit:
         assert "nodeOverrides" not in sim_call.kwargs
         assert sim_call.kwargs["arrayProperties"] == {"size": 4}
         assert sim_call.kwargs["jobQueue"] == "smscdk-vecoli-task-amd64"
-        assert sim_call.kwargs["dependsOn"] == [{"jobId": "parca-123", "type": "SEQUENTIAL"}]
+        # Plain dependency, NO "type" key -- real AWS Batch rejects {"type": "SEQUENTIAL"}
+        # combined with an explicit jobId when the submitting job itself sets
+        # arrayProperties (live error hit 2026-08-06: "Job Id cannot be set when
+        # dependency type is SEQUENTIAL"). Do not "simplify" this back to match
+        # _submit_mnp's shape -- that's the exact regression this assertion guards.
+        assert sim_call.kwargs["dependsOn"] == [{"jobId": "parca-123"}]
 
         sim_env = _array_env(sim_call)
         cmd = sim_env["ARRAY_JOB_CMD"]

--- a/uv.lock
+++ b/uv.lock
@@ -3075,7 +3075,7 @@ wheels = [
 
 [[package]]
 name = "sms-api"
-version = "0.9.39"
+version = "0.9.40"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
Live pilot dispatch of the just-deployed Array-jobs path (v0.9.39) failed immediately after ParCa submission: `Job Id cannot be set when dependency type is SEQUENTIAL`. `_submit_array` had copy-pasted `_submit_mnp`'s `dependsOn` shape verbatim (`{"jobId": jid, "type": "SEQUENTIAL"}`), but that's invalid for a job that also sets `arrayProperties`. Fixed to a plain `{"jobId": jid}` dependency. `_submit_mnp` untouched -- real successful dispatch history, never in question.

The mocked unit test for the array path had asserted the buggy shape as the expected value -- a real instance of the green-mock-as-go-signal anti-pattern (the mock never validates against AWS's actual API rules). Strengthened to assert the correct shape, with a comment explaining why.

make check clean, 39/39 targeted tests pass.