### PR TITLE
deploy(stanford prod): api 0.9.40 -> 0.9.41

### DIFF
--- a/kustomize/overlays/sms-api-stanford/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford/kustomization.yaml
@@ -70,8 +70,15 @@ images:
   # {"jobId": ..., "type": "SEQUENTIAL"} for a job that also sets arrayProperties
   # ("Job Id cannot be set when dependency type is SEQUENTIAL"), caught by the first
   # real Array-jobs pilot dispatch. Now a plain {"jobId": ...} dependency.
+  # 0.9.41 (#231, #227): auto-triggers analysis as a 3rd node in the same Batch
+  # dependsOn DAG already used for parca->sim (item 24) instead of composite-Step
+  # wiring, which is structurally wrong for the array/scatter shape (each child only
+  # sees 1/N of the sweep) -- reuses the existing S3-native run_standalone_analysis.py
+  # entrypoint. Also splits the workbench Deployment out of this overlay into the
+  # sibling ../sms-api-stanford-workbench overlay (item 21) and completes the
+  # sms_api -> viva_api package rename (main/deploy-trunk reunified, #232/#233).
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.9.40
+    newTag: 0.9.41
   # ptools pinned to last-known-good tag — CI only builds sms-api, so there is
   # no newer sms-ptools:0.6.x image on ghcr.io.  0.5.9 is the tag the live Stanford
   # pod has been running successfully; keeping both namespaces pointing here


### PR DESCRIPTION
## Summary
- Bumps the `sms-api-stanford` overlay's `api` image tag 0.9.40 -> 0.9.41
- Already applied + verified live: `kubectl apply -k kustomize/overlays/sms-api-stanford`, confirmed via `/version` and `/openapi.json` on the live pod (both report `0.9.41`)
- Ships: analysis auto-trigger DAG-node (item 24, #231), item 21 kustomize overlay split (#227, workbench no longer shares this overlay), and the sms_api -> viva_api rename reunification (#232/#233)

This PR documents a deploy already performed against Stanford prod, per the ecosystem's deploy-commit-through-PR convention (see #230).

## Test plan
- [x] `kubectl diff -k kustomize/overlays/sms-api-stanford` — only the api Deployment's image tag + generation changed, nothing else
- [x] `kubectl apply -k kustomize/overlays/sms-api-stanford` — applied cleanly
- [x] `kubectl rollout status deployment/api -n sms-api-stanford` — succeeded
- [x] Live pod image tag confirmed via `kubectl get pod -o jsonpath`: `ghcr.io/vivarium-collective/sms-api:0.9.41`
- [x] Live served version confirmed via port-forward: `/version` and `/openapi.json` both report `0.9.41`

🤖 Generated with [Claude Code](https://claude.com/claude-code)