### PR TITLE
deploy(stanford prod): workbench 0.3.36 -> 0.3.37

### DIFF
--- a/kustomize/overlays/sms-api-stanford-workbench/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-workbench/kustomization.yaml
@@ -142,8 +142,17 @@ images:
   # would have kept only the first-processed lineage -- same class of bug as
   # #674, recurring one level deeper. _merge_zarr_tree recurses into a
   # collision instead of skipping it, for both zarr conventions.
+  # 0.3.37 (workbench #753/#755/#756/#757/#759): fixes investigations dir
+  # resolution through WorkspacePaths in scaffold mutations (item 22 -- the
+  # investigation 404 bug); adds a UI trigger (Analyses button) to run
+  # analysis on an existing completed simulation instead of only at dispatch
+  # time (item 23, pairs with viva-api 0.9.41's analysis-DAG-node); aligns
+  # server-side canonical-run outcome resolution with the client's
+  # canonical:-flag semantics instead of last-run-wins; and adds a read-only
+  # GET /api/server-version endpoint so a published/readonly bundle can
+  # report what it's actually running.
   - name: ghcr.io/vivarium-collective/vivarium-workbench
-    newTag: 0.3.36
+    newTag: 0.3.37
 
 replicas:
   # Single writer: workbench holds a git working copy + SQLite on an RWO EBS volume.


### PR DESCRIPTION
## Summary
- Bumps the `sms-api-stanford-workbench` overlay's image tag 0.3.36 -> 0.3.37 (both the `workbench` and `seed-workspace` containers, which share the image)
- Already applied + verified live: `kubectl apply -k kustomize/overlays/sms-api-stanford-workbench`, confirmed via the new `/workbench/api/server-version` endpoint on the live pod: `{"git_rev":"abb82835","version":"0.3.37"}`
- Ships items 22 (investigation 404 fix, #753) + 23 (UI analysis trigger, #755), plus canonical-run outcomes + the server-version endpoint itself (#759) and cleanup (#756/#757)

## Test plan
- [x] `kubectl diff -k kustomize/overlays/sms-api-stanford-workbench` — only both containers' image tag + generation changed
- [x] `kubectl apply` — applied cleanly
- [x] `kubectl rollout status deployment/workbench -n sms-api-stanford --timeout=600s` — succeeded (Recreate strategy, ~15GB image)
- [x] Live pod image tags confirmed via `kubectl get pod -o jsonpath` for both containers
- [x] Live served version confirmed via port-forward + `/workbench/api/server-version`: `0.3.37`

🤖 Generated with [Claude Code](https://claude.com/claude-code)