### PR TITLE
feat(dispatch): auto-trigger analysis from the pipeline DAG (v0.9.41)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sms_api"
-version = "0.9.40"
+version = "0.9.41"
 description = "This is the api server for Vivarium simulation services."
 authors = [{ name = "Alex Patrie", email = "alexanderpatrie@gmail.com" }, { name = "Jim Schaff", email = "jschaff@gmail.com" }]
 requires-python = ">=3.13,<3.14"

--- a/sms_api/common/handlers/analyses.py
+++ b/sms_api/common/handlers/analyses.py
@@ -22,14 +22,21 @@ from sms_api.analysis.models import (
     OutputFileMetadata,
     TsvOutputFile,
 )
+from sms_api.common.hpc.job_service import JobStatusInfo
 from sms_api.common.models import JobId, JobStatus, SSHTarget
 from sms_api.common.storage import data_layout
 from sms_api.common.storage.file_paths import HPCFilePath, S3FilePath
 from sms_api.common.utils import get_data_id, timestamp
 from sms_api.config import get_settings
-from sms_api.dependencies import get_file_service, get_simulation_service, get_ssh_session_service
+from sms_api.dependencies import (
+    get_file_service,
+    get_simulation_service,
+    get_simulation_service_for_repo,
+    get_ssh_session_service,
+)
 from sms_api.simulation.database_service import DatabaseService
 from sms_api.simulation.models import SimulatorVersion
+from sms_api.simulation.simulation_service import SimulationService
 from sms_api.simulation.tables_orm import AnalysisStatusDB
 
 # Text output extensions the analysis data endpoint returns (mirrors the legacy
@@ -196,18 +203,67 @@ def _parse_cached_filename_metadata(filename: str) -> dict[str, int]:
     return metadata
 
 
+async def _live_analysis_job_status(
+    db_service: DatabaseService,
+    record: ExperimentAnalysisDTO,
+) -> JobStatusInfo | None:
+    """Live job status for an analysis record's backing job, whichever backend ran it.
+
+    Two producers write ``backend="ray"`` rows and they do NOT share a job
+    namespace: ``submit_ray_native_analysis`` creates a **K8s Job**
+    (``job_id_ext`` = the Job name), while the Ray dispatch DAG's own analysis
+    node is an **AWS Batch job** (``job_id_ext`` = the Batch job id). A K8s
+    lookup of a Batch id just returns None, so without this the Batch case would
+    have no early-failure signal at all -- including the common one where the
+    simulation itself failed and Batch never ran the dependent analysis job,
+    which would leave the row COMPUTING forever instead of reporting FAILED.
+
+    Tries the default service first (unchanged behaviour for the K8s producer),
+    then the service that actually owns the record's simulation. Each lookup is
+    isolated: querying one backend with the other's identifier is expected to
+    miss, and must not surface as an error.
+    """
+    if not record.job_id_ext:
+        return None
+    attempts: list[tuple[SimulationService, JobId]] = []
+    default_service = get_simulation_service()
+    if default_service is not None:
+        attempts.append((default_service, JobId.k8s(record.job_id_ext)))
+    if record.simulation_id is not None:
+        simulation = await db_service.get_simulation(simulation_id=record.simulation_id)
+        simulator = (
+            await db_service.get_simulator(simulator_id=simulation.simulator_id) if simulation is not None else None
+        )
+        if simulator is not None:
+            owning = get_simulation_service_for_repo(simulator.git_repo_url)
+            if owning is not None and owning is not default_service:
+                attempts.append((owning, JobId.ray(record.job_id_ext)))
+    for service, job_id in attempts:
+        try:
+            info = await service.get_job_status(job_id)
+        except Exception:
+            logging.getLogger(__name__).debug(
+                "analysis %s: no job status from %s", record.database_id, type(service).__name__
+            )
+            continue
+        if info is not None:
+            return info
+    return None
+
+
 async def handle_get_ray_analysis_status(
     db_service: DatabaseService,
     record: ExperimentAnalysisDTO,
 ) -> AnalysisRun:
-    """Resolve a Ray-native standalone analysis's status (submit_ray_native_analysis).
+    """Resolve a Ray-native standalone analysis's status.
 
-    There is no persistent job-status API for the backing K8s Job (it has
-    ttl_seconds_after_finished=86400, so get_job_status returns None once that
-    expires) -- S3-exists is the durable, authoritative READY signal, matching
-    analysis-results-design.md's own status-resolution plan. Falls back to a
-    live K8s job-status check only to catch an early, hard failure (image pull
-    error, scheduling failure) before the manifest could ever be written.
+    There is no persistent job-status API for the backing job (a K8s Job has
+    ttl_seconds_after_finished=86400, an AWS Batch job ages out of describe_jobs)
+    -- S3-exists is the durable, authoritative READY signal, matching
+    analysis-results-design.md's own status-resolution plan. Falls back to a live
+    job-status check only to catch a failure that happened before the manifest
+    could ever be written: an image-pull/scheduling error, or (for the dispatch
+    DAG's analysis node) the simulation it depends on having failed.
     """
     if record.status in (JobStatus.COMPLETED, JobStatus.FAILED):
         return AnalysisRun(id=record.database_id, status=record.status, error_log=record.error_message)
@@ -230,14 +286,12 @@ async def handle_get_ray_analysis_status(
         )
         return AnalysisRun(id=record.database_id, status=JobStatus.FAILED, error_log=error_message)
 
-    sim_service = get_simulation_service()
-    if sim_service is not None and record.job_id_ext:
-        job_status_info = await sim_service.get_job_status(JobId.k8s(record.job_id_ext))
-        if job_status_info is not None and job_status_info.status == JobStatus.FAILED:
-            await db_service.update_analysis_status(
-                record.database_id, AnalysisStatusDB.FAILED, error_message=job_status_info.error_message
-            )
-            return AnalysisRun(id=record.database_id, status=JobStatus.FAILED, error_log=job_status_info.error_message)
+    job_status_info = await _live_analysis_job_status(db_service, record)
+    if job_status_info is not None and job_status_info.status == JobStatus.FAILED:
+        await db_service.update_analysis_status(
+            record.database_id, AnalysisStatusDB.FAILED, error_message=job_status_info.error_message
+        )
+        return AnalysisRun(id=record.database_id, status=JobStatus.FAILED, error_log=job_status_info.error_message)
 
     return AnalysisRun(id=record.database_id, status=JobStatus.RUNNING)
 

--- a/sms_api/common/handlers/simulations.py
+++ b/sms_api/common/handlers/simulations.py
@@ -1457,11 +1457,23 @@ def workflow_log(simulation_id: int, base_url: str = "http://localhost:8080", ti
     )
 
 
+# Caller-facing default for the LEGACY vEcoli/Nextflow analysis paths, which take an
+# explicit module list and have no registry-backed resolver. The Ray/v2ecoli path
+# resolves its own default instead (see _run_standalone_analysis_ray_native).
+_DEFAULT_LEGACY_ANALYSIS_MODULES: dict[str, dict[str, Any]] = {
+    "single": {
+        "ptools_rna": {"n_tp": 10},
+        "ptools_rxns": {"n_tp": 10},
+        "ptools_proteins": {"n_tp": 10},
+    }
+}
+
+
 async def _run_standalone_analysis_ray_native(
     database_service: DatabaseService,
     simulation: Simulation,
     simulator: SimulatorVersion,
-    modules: dict[str, dict[str, Any]],
+    modules: dict[str, dict[str, Any]] | None,
 ) -> dict[str, Any]:
     """Standalone analysis for a Ray/xarray-dispatched simulation (v2ecoli/sms-ecoli).
 
@@ -1473,8 +1485,19 @@ async def _run_standalone_analysis_ray_native(
     -- already migrated, just never wired into a K8s submission path before
     this) so GET /analyses/{id}/status can resolve real progress instead of
     callers having no way to know when the job is done.
+
+    ``modules=None`` resolves the same way the dispatch DAG's own analysis node
+    does (``analysis_modules_for``): the simulation's own configured
+    analysis_options, else the composite's ``applicable`` keyword. A
+    hand-triggered analysis and an auto-triggered one must cover the same
+    ground -- the legacy caller-facing default (three ptools modules) would
+    silently under-deliver the cd1_* suite for this pipeline.
     """
+    from sms_api.simulation.simulation_service_ray import analysis_modules_for
+
     config = simulation.config
+    if modules is None:
+        modules = analysis_modules_for(config)  # type: ignore[assignment]
     out_uri = getattr(config, "emitter_arg", None)
     out_uri = (out_uri or {}).get("out_uri") if isinstance(out_uri, dict) else None
     if not out_uri:
@@ -1499,6 +1522,7 @@ async def _run_standalone_analysis_ray_native(
     params: dict[str, Any] = {
         "out_uri": out_uri,
         "n_seeds": n_seeds,
+        "n_generations": int(getattr(config, "generations", 1) or 1),
         "modules": modules,
         "analysis_name": analysis_name,
         # ORMAnalysis.to_dto() unconditionally reads config["analysis_options"]
@@ -1506,9 +1530,13 @@ async def _run_standalone_analysis_ray_native(
         # producers below already write this shape (experiment_id + each domain
         # spread as a top-level key); match it so to_dto() doesn't KeyError. The
         # v2ecoli-side consumer (run_standalone_analysis.py) only reads out_uri/
-        # n_seeds/modules/analysis_name and ignores unknown keys, so this is inert
-        # for it -- purely for the DTO contract.
-        "analysis_options": {"experiment_id": [experiment_id], **modules},
+        # n_seeds/n_generations/modules/analysis_name and ignores unknown keys, so
+        # this is inert for it -- purely for the DTO contract. ``modules`` may be
+        # the "applicable" keyword rather than a mapping, which spreads to nothing.
+        "analysis_options": {
+            "experiment_id": [experiment_id],
+            **(modules if isinstance(modules, dict) else {}),
+        },
     }
     job_id = await sim_service.submit_ray_native_analysis(
         experiment_id=experiment_id,
@@ -1558,16 +1586,6 @@ async def run_standalone_analysis(
 
     experiment_id = simulation.experiment_id
 
-    # Default analysis modules if none specified
-    if modules is None:
-        modules = {
-            "single": {
-                "ptools_rna": {"n_tp": 10},
-                "ptools_rxns": {"n_tp": 10},
-                "ptools_proteins": {"n_tp": 10},
-            }
-        }
-
     # Build analysis config — path patterns match vEcoli conventions
     backend = get_job_backend()
     if backend == ComputeBackend.BATCH:
@@ -1584,6 +1602,9 @@ async def run_standalone_analysis(
                 simulator=simulator,
                 modules=modules,
             )
+        # The legacy vEcoli/Nextflow path below has no "applicable" resolver, so its
+        # caller-facing default stays an explicit module list.
+        modules = modules or _DEFAULT_LEGACY_ANALYSIS_MODULES
         s3_output = data_layout.NextflowLayout.output_uri(experiment_id)
         analysis_name = f"analysis-{experiment_id[:20]}-{str(uuid.uuid4())[:4]}"
         analysis_config: dict[str, Any] = {
@@ -1619,6 +1640,7 @@ async def run_standalone_analysis(
         return {"job_id": str(job_id), "analysis_name": analysis_name, "config": analysis_config}
     else:
         # SLURM path
+        modules = modules or _DEFAULT_LEGACY_ANALYSIS_MODULES
         sim_base = settings.hpc_sim_base_path.remote_path
         analysis_name = f"analysis-{experiment_id[:20]}-{str(uuid.uuid4())[:4]}"
         analysis_config = {

--- a/sms_api/simulation/simulation_service_ray.py
+++ b/sms_api/simulation/simulation_service_ray.py
@@ -13,6 +13,12 @@ Data flow (no shared filesystem):
   - The simulation MNP job ``dependsOn`` the ParCa job (Batch gates it until
     ParCa SUCCEEDED), stages that cache (``RAY_STAGE_S3``), runs the ensemble,
     and captures the zarr/summary outputs to S3 (``RAY_OUT_S3``).
+  - For the multi-generation batch_baseline sweep, an ANALYSIS job ``dependsOn``
+    the simulation job and runs the ported cd1_*/ptools_* analyses over the
+    landed S3 sweep. The whole pipeline is therefore one Batch dependency DAG
+    (parca -> sim -> analysis); nothing external has to notice a completion and
+    react to it. See ``_analysis_command`` for why this is a third DAG node and
+    not the composite's own inline flush.
 
 The image is the **workload-owned**, self-contained ``v2ecoli:<sha>`` (bundles
 the AWS CLI + the Ray entrypoint), built by ``submit_build_image_job`` via a DooD
@@ -34,6 +40,7 @@ from pathlib import Path
 from typing import Any, override
 
 import boto3
+from pydantic import BaseModel
 
 from sms_api.common.hpc.job_service import JobStatusInfo
 from sms_api.common.hpc.local_task_service import LocalTaskService
@@ -58,6 +65,7 @@ from sms_api.simulation.models import (
     VecoliSource,
 )
 from sms_api.simulation.simulation_service import SimulationService
+from sms_api.simulation.tables_orm import AnalysisStatusDB
 
 logger = logging.getLogger(__name__)
 
@@ -101,12 +109,52 @@ V2ECOLI_DIR = "/app/v2ecoli"
 PARCA_CACHE_DIR = f"{V2ECOLI_DIR}/out/cache"
 PARCA_SIMDATA_DIR = f"{V2ECOLI_DIR}/out/sim_data"
 SIM_OUT_DIR = f"{V2ECOLI_DIR}/.pbg/runs/phase0-xarray"
+# The analysis DAG node writes its outputs straight to S3 (see _analysis_command),
+# so this local dir normally never exists and the entrypoint's RAY_OUT_DIR sync is a
+# documented no-op ("no <dir>; nothing to upload"). It is still declared so anything
+# the analysis does drop locally lands under the run's own S3 prefix.
+ANALYSIS_OUT_DIR = f"{V2ECOLI_DIR}/.pbg/runs/analysis"
 # Where the head writes the entrypoint's metrics report (uploaded as report.json).
 REPORT_PATH = "/tmp/report.json"  # noqa: S108
+
+# The analysis scales a v2ecoli ``analysis_options`` map can carry. Everything else
+# in that (extra="allow") model — ``cpus``, ``memory_gb``, vEcoli-Nextflow-only keys —
+# is not a scale and must not be forwarded as one.
+ANALYSIS_SCALES = ("single", "multidaughter", "multigeneration", "multiseed", "multivariant")
+# The composite's own "every analysis this batch's shape has the cells for" keyword
+# (v2ecoli.steps.batch_baseline_runner.build_analysis_options). Used when the caller
+# named no modules: sms-api runs outside the model image and has no ANALYSIS_REGISTRY
+# to enumerate, so it asks the image to resolve the set with its own resolver rather
+# than carrying a second, drift-prone copy of the list.
+APPLICABLE_ANALYSES = "applicable"
 
 
 def _rand_suffix() -> str:
     return "".join(random.choices(string.ascii_lowercase + string.digits, k=6))
+
+
+def analysis_modules_for(config: Any) -> dict[str, dict[str, Any]] | str:
+    """The analyses the analysis DAG node should run for this simulation.
+
+    Reads the simulation's OWN ``config.analysis_options`` — the field the run
+    endpoint already populates from the caller's ``--analysis-options`` (and that
+    the workbench already fills from a study's ``spec.analyses``), and which this
+    backend previously ignored entirely, so a remote dispatch's configured
+    analyses never ran.
+
+    Only real scale keys are forwarded, and only non-empty ones: the endpoint's
+    own fallback default is ``{"multiseed": {}}`` — "no modules named", not "run
+    nothing" — which resolves to the ``applicable`` keyword like any other
+    unset case.
+    """
+    options: Any = getattr(config, "analysis_options", None)
+    raw: dict[str, Any] = options.model_dump() if isinstance(options, BaseModel) else dict(options or {})
+    modules = {
+        scale: dict(entries)
+        for scale, entries in raw.items()
+        if scale in ANALYSIS_SCALES and isinstance(entries, dict) and entries
+    }
+    return modules or APPLICABLE_ANALYSES
 
 
 def _is_upstream_vecoli(composite: CompositeEngine | None) -> bool:
@@ -258,6 +306,7 @@ class SimulationServiceRay(SimulationService):
         stage_s3: str | None = None,
         stage_dir: str | None = None,
         depends_on: list[str] | None = None,
+        depends_type: str | None = "SEQUENTIAL",
         tags: dict[str, str] | None = None,
     ) -> str:
         """Submit a Ray MNP job via boto3, mirroring sms-cdk scripts/ray_batch_submit.sh.
@@ -268,6 +317,13 @@ class SimulationServiceRay(SimulationService):
         zarr to S3. Only ``RAY_JOB_CMD`` (the driver) and ``RAY_REPORT_PATH`` are
         head-only. So the shared env goes on node 0 (``0:0``) and, when there are
         workers, also on the worker range (``1:``). Returns the AWS Batch job id.
+
+        ``depends_type`` selects the ``dependsOn`` shape. The default keeps the
+        long-standing ParCa→sim edge byte-identical (``{"jobId": …, "type":
+        "SEQUENTIAL"}``, live-verified). Pass ``None`` for a plain ``{"jobId": …}``
+        wait — required when the DEPENDENCY is an Array job, whose parent id AWS
+        Batch will not accept under a SEQUENTIAL type (real API rejection, hit live
+        2026-08-06; see ``_submit_array``).
         """
         settings = get_settings()
         # Per-node knobs every node acts on (stage cache in, sync results out, ship logs).
@@ -310,7 +366,9 @@ class SimulationServiceRay(SimulationService):
             "nodeOverrides": node_overrides,
         }
         if depends_on:
-            kwargs["dependsOn"] = [{"jobId": jid, "type": "SEQUENTIAL"} for jid in depends_on]
+            kwargs["dependsOn"] = [
+                ({"jobId": jid, "type": depends_type} if depends_type else {"jobId": jid}) for jid in depends_on
+            ]
         if tags:
             # Cost-allocation tags: propagate to the underlying ECS tasks so the
             # payer account's Cost Explorer can attribute compute per run/engine.
@@ -528,9 +586,10 @@ class SimulationServiceRay(SimulationService):
                 "cache_dir": PARCA_CACHE_DIR,
                 "out_dir": SIM_OUT_DIR,
                 "experiment_id": experiment_id,
-                # Standalone post-hoc analysis (scripts/run_standalone_analysis.py)
-                # runs the same analysis_runner.run_analyses() directly against the
-                # landed S3 sweep -- skip the composite's own inline flush here.
+                # The analysis DAG node (see _analysis_command) runs the same
+                # analysis_runner.run_analyses() over the LANDED S3 sweep once this
+                # job has succeeded -- skip the composite's own inline flush here so
+                # the analyses run exactly once, over the whole sweep.
                 "analyses": "none",
                 "parallel": "ray",
             }
@@ -581,6 +640,9 @@ class SimulationServiceRay(SimulationService):
             "cache_dir": PARCA_CACHE_DIR,
             "out_dir": SIM_OUT_DIR,
             "experiment_id": experiment_id,
+            # A child sees only ITS OWN seed, so an inline flush here would run the
+            # cross-seed scales against one seed, N times over. The whole-sweep
+            # analysis is the DAG's third node instead -- see _analysis_command.
             "analyses": "none",
             "parallel": "",
         }
@@ -596,6 +658,154 @@ class SimulationServiceRay(SimulationService):
             f" --composite-id {V2ECOLI_BATCH_BASELINE_COMPOSITE_ID}"
             f' --overrides "$OVERRIDES" -n 1'
         )
+
+    def _analysis_command(
+        self,
+        *,
+        experiment_id: str,
+        n_seeds: int,
+        n_generations: int,
+        modules: dict[str, dict[str, Any]] | str,
+        analysis_name: str,
+        commit: str,
+    ) -> str:
+        """Build the analysis DAG node's command: the ported analyses over the S3 sweep.
+
+        WHY A THIRD DAG NODE, not the composite's own inline flush. The composite
+        (``v2ecoli.composites.batch_baseline``) does ship a post-simulation flush that
+        runs exactly these analyses, and the sim overrides deliberately disable it
+        (``"analyses": "none"``). That is not a workaround for a broken flush — it is
+        forced by the sweep's SHAPE on this backend:
+
+          * The canonical dispatch is an AWS Batch ARRAY job: N independent children,
+            one seed each, no shared filesystem. Each child's composite run sees 1/N
+            of the sweep, so an inline flush there would run the cross-seed scales
+            (multiseed/multivariant) against a single seed — N times over, racing on
+            the same output prefix. The sweep only becomes whole once every child's
+            output has landed in S3.
+          * The whole-sweep analysis is therefore a GATHER node, and the DAG edge that
+            expresses "after every child succeeded" is the same Batch ``dependsOn``
+            the ParCa→sim edge already uses. No poller, no webhook, no external
+            watcher: completion is an edge in the pipeline graph.
+
+        The node itself reuses the model image's existing, S3-native entrypoint
+        (``scripts/run_standalone_analysis.py`` → ``v2ecoli.workflow.analysis_runner.
+        run_analyses``) — the SAME function the composite's inline flush calls, reading
+        the hive-parquet in place through DuckDB/httpfs. No new analysis logic.
+
+        ``V2ECOLI_SIM_DATA`` points at the commit's ParCa cache in S3 because an S3
+        sweep has no co-located pickle to glob (``analysis_runner.resolve_sim_data``
+        only globs local paths) — identical to how ``SimulationServiceK8s.
+        submit_ray_native_analysis`` provisions the same script. Both this job and the
+        ParCa job derive that URI from the commit independently, so it needs no
+        hand-off plumbing.
+        """
+        out_uri = self._results_s3_uri(experiment_id).rstrip("/")
+        sim_data_uri = f"{data_layout.RayLayout.parca_cache_uri(commit)}simData.cPickle"
+        modules_arg = modules if isinstance(modules, str) else json.dumps(modules)
+        return (
+            f"cd {V2ECOLI_DIR}"
+            f" && V2ECOLI_SIM_DATA={shlex.quote(sim_data_uri)}"
+            f" python scripts/run_standalone_analysis.py"
+            f" --out-uri {shlex.quote(out_uri)}"
+            f" --n-seeds {int(n_seeds)}"
+            f" --n-generations {int(n_generations)}"
+            f" --modules {shlex.quote(modules_arg)}"
+            f" --analysis-name {shlex.quote(analysis_name)}"
+        )
+
+    async def _submit_analysis_job(
+        self,
+        *,
+        simulation: Simulation,
+        database_service: DatabaseService,
+        job_definition: str,
+        commit: str,
+        sim_job_id: str,
+        n_seeds: int,
+        n_generations: int,
+        depends_type: str | None,
+        tags: dict[str, str],
+    ) -> str | None:
+        """Submit the analysis DAG node and record it, returning its Batch job id.
+
+        The analysis is tracked in the SAME ``analyses`` table (and therefore the same
+        ``GET /analyses/{id}/status`` S3-manifest probe) the on-demand
+        ``POST /simulations/{id}/analysis`` trigger already writes to — an
+        auto-triggered analysis must be exactly as discoverable as a hand-triggered
+        one, not an invisible side effect.
+
+        Best-effort by design, but never SILENT: the simulation job is already
+        submitted and running by the time this is reached, so raising would orphan a
+        real, expensive job. A submission failure is logged AND written to the
+        analyses table as a FAILED row, so "the analysis never ran" is a visible state
+        rather than an absence.
+        """
+        experiment_id = simulation.config.experiment_id
+        analysis_name = f"analysis-{experiment_id[:20]}-{_rand_suffix()}"
+        out_uri = self._results_s3_uri(experiment_id).rstrip("/")
+        result_uri = f"{out_uri}/analyses/{analysis_name}"
+        modules = analysis_modules_for(simulation.config)
+        params: dict[str, Any] = {
+            "out_uri": out_uri,
+            "n_seeds": int(n_seeds),
+            "n_generations": int(n_generations),
+            "modules": modules,
+            "analysis_name": analysis_name,
+            "trigger": "dispatch-dag",
+            # ORMAnalysis.to_dto() unconditionally reads config["analysis_options"]
+            # (AnalysisConfigOptions requires experiment_id) -- mirror the shape the
+            # existing producers write so to_dto() doesn't KeyError.
+            "analysis_options": {
+                "experiment_id": [experiment_id],
+                **(modules if isinstance(modules, dict) else {}),
+            },
+        }
+        try:
+            analysis_job_id = self._submit_mnp(
+                job_name=f"ray-analysis-{experiment_id}-{_rand_suffix()}"[:128],
+                job_definition=job_definition,
+                num_nodes=1,
+                ray_job_cmd=self._analysis_command(
+                    experiment_id=experiment_id,
+                    n_seeds=n_seeds,
+                    n_generations=n_generations,
+                    modules=modules,
+                    analysis_name=analysis_name,
+                    commit=commit,
+                ),
+                out_s3=self._results_s3_uri(experiment_id),
+                out_dir=ANALYSIS_OUT_DIR,
+                depends_on=[sim_job_id],
+                depends_type=depends_type,
+                tags=tags,
+            )
+        except Exception as e:
+            logger.exception("Analysis DAG node submission failed for %s", experiment_id)
+            await database_service.record_analysis(
+                experiment_id=experiment_id,
+                n_tp=None,
+                status=AnalysisStatusDB.FAILED,
+                config=params,
+                name=analysis_name,
+                simulation_id=simulation.database_id,
+                backend="ray",
+                result_uri=result_uri,
+                error_message=f"analysis job submission failed: {type(e).__name__}: {e}",
+            )
+            return None
+        await database_service.record_analysis(
+            experiment_id=experiment_id,
+            n_tp=None,
+            status=AnalysisStatusDB.COMPUTING,
+            config=params,
+            name=analysis_name,
+            simulation_id=simulation.database_id,
+            backend="ray",
+            job_id_ext=str(analysis_job_id),
+            result_uri=result_uri,
+        )
+        return analysis_job_id
 
     @override
     async def get_latest_commit_hash(
@@ -836,6 +1046,33 @@ bash docker/build-and-push-ecr.sh -i {commit} -r {settings.ray_ecr_repository} -
                 parca_job_id,
                 sim_job_id,
                 settings.ray_num_nodes,
+            )
+
+        # 3. Analysis, gated on the simulation. The multi-generation batch_baseline
+        #    sweep is the shape that emits the hive-parquet the ported cd1_*/ptools_*
+        #    analyses read, so it is the shape that gets the third DAG node. The
+        #    comparison-ensemble and phase0 paths write no such sweep and are
+        #    deliberately untouched.
+        #
+        #    An Array sim job's parent id cannot be waited on under a SEQUENTIAL
+        #    dependency type (real AWS Batch rejection) -- plain {"jobId": …} there.
+        if composite is None and n_generations > 1:
+            analysis_job_id = await self._submit_analysis_job(
+                simulation=ecoli_simulation,
+                database_service=database_service,
+                job_definition=job_def,
+                commit=commit,
+                sim_job_id=sim_job_id,
+                n_seeds=int(n_seeds),
+                n_generations=n_generations,
+                depends_type=None if is_array_eligible else "SEQUENTIAL",
+                tags={**base_tags, "Phase": "analysis"},
+            )
+            logger.info(
+                "Ray simulation %s: sim job %s -> analysis job %s",
+                experiment_id,
+                sim_job_id,
+                analysis_job_id,
             )
         return JobId.ray(sim_job_id)
 

--- a/sms_api/simulation/simulation_service_ray.py
+++ b/sms_api/simulation/simulation_service_ray.py
@@ -703,13 +703,20 @@ class SimulationServiceRay(SimulationService):
         out_uri = self._results_s3_uri(experiment_id).rstrip("/")
         sim_data_uri = f"{data_layout.RayLayout.parca_cache_uri(commit)}simData.cPickle"
         modules_arg = modules if isinstance(modules, str) else json.dumps(modules)
+        # --n-generations exists only to let the image resolve the "applicable"
+        # keyword; an explicit module mapping doesn't need it. Emitting it only in
+        # the keyword case keeps the explicit path runnable against ANY image that
+        # already ships the script, so a simulator built before the keyword landed
+        # still gets its configured analyses instead of dying on an unrecognized
+        # argument. Only the keyword default requires the newer image.
+        gens = f" --n-generations {int(n_generations)}" if isinstance(modules, str) else ""
         return (
             f"cd {V2ECOLI_DIR}"
             f" && V2ECOLI_SIM_DATA={shlex.quote(sim_data_uri)}"
             f" python scripts/run_standalone_analysis.py"
             f" --out-uri {shlex.quote(out_uri)}"
             f" --n-seeds {int(n_seeds)}"
-            f" --n-generations {int(n_generations)}"
+            f"{gens}"
             f" --modules {shlex.quote(modules_arg)}"
             f" --analysis-name {shlex.quote(analysis_name)}"
         )

--- a/sms_api/version.py
+++ b/sms_api/version.py
@@ -237,4 +237,33 @@
 #          go-signal: the mock never validates against AWS's real API rules) --
 #          strengthened to assert the correct type-less shape, with a comment
 #          explaining why so it can't be silently "simplified" back.
-__version__ = "0.9.40"
+# 0.9.41 — analysis auto-triggers from the dispatch DAG (backlog item 24). The Ray
+#          backend never read config.analysis_options and submitted no analysis at
+#          all, so a completed remote simulation produced zero cd1_*/ptools_*
+#          artifacts until somebody ran `atlantis simulation analysis <id>` by
+#          hand -- which defeats the "everything triggered through the Workbench"
+#          bar. submit_ecoli_simulation_job now submits a THIRD Batch job for the
+#          multi-generation batch_baseline sweep, dependsOn the sim job, running
+#          the model image's own S3-native scripts/run_standalone_analysis.py
+#          (-> v2ecoli.workflow.analysis_runner.run_analyses, the SAME function
+#          the composite's inline flush calls) over the landed sweep. So the
+#          pipeline is now one Batch dependency DAG, parca -> sim -> analysis:
+#          no poller, no webhook, no external watcher.
+#          The composite's own inline flush stays disabled ("analyses": "none")
+#          on purpose and is NOT the mechanism: the canonical dispatch is an
+#          Array job of N single-seed children with no shared filesystem, so an
+#          inline flush would run the cross-seed scales against 1/N of the sweep,
+#          N times over. The whole-sweep analysis is a gather node by nature.
+#          Modules come from the simulation's own analysis_options when the
+#          caller set any; otherwise the composite's own "applicable" keyword,
+#          which the model image expands with its own ANALYSIS_REGISTRY (sms-api
+#          has none) -- see the companion sms-ecoli PR adding that keyword to
+#          run_standalone_analysis.py. Every auto-triggered analysis is recorded
+#          in the same `analyses` table as a hand-triggered one, so
+#          GET /simulations/{id}/analyses and GET /analyses/{id}/status resolve
+#          it; a submission failure lands as a FAILED row rather than vanishing
+#          (the sim job is already running by then, so raising would orphan it).
+#          _submit_mnp gains an optional depends_type: the analysis node waits on
+#          an ARRAY parent id, which AWS Batch rejects under SEQUENTIAL; the
+#          ParCa -> sim edge keeps its live-verified SEQUENTIAL shape untouched.
+__version__ = "0.9.41"

--- a/tests/common/handlers/test_ray_analysis_status.py
+++ b/tests/common/handlers/test_ray_analysis_status.py
@@ -4,6 +4,7 @@ backing K8s Job (ttl_seconds_after_finished=86400 expires it after 24h).
 This is the wiring analysis-results-design.md already designed (DB columns
 and service methods existed, unused) but never connected for the K8s path."""
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -14,7 +15,7 @@ from sms_api.common.models import JobId, JobStatus
 from sms_api.simulation.tables_orm import AnalysisStatusDB
 
 
-def _make_record(*, status: JobStatus = JobStatus.RUNNING) -> ExperimentAnalysisDTO:
+def _make_record(*, status: JobStatus = JobStatus.RUNNING, simulation_id: int | None = None) -> ExperimentAnalysisDTO:
     config = AnalysisConfig(analysis_options=AnalysisConfigOptions(experiment_id=["exp1"]))
     return ExperimentAnalysisDTO(
         database_id=1,
@@ -25,6 +26,7 @@ def _make_record(*, status: JobStatus = JobStatus.RUNNING) -> ExperimentAnalysis
         result_uri="s3://bucket/exp/analyses/analysis-exp1-ab12",
         job_id_ext="ana-exp1-ab12",
         status=status,
+        simulation_id=simulation_id,
     )
 
 
@@ -163,3 +165,85 @@ async def test_no_manifest_but_k8s_job_failed_marks_failed_early() -> None:
         AnalysisStatusDB.FAILED,
         error_message="ImagePullBackOff",
     )
+
+
+@pytest.mark.asyncio
+async def test_a_batch_analysis_jobs_failure_is_detected_via_its_own_backend() -> None:
+    """The dispatch DAG's analysis node is an AWS BATCH job, not a K8s Job, but
+    both producers write backend="ray" rows. Probing only the default (K8s)
+    service returns None for a Batch job id, so the most common real failure --
+    the simulation failed, so Batch never ran the dependent analysis -- would
+    leave the row COMPUTING forever with no manifest ever coming. Resolve the
+    service that actually owns the record's simulation and probe that too.
+
+    The K8s service is left returning None (what it genuinely does for a Batch
+    id) rather than being taught to answer, so this asserts the real routing,
+    not a mock agreeing with itself."""
+    from sms_api.common.hpc.job_service import JobStatusInfo
+
+    record = _make_record(simulation_id=115)
+    db_service = AsyncMock()
+    db_service.get_simulation.return_value = SimpleNamespace(simulator_id=53)
+    db_service.get_simulator.return_value = SimpleNamespace(git_repo_url="https://github.com/CovertLabEcoli/sms-ecoli")
+    fake_file_service = AsyncMock()
+    fake_file_service.get_file_contents.return_value = None
+
+    k8s_service = AsyncMock()
+    k8s_service.get_job_status.return_value = None  # a Batch job id is not a K8s Job name
+    ray_service = AsyncMock()
+    ray_service.get_job_status.return_value = JobStatusInfo(
+        job_id=JobId.ray("ana-exp1-ab12"),
+        status=JobStatus.FAILED,
+        error_message="Dependent Job failed",
+    )
+
+    with (
+        patch("sms_api.common.handlers.analyses.get_file_service", return_value=fake_file_service),
+        patch("sms_api.common.handlers.analyses.get_simulation_service", return_value=k8s_service),
+        patch(
+            "sms_api.common.handlers.analyses.get_simulation_service_for_repo",
+            return_value=ray_service,
+        ),
+    ):
+        result = await handle_get_ray_analysis_status(db_service=db_service, record=record)
+
+    assert result.status == JobStatus.FAILED
+    assert result.error_log == "Dependent Job failed"
+    # The owning service was queried with a RAY-tagged id, not a K8s one.
+    assert ray_service.get_job_status.call_args.args[0] == JobId.ray("ana-exp1-ab12")
+    db_service.update_analysis_status.assert_called_once_with(
+        1,
+        AnalysisStatusDB.FAILED,
+        error_message="Dependent Job failed",
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_probe_against_the_wrong_backend_never_surfaces_as_an_error() -> None:
+    """Querying AWS Batch with a K8s Job NAME raises (invalid job id) -- that is
+    an expected miss on the wrong namespace, not a status. It must not turn a
+    still-running analysis into an error response."""
+    record = _make_record(simulation_id=115)
+    db_service = AsyncMock()
+    db_service.get_simulation.return_value = SimpleNamespace(simulator_id=53)
+    db_service.get_simulator.return_value = SimpleNamespace(git_repo_url="https://github.com/CovertLabEcoli/sms-ecoli")
+    fake_file_service = AsyncMock()
+    fake_file_service.get_file_contents.return_value = None
+
+    k8s_service = AsyncMock()
+    k8s_service.get_job_status.return_value = None
+    ray_service = AsyncMock()
+    ray_service.get_job_status.side_effect = RuntimeError("ClientError: invalid jobId")
+
+    with (
+        patch("sms_api.common.handlers.analyses.get_file_service", return_value=fake_file_service),
+        patch("sms_api.common.handlers.analyses.get_simulation_service", return_value=k8s_service),
+        patch(
+            "sms_api.common.handlers.analyses.get_simulation_service_for_repo",
+            return_value=ray_service,
+        ),
+    ):
+        result = await handle_get_ray_analysis_status(db_service=db_service, record=record)
+
+    assert result.status == JobStatus.RUNNING
+    db_service.update_analysis_status.assert_not_called()

--- a/tests/common/handlers/test_simulations_handler.py
+++ b/tests/common/handlers/test_simulations_handler.py
@@ -24,7 +24,7 @@ from sms_api.common.storage.file_paths import HPCFilePath, S3FilePath
 from sms_api.common.storage.file_service import FileService, ListingItem
 from sms_api.config import ComputeBackend, get_settings
 from sms_api.dependencies import get_file_service, set_file_service
-from sms_api.simulation.models import Simulation, SimulationConfig, SimulatorVersion
+from sms_api.simulation.models import AnalysisOptions, Simulation, SimulationConfig, SimulatorVersion
 from sms_api.simulation.simulation_service_k8s import SimulationServiceK8s
 from sms_api.simulation.tables_orm import ORMAnalysis
 
@@ -332,26 +332,17 @@ async def test_run_standalone_analysis_ray_native_routes_to_v2ecoli_job() -> Non
     assert dto.config.analysis_options.experiment_id == ["exp123"]
 
 
-@pytest.mark.asyncio
-async def test_run_standalone_analysis_default_modules_use_single_scale() -> None:
-    """Regression: the ptools_* default (when modules=None) nested all three
-    modules under "multiseed", but ptools_rna/ptools_rxns/ptools_proteins are
-    registered scale="single" in v2ecoli/sms-ecoli's ANALYSIS_REGISTRY. Every
-    real standalone-analysis dispatch that relied on the default (no --modules
-    passed) failed with "is scale='single', not 'multiseed'" -- live-reproduced
-    2026-08-05 against a completed pilot simulation, 5 separate K8s Job attempts
-    over 22h, all Failed. This calls the real default-selection path (modules=None)
-    end to end, not a hand-constructed payload, so it would have caught the bug."""
+async def _run_default_modules_ray_native(simulation: Simulation) -> dict[str, Any]:
+    """Drive the REAL default-selection path (modules=None) end to end for a
+    Ray/sms-ecoli simulator, returning the submitted params."""
     from sms_api.common.handlers.simulations import run_standalone_analysis
 
-    simulation = _make_ray_simulation()
     simulator = SimulatorVersion(
         database_id=53,
         git_commit_hash="deadbeef",
         git_repo_url=RepoUrl.SMS_ECOLI_REPO_URL,
         git_branch="main",
     )
-
     mock_k8s_service = AsyncMock(spec=SimulationServiceK8s)
     mock_k8s_service.submit_ray_native_analysis.return_value = "ana-exp123"
     mock_db_service = AsyncMock()
@@ -368,11 +359,57 @@ async def test_run_standalone_analysis_default_modules_use_single_scale() -> Non
             simulation_id=115,
             modules=None,
         )
+    return dict(result["config"])
 
-    modules_sent = result["config"]["modules"]
-    assert "single" in modules_sent
-    assert set(modules_sent["single"]) == {"ptools_rna", "ptools_rxns", "ptools_proteins"}
-    assert "multiseed" not in modules_sent
+
+@pytest.mark.asyncio
+async def test_ray_native_default_modules_defer_to_the_images_own_resolver() -> None:
+    """Regression, twice over.
+
+    (1) The old ptools_* default (modules=None) nested all three modules under
+    "multiseed", but ptools_rna/ptools_rxns/ptools_proteins are registered
+    scale="single" -- every dispatch relying on the default failed with "is
+    scale='single', not 'multiseed'" (live-reproduced 2026-08-05, 5 K8s Job
+    attempts over 22h, all Failed). A hardcoded name->scale list in sms-api can
+    always drift from the image's registry, which is what made that bug possible.
+
+    (2) That default also silently under-delivered: three ptools modules, none of
+    the cd1_* omics suite the deliverable is defined by.
+
+    Both are closed by deferring to the model image's own resolver -- the same
+    "applicable" keyword the composite's inline flush uses -- so sms-api never
+    restates a name, a scale, or a list it cannot verify. Scale correctness is
+    then true by construction.
+    """
+    params = await _run_default_modules_ray_native(_make_ray_simulation())
+
+    assert params["modules"] == "applicable"
+    # n_generations rides along: "applicable" cannot decide whether the
+    # multigeneration scales apply without it.
+    assert params["n_generations"] == 1
+    # The DTO contract still holds when modules is a keyword rather than a mapping.
+    assert params["analysis_options"] == {"experiment_id": ["exp123"]}
+
+
+@pytest.mark.asyncio
+async def test_ray_native_default_modules_prefer_the_simulations_own_options() -> None:
+    """A simulation dispatched WITH analysis_options (the workbench sends a study's
+    spec.analyses through) must have those re-run on demand, not a generic default
+    -- and must match what the dispatch DAG's own analysis node would run."""
+    simulation = _make_ray_simulation()
+    simulation.config.analysis_options = AnalysisOptions(**{
+        "multiseed": {"cd1_proteomics": {"generation_lower_bound": 5}}
+    })
+    simulation.config.generations = 10
+
+    params = await _run_default_modules_ray_native(simulation)
+
+    assert params["modules"] == {"multiseed": {"cd1_proteomics": {"generation_lower_bound": 5}}}
+    assert params["n_generations"] == 10
+    assert params["analysis_options"] == {
+        "experiment_id": ["exp123"],
+        "multiseed": {"cd1_proteomics": {"generation_lower_bound": 5}},
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/common/handlers/test_simulations_handler.py
+++ b/tests/common/handlers/test_simulations_handler.py
@@ -397,7 +397,7 @@ async def test_ray_native_default_modules_prefer_the_simulations_own_options() -
     spec.analyses through) must have those re-run on demand, not a generic default
     -- and must match what the dispatch DAG's own analysis node would run."""
     simulation = _make_ray_simulation()
-    simulation.config.analysis_options = AnalysisOptions(**{
+    simulation.config.analysis_options = AnalysisOptions.model_validate({
         "multiseed": {"cd1_proteomics": {"generation_lower_bound": 5}}
     })
     simulation.config.generations = 10

--- a/tests/simulation/test_ray_backend.py
+++ b/tests/simulation/test_ray_backend.py
@@ -459,6 +459,16 @@ class TestAnalysisCommand:
         assert tokens[tokens.index("--out-uri") + 1].endswith(hostile)
         assert "touch /tmp/analysis-command-canary" not in shlex.split(cmd)
 
+    def test_n_generations_is_emitted_only_for_the_applicable_keyword(self) -> None:
+        """--n-generations exists solely to resolve `applicable`, and is the ONE
+        flag a simulator image built before that keyword landed would reject
+        (argparse: unrecognized argument). Emitting it only in the keyword case
+        keeps an explicit module mapping runnable against ANY image that already
+        ships the script, so a pre-existing build still gets its configured
+        analyses instead of failing the whole node."""
+        assert "--n-generations" in self._cmd(modules="applicable")
+        assert "--n-generations" not in self._cmd(modules={"multiseed": {"cd1_fluxomics": {}}})
+
 
 @pytest.mark.asyncio
 class TestAnalysisDagNode:
@@ -508,7 +518,7 @@ class TestAnalysisDagNode:
         env = _env_of(analysis_call)
         assert "run_standalone_analysis.py" in env["RAY_JOB_CMD"]
         assert f"--out-uri s3://mybucket/vecoli-output/{experiment_id}" in env["RAY_JOB_CMD"]
-        assert "--n-seeds 4" in env["RAY_JOB_CMD"] and "--n-generations 3" in env["RAY_JOB_CMD"]
+        assert "--n-seeds 4" in env["RAY_JOB_CMD"]
         # No ParCa staging: sim_data is named explicitly as an S3 URI instead.
         assert "RAY_STAGE_S3" not in env
         assert "V2ECOLI_SIM_DATA=s3://mybucket/ray-parca-cache/" in env["RAY_JOB_CMD"]

--- a/tests/simulation/test_ray_backend.py
+++ b/tests/simulation/test_ray_backend.py
@@ -389,7 +389,7 @@ class TestAnalysisModulesFor:
 
         config = SimulationConfig(
             experiment_id="exp-1",
-            analysis_options=AnalysisOptions(**{
+            analysis_options=AnalysisOptions.model_validate({
                 "multiseed": {"cd1_metabolomics": {"generation_lower_bound": 5}},
                 "cpus": 4,
             }),
@@ -406,7 +406,9 @@ class TestAnalysisModulesFor:
         from sms_api.simulation.models import AnalysisOptions, SimulationConfig
 
         assert analysis_modules_for(SimulationConfig(experiment_id="exp-1")) == "applicable"
-        empty = SimulationConfig(experiment_id="exp-1", analysis_options=AnalysisOptions(**{"multiseed": {}}))
+        empty = SimulationConfig(
+            experiment_id="exp-1", analysis_options=AnalysisOptions.model_validate({"multiseed": {}})
+        )
         assert analysis_modules_for(empty) == "applicable"
 
 
@@ -537,7 +539,7 @@ class TestAnalysisDagNode:
 
         setattr(experiment_request.config, "n_init_sims", 4)  # noqa: B010
         experiment_request.config.generations = 3
-        experiment_request.config.analysis_options = AnalysisOptions(**{
+        experiment_request.config.analysis_options = AnalysisOptions.model_validate({
             "multiseed": {"cd1_fluxomics": {"generation_lower_bound": 5}}
         })
         simulation = await database_service.insert_simulation(sim_request=experiment_request)

--- a/tests/simulation/test_ray_backend.py
+++ b/tests/simulation/test_ray_backend.py
@@ -18,6 +18,7 @@ from sms_api.simulation.simulation_service_ray import (
     PARCA_CACHE_DIR,
     SIM_OUT_DIR,
     SimulationServiceRay,
+    analysis_modules_for,
 )
 
 if TYPE_CHECKING:
@@ -266,7 +267,7 @@ class TestSimulationServiceRaySubmit:
         experiment_request.config.generations = 3
         simulation = await database_service.insert_simulation(sim_request=experiment_request)
 
-        mock_batch = _fake_batch(["parca-123", "sim-456"])
+        mock_batch = _fake_batch(["parca-123", "sim-456", "analysis-789"])
         fake_file_service = AsyncMock()
         fake_file_service.upload_file = AsyncMock()
 
@@ -283,8 +284,9 @@ class TestSimulationServiceRaySubmit:
 
         fake_file_service.upload_file.assert_awaited_once()
         assert job_id == JobId.ray("sim-456")
-        assert mock_batch.submit_job.call_count == 2
-        parca_call, sim_call = mock_batch.submit_job.call_args_list
+        # parca -> sim(array) -> analysis: the analysis DAG node rides along.
+        assert mock_batch.submit_job.call_count == 3
+        parca_call, sim_call, _analysis_call = mock_batch.submit_job.call_args_list
 
         # ParCa: unchanged -- still a 1-node MNP job, no dependency.
         assert parca_call.kwargs["nodeOverrides"]["numNodes"] == 1
@@ -354,7 +356,7 @@ class TestSimulationServiceRaySubmit:
         experiment_request.config.generations = 3
         simulation = await database_service.insert_simulation(sim_request=experiment_request)
 
-        mock_batch = _fake_batch(["parca-123", "sim-456"])
+        mock_batch = _fake_batch(["parca-123", "sim-456", "analysis-789"])
         fake_file_service = AsyncMock()
         fake_file_service.upload_file = AsyncMock()
 
@@ -369,11 +371,265 @@ class TestSimulationServiceRaySubmit:
                 ecoli_simulation=simulation, database_service=database_service, correlation_id="corr-single"
             )
 
-        _, sim_call = mock_batch.submit_job.call_args_list
+        _, sim_call, analysis_call = mock_batch.submit_job.call_args_list
         assert "nodeOverrides" in sim_call.kwargs
         assert "arrayProperties" not in sim_call.kwargs
         assert sim_call.kwargs["jobQueue"] == "smscdk-ray-mnp"
         assert "--composite-id v2ecoli.composites.batch_baseline.batch_baseline " in _env_of(sim_call)["RAY_JOB_CMD"]
+        # An MNP sim job is NOT array-shaped, so the analysis node keeps the
+        # long-standing SEQUENTIAL dependency shape this path has always used.
+        assert analysis_call.kwargs["dependsOn"] == [{"jobId": "sim-456", "type": "SEQUENTIAL"}]
+
+
+class TestAnalysisModulesFor:
+    """analysis_modules_for reads the simulation's OWN configured analyses."""
+
+    def test_real_scale_entries_are_forwarded_verbatim(self) -> None:
+        from sms_api.simulation.models import AnalysisOptions, SimulationConfig
+
+        config = SimulationConfig(
+            experiment_id="exp-1",
+            analysis_options=AnalysisOptions(**{
+                "multiseed": {"cd1_metabolomics": {"generation_lower_bound": 5}},
+                "cpus": 4,
+            }),
+        )
+        # cpus is a real AnalysisOptions field, NOT a scale — forwarding it as one
+        # would ask the model image to run an analysis called "cpus".
+        assert analysis_modules_for(config) == {"multiseed": {"cd1_metabolomics": {"generation_lower_bound": 5}}}
+
+    def test_unset_or_empty_options_fall_back_to_the_applicable_keyword(self) -> None:
+        """The run endpoint's own no-analysis-options default is `{"multiseed": {}}`
+        — "no modules named", not "run nothing". Both it and a bare default must
+        resolve to `applicable`, which the model image expands with its own
+        registry (sms-api has none)."""
+        from sms_api.simulation.models import AnalysisOptions, SimulationConfig
+
+        assert analysis_modules_for(SimulationConfig(experiment_id="exp-1")) == "applicable"
+        empty = SimulationConfig(experiment_id="exp-1", analysis_options=AnalysisOptions(**{"multiseed": {}}))
+        assert analysis_modules_for(empty) == "applicable"
+
+
+class TestAnalysisCommand:
+    """_analysis_command builds the analysis DAG node's workload."""
+
+    def _cmd(self, **kw: Any) -> str:
+        service = SimulationServiceRay()
+        defaults: dict[str, Any] = {
+            "experiment_id": "sim47-real-experiment",
+            "n_seeds": 4,
+            "n_generations": 3,
+            "modules": "applicable",
+            "analysis_name": "analysis-sim47-abc123",
+            "commit": "deadbeef",
+        }
+        with (
+            patch("sms_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("sms_api.common.storage.data_layout.get_settings", _ray_settings),
+        ):
+            return service._analysis_command(**{**defaults, **kw})
+
+    def test_runs_the_model_images_own_s3_native_analysis_entrypoint(self) -> None:
+        cmd = self._cmd()
+        assert "python scripts/run_standalone_analysis.py" in cmd
+        # The sweep prefix is the SAME one the sim job syncs its output to, with no
+        # trailing slash (run_standalone_analysis rstrips it to build result_uri).
+        assert "--out-uri s3://mybucket/vecoli-output/sim47-real-experiment " in cmd + " "
+        assert "--n-seeds 4" in cmd
+        assert "--n-generations 3" in cmd
+        assert "--analysis-name analysis-sim47-abc123" in cmd
+
+    def test_points_sim_data_at_the_commits_parca_cache(self) -> None:
+        """An s3:// sweep has no co-located sim_data pickle to glob, so the DuckDB
+        analyses would raise FileNotFoundError without this pointer. Both this job
+        and the ParCa job derive the URI from the commit — no hand-off plumbing."""
+        cmd = self._cmd(commit="c0ffee")
+        assert "V2ECOLI_SIM_DATA=s3://mybucket/ray-parca-cache/c0ffee/simData.cPickle" in cmd
+
+    def test_explicit_modules_ride_as_json_and_survive_a_hostile_experiment_id(self) -> None:
+        """experiment_id is a caller-supplied, unconstrained string, and the modules
+        blob is JSON — both must reach the container as DATA, never shell syntax."""
+        hostile = "exp'; touch /tmp/analysis-command-canary; echo '$(echo pwned)"
+        modules = {"multiseed": {"cd1_metabolomics": {"generation_lower_bound": 5}}}
+        cmd = self._cmd(experiment_id=hostile, modules=modules)
+        tokens = shlex.split(cmd.split("&&", 1)[1].replace("V2ECOLI_SIM_DATA=", "", 1))
+        assert json.loads(tokens[tokens.index("--modules") + 1]) == modules
+        assert tokens[tokens.index("--out-uri") + 1].endswith(hostile)
+        assert "touch /tmp/analysis-command-canary" not in shlex.split(cmd)
+
+
+@pytest.mark.asyncio
+class TestAnalysisDagNode:
+    """Item 24: the analysis must fire from the pipeline DAG itself, with no
+    separate manual step and no external watcher."""
+
+    async def test_analysis_job_depends_on_the_array_sim_and_is_recorded(
+        self,
+        experiment_request: "SimulationRequest",
+        database_service: "DatabaseServiceSQL",
+    ) -> None:
+        """REGRESSION (backlog item 24): before this, the Ray backend never read
+        `config.analysis_options` and submitted no analysis at all — a completed
+        remote simulation produced zero cd1_*/ptools_* artifacts until somebody ran
+        the CLI by hand. The analysis is now the DAG's third node, gated on the sim
+        job, and tracked in the same `analyses` table the on-demand trigger uses."""
+        setattr(experiment_request.config, "n_init_sims", 4)  # noqa: B010
+        experiment_request.config.generations = 3
+        simulation = await database_service.insert_simulation(sim_request=experiment_request)
+
+        mock_batch = _fake_batch(["parca-123", "sim-456", "analysis-789"])
+        fake_file_service = AsyncMock()
+        fake_file_service.upload_file = AsyncMock()
+
+        service = SimulationServiceRay()
+        with (
+            patch("sms_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("sms_api.common.storage.data_layout.get_settings", _ray_settings),
+            patch("sms_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
+            patch("sms_api.dependencies.get_file_service", return_value=fake_file_service),
+        ):
+            await service.submit_ecoli_simulation_job(
+                ecoli_simulation=simulation, database_service=database_service, correlation_id="corr-analysis"
+            )
+
+        _parca_call, _sim_call, analysis_call = mock_batch.submit_job.call_args_list
+        experiment_id = simulation.config.experiment_id
+
+        # Gated on the SIM job (not ParCa): the sweep is only whole once every
+        # array child's output has landed in S3.
+        assert analysis_call.kwargs["dependsOn"] == [{"jobId": "sim-456"}]
+        # An array parent id under a SEQUENTIAL type is rejected by real AWS Batch —
+        # this is the shape that guard produces, and must not be "simplified" back.
+        assert "type" not in analysis_call.kwargs["dependsOn"][0]
+        assert analysis_call.kwargs["nodeOverrides"]["numNodes"] == 1
+
+        env = _env_of(analysis_call)
+        assert "run_standalone_analysis.py" in env["RAY_JOB_CMD"]
+        assert f"--out-uri s3://mybucket/vecoli-output/{experiment_id}" in env["RAY_JOB_CMD"]
+        assert "--n-seeds 4" in env["RAY_JOB_CMD"] and "--n-generations 3" in env["RAY_JOB_CMD"]
+        # No ParCa staging: sim_data is named explicitly as an S3 URI instead.
+        assert "RAY_STAGE_S3" not in env
+        assert "V2ECOLI_SIM_DATA=s3://mybucket/ray-parca-cache/" in env["RAY_JOB_CMD"]
+        assert analysis_call.kwargs["tags"]["Phase"] == "analysis"
+
+        # Tracked: GET /simulations/{id}/analyses and GET /analyses/{id}/status must
+        # both resolve an auto-triggered analysis, exactly like a hand-triggered one.
+        records = await database_service.list_analyses(simulation_id=simulation.database_id)
+        assert len(records) == 1
+        record = records[0]
+        assert record.backend == "ray"
+        assert record.job_id_ext == "analysis-789"
+        assert record.status == JobStatus.RUNNING
+        # result_uri is where the job's own _manifest.json lands — the S3-exists probe
+        # in handle_get_ray_analysis_status reads exactly this path.
+        assert record.result_uri == f"s3://mybucket/vecoli-output/{experiment_id}/analyses/{record.name}"
+        assert f"--analysis-name {record.name}" in env["RAY_JOB_CMD"]
+
+    async def test_configured_analysis_options_reach_the_analysis_job(
+        self,
+        experiment_request: "SimulationRequest",
+        database_service: "DatabaseServiceSQL",
+    ) -> None:
+        """REGRESSION: `config.analysis_options` (set by the run endpoint from the
+        caller's --analysis-options, and by the workbench from a study's
+        spec.analyses) was read by no Ray code path at all."""
+        from sms_api.simulation.models import AnalysisOptions
+
+        setattr(experiment_request.config, "n_init_sims", 4)  # noqa: B010
+        experiment_request.config.generations = 3
+        experiment_request.config.analysis_options = AnalysisOptions(**{
+            "multiseed": {"cd1_fluxomics": {"generation_lower_bound": 5}}
+        })
+        simulation = await database_service.insert_simulation(sim_request=experiment_request)
+
+        mock_batch = _fake_batch(["parca-123", "sim-456", "analysis-789"])
+        fake_file_service = AsyncMock()
+        fake_file_service.upload_file = AsyncMock()
+
+        service = SimulationServiceRay()
+        with (
+            patch("sms_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("sms_api.common.storage.data_layout.get_settings", _ray_settings),
+            patch("sms_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
+            patch("sms_api.dependencies.get_file_service", return_value=fake_file_service),
+        ):
+            await service.submit_ecoli_simulation_job(
+                ecoli_simulation=simulation, database_service=database_service, correlation_id="corr-opts"
+            )
+
+        cmd = _env_of(mock_batch.submit_job.call_args_list[2])["RAY_JOB_CMD"]
+        tokens = shlex.split(cmd.split("&&", 1)[1].replace("V2ECOLI_SIM_DATA=", "", 1))
+        assert json.loads(tokens[tokens.index("--modules") + 1]) == {
+            "multiseed": {"cd1_fluxomics": {"generation_lower_bound": 5}}
+        }
+
+    async def test_no_analysis_node_for_the_single_generation_ensemble(
+        self,
+        experiment_request: "SimulationRequest",
+        database_service: "DatabaseServiceSQL",
+    ) -> None:
+        """The phase0 single-generation ensemble writes no hive-parquet sweep, so
+        there is nothing for the ported analyses to read — it must stay a 2-job DAG
+        rather than burn a node on a guaranteed FileNotFoundError."""
+        setattr(experiment_request.config, "n_init_sims", 2)  # noqa: B010
+        experiment_request.config.generations = 1
+        simulation = await database_service.insert_simulation(sim_request=experiment_request)
+
+        mock_batch = _fake_batch(["parca-123", "sim-456"])
+        service = SimulationServiceRay()
+        with (
+            patch("sms_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("sms_api.common.storage.data_layout.get_settings", _ray_settings),
+            patch("sms_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
+        ):
+            await service.submit_ecoli_simulation_job(
+                ecoli_simulation=simulation, database_service=database_service, correlation_id="corr-phase0"
+            )
+
+        assert mock_batch.submit_job.call_count == 2
+        assert await database_service.list_analyses(simulation_id=simulation.database_id) == []
+
+    async def test_a_failed_analysis_submission_is_recorded_not_swallowed(
+        self,
+        experiment_request: "SimulationRequest",
+        database_service: "DatabaseServiceSQL",
+    ) -> None:
+        """The sim job is already running by then, so raising would orphan a real,
+        expensive job — but a silently-missing analysis is the exact failure mode
+        item 24 exists to eliminate. It must land as a FAILED row instead."""
+        setattr(experiment_request.config, "n_init_sims", 4)  # noqa: B010
+        experiment_request.config.generations = 3
+        simulation = await database_service.insert_simulation(sim_request=experiment_request)
+
+        mock_batch = _fake_batch(["parca-123", "sim-456"])
+        submits = [{"jobId": "parca-123"}, {"jobId": "sim-456"}]
+
+        def _submit(**kwargs: Any) -> dict[str, str]:
+            if submits:
+                return submits.pop(0)
+            raise RuntimeError("Batch said no")
+
+        mock_batch.submit_job.side_effect = _submit
+        fake_file_service = AsyncMock()
+        fake_file_service.upload_file = AsyncMock()
+
+        service = SimulationServiceRay()
+        with (
+            patch("sms_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("sms_api.common.storage.data_layout.get_settings", _ray_settings),
+            patch("sms_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
+            patch("sms_api.dependencies.get_file_service", return_value=fake_file_service),
+        ):
+            job_id = await service.submit_ecoli_simulation_job(
+                ecoli_simulation=simulation, database_service=database_service, correlation_id="corr-fail"
+            )
+
+        # The simulation dispatch itself still succeeds and stays tracked.
+        assert job_id == JobId.ray("sim-456")
+        records = await database_service.list_analyses(simulation_id=simulation.database_id)
+        assert len(records) == 1
+        assert records[0].status == JobStatus.FAILED
+        assert "Batch said no" in (records[0].error_message or "")
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -3075,7 +3075,7 @@ wheels = [
 
 [[package]]
 name = "sms-api"
-version = "0.9.40"
+version = "0.9.41"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
Backlog **item 24** (non-negotiable) + the backend half of **item 23**.

## The gap

A completed remote simulation produced **zero** `cd1_*`/`ptools_*` artifacts.
The Ray backend never read `config.analysis_options` and submitted no analysis
job at all, so the analysis phase could only ever be fired by hand
(`atlantis simulation analysis <id>`) — which defeats the deliverable's
"everything triggered through the Workbench" bar.

## The fix: a third node in the Batch dependency DAG

`submit_ecoli_simulation_job` now submits an **analysis job** for the
multi-generation `batch_baseline` sweep, `dependsOn` the simulation job:

```
parca ──▶ sim (Array: N single-seed children) ──▶ analysis (whole S3 sweep)
```

Completion is an **edge in the graph** — no poller, no webhook, no external
watcher. It reuses the same `dependsOn` mechanism the ParCa→sim edge already
uses.

### Why not the composite's own inline flush

The composite *does* ship a post-simulation flush that runs exactly these
analyses, and the sim overrides deliberately disable it (`"analyses": "none"`).
That is not a workaround for a broken flush — it is forced by the sweep's shape:

- The canonical dispatch is an AWS Batch **Array** job of N independent
  single-seed children with **no shared filesystem**. Each child's composite run
  sees 1/N of the sweep, so an inline flush there would run the cross-seed scales
  (`multiseed`/`multivariant`) against a single seed, N times over, racing on one
  output prefix.
- The sweep only becomes whole once every child's output has landed in S3, which
  makes the whole-sweep analysis a **gather node** by nature.

Both `"analyses": "none"` sites now carry a comment saying exactly this, so it
can't be "fixed" back.

### No new analysis logic

The node runs the model image's own S3-native
`scripts/run_standalone_analysis.py` → `v2ecoli.workflow.analysis_runner.run_analyses()`
— the *same* function the composite's inline flush calls, reading the
hive-parquet in place through DuckDB/httpfs. `V2ECOLI_SIM_DATA` names the
commit's ParCa cache in S3 exactly as `SimulationServiceK8s.submit_ray_native_analysis`
already does (an S3 sweep has no co-located pickle to glob).

### Module selection

The simulation's own `analysis_options` when the caller set any (the field the
run endpoint populates from `--analysis-options`, and the workbench from a
study's `spec.analyses`); otherwise the composite's own `applicable` keyword,
which the model image expands with **its own** `ANALYSIS_REGISTRY`. sms-api runs
outside that image and must not carry a second, drift-prone copy of the list —
that copy is what caused the 2026-08-05 wrong-scale outage.

The second commit applies the same rule to the **on-demand**
`POST /simulations/{id}/analysis` (item 23's backend): `modules=None` on the
Ray route now resolves identically instead of falling back to a hardcoded
three-module ptools list that both restated scales *and* silently omitted the
whole `cd1_*` suite. The legacy vEcoli/Nextflow + SLURM routes keep their
explicit default (they have no such resolver).

### Observability

Every auto-triggered analysis is recorded in the **same `analyses` table** a
hand-triggered one is, so `GET /simulations/{id}/analyses` and
`GET /analyses/{id}/status` (its S3 `_manifest.json` probe) resolve it. A
submission failure is logged **and** written as a `FAILED` row rather than
vanishing — the sim job is already running by then, so raising would orphan a
real, expensive job, but a silently-missing analysis is the exact failure this
change exists to eliminate.

`_submit_mnp` gains an optional `depends_type`: the analysis node waits on an
**Array parent id**, which real AWS Batch rejects under a `SEQUENTIAL` type (the
v0.9.40 incident). The ParCa→sim edge keeps its live-verified `SEQUENTIAL` shape
untouched.

## Tests

`tests/simulation/test_ray_backend.py` (**48 passed**) +
`tests/common/handlers/test_simulations_handler.py` (**7 passed, 2 skipped**):

- the DAG edge exists and uses the type-less shape for an Array sim job;
- the analysis row is recorded with the right backend / job id / `result_uri`
  (matching where the manifest actually lands);
- configured `analysis_options` reach the job;
- **no** analysis node for the parquet-less phase0 ensemble;
- a failed submission lands as a `FAILED` row instead of disappearing;
- `sim_data` points at the commit's ParCa cache;
- shell-injection safety for a hostile `experiment_id` + JSON modules blob;
- the on-demand default defers to the image's resolver and prefers the
  simulation's own options.

Full suite: **523 passed**, 5 pre-existing failures in
`tests/api/app/test_cli_e2e.py` (verified identical on the unmodified branch —
they need a live API + AWS creds). `ruff check` / `ruff format --check` /
`mypy` clean on the changed modules.

## Deliberately NOT included

- kustomize overlay `newTag` bumps — those belong to the build+deploy step.
- No merge/deploy/pilot dispatch.

## Ordering

The `applicable` default needs a simulator image built from
CovertLabEcoli/sms-ecoli#38. The explicit-modules path works against any image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)