### PR TITLE
fix(item 21): mount workbench build-cache on the durable PVC

### DIFF
--- a/kustomize/base/workbench/workbench.yaml
+++ b/kustomize/base/workbench/workbench.yaml
@@ -151,6 +151,22 @@ spec:
               value: "http://api:8000"
             - name: VIVARIUM_WORKBENCH_WORKSPACE
               value: "/workspace"
+            # Item 21 (durability): materialized/switched simulator builds, and
+            # each session's own isolated clone of one
+            # (remote_build_source.materialize_build /
+            # .materialize_session_build in vivarium-workbench), used to live
+            # under this container's ephemeral root filesystem -- a legitimate
+            # pod restart (image bump, node eviction, OOM-kill) silently wiped
+            # every in-progress session's build cache (PR #227 fixed the
+            # unrelated-deploy blast radius; this closes the residual root
+            # cause). Points the SAME durable path the code already defaults to
+            # (Path.home()/".pbg"/"build-cache" == /root/.pbg/build-cache at
+            # uid 0) at the second volumeMount below (workbench-workspace PVC,
+            # subPath: build-cache) so it survives restarts. Explicit here even
+            # though it matches the code's own default -- self-documenting, and
+            # still correct if that default ever changes.
+            - name: VIVARIUM_WORKBENCH_BUILD_CACHE
+              value: "/root/.pbg/build-cache"
             # The internal ALB terminating /workbench REWRITES the Host header and
             # does NOT emit X-Forwarded-Host, so the CSRF same-origin check (and
             # --trust-proxy) can never match the browser's Origin. Declare the
@@ -196,10 +212,22 @@ spec:
           volumeMounts:
             - name: workspace
               mountPath: /workspace
+            # Item 21: a SECOND mount of the SAME PVC (no new claim, no new
+            # StorageClass) at a disjoint subPath, so materialized build
+            # caches persist across restarts without touching the existing
+            # /workspace data or requiring an EBS volume expansion up front.
+            # Matches this project's original intent (vivarium-workbench's
+            # docs/REFACTOR-PLAN.md §2B.3: "workspace (git/YAML/SQLite) +
+            # caches (venv, ParCa ~175 MB, `~/.pbg/build-cache`)") -- only the
+            # workspace half had shipped until now.
+            - name: workspace
+              mountPath: /root/.pbg/build-cache
+              subPath: build-cache
       volumes:
-        # Private EBS gp3 PVC (RWO) — workspace + caches. The claim is defined in
-        # the overlay (workbench-pvc.yaml). No shared filesystem with the compute:
-        # run outputs arrive from S3 via sms-api's download endpoints.
+        # Private EBS gp3 PVC (RWO) — workspace + build-cache (via the second
+        # subPath mount on the workbench container above). The claim is defined
+        # in the overlay (workbench-pvc.yaml). No shared filesystem with the
+        # compute: run outputs arrive from S3 via sms-api's download endpoints.
         - name: workspace
           persistentVolumeClaim:
             claimName: workbench-workspace

--- a/kustomize/overlays/sms-api-stanford-workbench/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-workbench/kustomization.yaml
@@ -21,10 +21,13 @@ namespace: sms-api-stanford
 # recreate the workbench Deployment and silently wipe in-progress session
 # state. This split narrows that blast radius: a viva-api-only change now
 # renders and applies from ../sms-api-stanford alone, never touching this
-# kustomization's resources. It does NOT fix the underlying ephemeral-cache
-# defect (a legitimate workbench-image bump, node eviction, or OOM-kill still
-# wipes it) -- that requires moving the build-cache onto persistent storage,
-# tracked separately as the real fix for item 21.
+# kustomization's resources. Item 21's other half -- the underlying
+# ephemeral-cache defect itself (a legitimate workbench-image bump, node
+# eviction, or OOM-kill wiping /root/.pbg/build-cache) -- is now closed in
+# base/workbench/workbench.yaml: a second volumeMount of this SAME PVC
+# (subPath: build-cache) makes that path durable too, matching this
+# project's original intent (vivarium-workbench's docs/REFACTOR-PLAN.md
+# §2B.3).
 #
 # Apply independently:
 #   kubectl kustomize kustomize/overlays/sms-api-stanford-workbench | kubectl apply -f -


### PR DESCRIPTION
## Summary
- The workbench's materialized/switched simulator build cache (`/root/.pbg/build-cache`, including each session's own isolated clone) lived on the pod's ephemeral root filesystem, not the `workbench-workspace` PVC.
- PR #227 (this repo) fixed the blast radius of an *unrelated* deploy silently recreating the pod and wiping every session's cache. This closes the residual root cause: a legitimate workbench-image bump, node eviction, or OOM-kill would still wipe it.
- Fix: a second `volumeMount` of the **same** `workbench-workspace` PVC (no new claim, no new StorageClass, no CDK change) at `subPath: build-cache`, matching vivarium-workbench's own original intent (`docs/REFACTOR-PLAN.md` §2B.3 — only the workspace half of "workspace + caches" had ever shipped).

This is the viva-api-side follow-up to backlog item 21 / item 20's residual bugs. Session-isolation itself (item 20's other half) turned out to already be fixed on vivarium-workbench's `main` (PR #729, merged 2026-08-04) — verified before starting this, not assumed. Companion PR: vivarium-collective/vivarium-workbench#763 (corrects stale ephemeral-cache docstrings + adds durability regression tests on that side).

## RWX-concurrency
Not needed. `workbench.yaml` pins `replicas: 1` / `strategy: Recreate` specifically because the PVC is RWO (git working copy + SQLite need a single writer) — confirmed from the file's own existing comments. A session-keyed subdirectory scheme under one pod/mount needs no multi-writer support; going RWX (EFS) would be an unrelated, already-considered-and-declined architectural change (`REFACTOR-PLAN.md` §2B.3).

## Test plan
- [x] `kubectl kustomize kustomize/overlays/sms-api-stanford-workbench` — renders cleanly (dry-render only, no cluster access used).
- [x] Parsed the rendered manifest and confirmed: exactly one PVC claim (`workbench-workspace`), two disjoint volumeMounts (`/workspace`, `/root/.pbg/build-cache` via `subPath: build-cache`), the new env var present with the expected value.
- [ ] Live `kubectl apply` — **deliberately not done**. Needs its own explicit go-ahead before any deploy to shared production infrastructure, separate from this PR/review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)