### PR TITLE
feat(item 33): individual per-seed job chain dispatch for AWS Batch

### DIFF
--- a/alembic/versions/f2b8e4a6c9d1_add_wave_columns_to_hpcrun.py
+++ b/alembic/versions/f2b8e4a6c9d1_add_wave_columns_to_hpcrun.py
@@ -1,18 +1,34 @@
-"""add wave_index/wave_seed_indices columns to hpcrun
+"""add chain-dispatch campaign columns to hpcrun
 
 Revision ID: f2b8e4a6c9d1
 Revises: e5a7c9d10f21
 Create Date: 2026-08-08
 
-Backlog item 33 (per-generation wave dispatch): adds two nullable columns to
-the existing ``hpcrun`` table so a wave-dispatch campaign can track, per HpcRun
-row, which 0-based generation its AWS Batch Array job ran (``wave_index``) and
-the real seed dispatched at each local array position (``wave_seed_indices``,
-JSONB list of ints -- needed to remap a sparse survivor set back to real seeds
-after Spot/OOM attrition). Both are NULL for every pre-existing row and every
-non-wave HpcRun going forward (SLURM, K8s, MNP, single-shot Array) -- purely
-additive, no new table (ORMHpcRun already supports multiple rows per
-simulation, one per wave/generation).
+Backlog item 33 (per-generation task decomposition): adds two nullable columns
+to the existing ``hpcrun`` table so ONE row can track a whole per-seed
+chain-dispatch campaign -- ``chain_n_generations`` (the campaign's total
+generation count G, also doubling as the "is this row a chain-campaign
+tracker" discriminator via IS NOT NULL) and ``chain_final_job_ids`` (JSONB
+list of the AWS Batch job id AWS assigned to each seed's own last
+successfully-submitted generation job -- the set the analysis-fan-in poller,
+``JobScheduler.update_chain_campaigns``, watches for all-terminal). Both are
+NULL for every pre-existing row and every non-chain-campaign HpcRun going
+forward (SLURM, K8s, MNP, single-shot Array) -- purely additive, no new table
+(ORMHpcRun already supports multiple rows per simulation).
+
+Amended in place (still unmerged -- PR #237) rather than stacking a second
+migration on top: this revision originally shipped as
+``wave_index``/``wave_seed_indices``, sized for a fundamentally different
+design (one HpcRun row per GENERATION-WIDE array job, "wave_seed_indices"
+holding the real seed at each local array position). That design was
+superseded before merge by individual per-seed AWS Batch job chains (each
+generation its own job, chained via native ``dependsOn`` -- see
+``SimulationServiceRay.submit_chain_dispatch_job``), which collapses the
+per-campaign bookkeeping to ONE row holding the N seeds' own final job ids
+directly, rather than N array-position indices. Since nothing was ever
+deployed against the old column names (this capability is still unwired from
+any HTTP router), renaming here costs nothing and avoids a churny
+add-then-drop pair of migrations for a shape that never shipped.
 """
 
 from collections.abc import Sequence
@@ -30,10 +46,10 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    op.add_column("hpcrun", sa.Column("wave_index", sa.Integer(), nullable=True))
-    op.add_column("hpcrun", sa.Column("wave_seed_indices", postgresql.JSONB(), nullable=True))
+    op.add_column("hpcrun", sa.Column("chain_n_generations", sa.Integer(), nullable=True))
+    op.add_column("hpcrun", sa.Column("chain_final_job_ids", postgresql.JSONB(), nullable=True))
 
 
 def downgrade() -> None:
-    op.drop_column("hpcrun", "wave_seed_indices")
-    op.drop_column("hpcrun", "wave_index")
+    op.drop_column("hpcrun", "chain_final_job_ids")
+    op.drop_column("hpcrun", "chain_n_generations")

--- a/alembic/versions/f2b8e4a6c9d1_add_wave_columns_to_hpcrun.py
+++ b/alembic/versions/f2b8e4a6c9d1_add_wave_columns_to_hpcrun.py
@@ -1,0 +1,39 @@
+"""add wave_index/wave_seed_indices columns to hpcrun
+
+Revision ID: f2b8e4a6c9d1
+Revises: e5a7c9d10f21
+Create Date: 2026-08-08
+
+Backlog item 33 (per-generation wave dispatch): adds two nullable columns to
+the existing ``hpcrun`` table so a wave-dispatch campaign can track, per HpcRun
+row, which 0-based generation its AWS Batch Array job ran (``wave_index``) and
+the real seed dispatched at each local array position (``wave_seed_indices``,
+JSONB list of ints -- needed to remap a sparse survivor set back to real seeds
+after Spot/OOM attrition). Both are NULL for every pre-existing row and every
+non-wave HpcRun going forward (SLURM, K8s, MNP, single-shot Array) -- purely
+additive, no new table (ORMHpcRun already supports multiple rows per
+simulation, one per wave/generation).
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f2b8e4a6c9d1"
+down_revision: str | Sequence[str] | None = "e5a7c9d10f21"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("hpcrun", sa.Column("wave_index", sa.Integer(), nullable=True))
+    op.add_column("hpcrun", sa.Column("wave_seed_indices", postgresql.JSONB(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("hpcrun", "wave_seed_indices")
+    op.drop_column("hpcrun", "wave_index")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "viva_api"
-version = "0.9.41"
+version = "0.9.42"
 description = "This is the api server for Vivarium simulation services."
 authors = [{ name = "Alex Patrie", email = "alexanderpatrie@gmail.com" }, { name = "Jim Schaff", email = "jschaff@gmail.com" }]
 requires-python = ">=3.13,<3.14"

--- a/tests/api/app/test_cli_e2e.py
+++ b/tests/api/app/test_cli_e2e.py
@@ -54,7 +54,7 @@ def _api_is_reachable() -> bool:
 
 def _aws_credentials_valid() -> bool:
     try:
-        result = subprocess.run(  # noqa: S603
+        result = subprocess.run(
             ["aws", "sts", "get-caller-identity"],  # noqa: S607
             capture_output=True,
             text=True,

--- a/tests/api/app/test_cli_e2e.py
+++ b/tests/api/app/test_cli_e2e.py
@@ -54,7 +54,7 @@ def _api_is_reachable() -> bool:
 
 def _aws_credentials_valid() -> bool:
     try:
-        result = subprocess.run(
+        result = subprocess.run(  # noqa: S603
             ["aws", "sts", "get-caller-identity"],  # noqa: S607
             capture_output=True,
             text=True,

--- a/tests/common/handlers/test_simulations_handler.py
+++ b/tests/common/handlers/test_simulations_handler.py
@@ -18,14 +18,23 @@ from viva_api.common.handlers.simulations import (
     fetch_omics_outputs,
     get_available_omics_output_paths,
 )
+from viva_api.common.models import JobId, JobStatus
 from viva_api.common.simulator_defaults import RepoUrl
 from viva_api.common.ssh.ssh_service import SSHSessionService
 from viva_api.common.storage.file_paths import HPCFilePath, S3FilePath
 from viva_api.common.storage.file_service import FileService, ListingItem
 from viva_api.config import ComputeBackend, get_settings
 from viva_api.dependencies import get_file_service, set_file_service
-from viva_api.simulation.models import AnalysisOptions, Simulation, SimulationConfig, SimulatorVersion
+from viva_api.simulation.models import (
+    AnalysisOptions,
+    HpcRun,
+    JobType,
+    Simulation,
+    SimulationConfig,
+    SimulatorVersion,
+)
 from viva_api.simulation.simulation_service_k8s import SimulationServiceK8s
+from viva_api.simulation.simulation_service_ray import SimulationServiceRay
 from viva_api.simulation.tables_orm import ORMAnalysis
 
 
@@ -431,3 +440,140 @@ async def test_run_standalone_analysis_ray_native_requires_out_uri() -> None:
             simulator=simulator,
             modules={},
         )
+
+
+def _make_chain_campaign_hpc_run(status: JobStatus = JobStatus.RUNNING) -> HpcRun:
+    return HpcRun(
+        database_id=300,
+        job_id=JobId.ray("parca-job-abc"),
+        correlation_id="N/A",
+        job_type=JobType.SIMULATION,
+        ref_id=214,
+        status=status,
+        chain_n_generations=10,
+        chain_final_job_ids=["seed0-gen9-job", "seed1-gen9-job"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_simulation_status_chain_campaign_not_terminal_does_not_write_db() -> None:
+    """Regression for the severe bug found 2026-08-10: `get_simulation_status` used to read
+    the campaign's stored `job_id` (the ParCa kickoff job, which finishes long before the real
+    per-seed chains) and write ITS status onto the whole campaign row -- corrupting it to
+    COMPLETED while the real chains were still 5% done, permanently dropping the campaign out
+    of JobScheduler.list_active_chain_campaigns()'s poll set and silently killing analysis
+    auto-fire. A chain campaign's status must come from get_chain_campaign_result (polling the
+    real tracked per-seed job ids), and this endpoint must never write to the DB -- only
+    JobScheduler's own poll loop may transition a campaign row's status."""
+    from viva_api.common.handlers.simulations import get_simulation_status
+    from viva_api.simulation.simulation_service_ray import ChainCampaignPollResult
+
+    hpc_run = _make_chain_campaign_hpc_run()
+    mock_db_service = AsyncMock()
+    mock_db_service.get_simulation.return_value = SimpleNamespace(database_id=214)
+    mock_db_service.get_hpcrun_by_ref.return_value = hpc_run
+
+    mock_ray_service = AsyncMock(spec=SimulationServiceRay)
+    mock_ray_service.get_chain_campaign_result = lambda job_ids: ChainCampaignPollResult(terminal=False)
+
+    with patch(
+        "viva_api.common.handlers.simulations.get_simulation_service_for_job",
+        return_value=mock_ray_service,
+    ):
+        result = await get_simulation_status(db_service=mock_db_service, id=214)
+
+    assert result.status == JobStatus.RUNNING
+    mock_db_service.update_hpcrun_status.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_simulation_status_chain_campaign_terminal_success_does_not_write_db() -> None:
+    """A terminal, all-succeeded chain campaign reports COMPLETED without writing the DB --
+    JobScheduler.update_chain_campaigns owns that write, on its own poll interval, not this
+    read path (avoids a race between a status check and the scheduler's own transition)."""
+    from viva_api.common.handlers.simulations import get_simulation_status
+    from viva_api.simulation.simulation_service_ray import ChainCampaignPollResult
+
+    hpc_run = _make_chain_campaign_hpc_run()
+    mock_db_service = AsyncMock()
+    mock_db_service.get_simulation.return_value = SimpleNamespace(database_id=214)
+    mock_db_service.get_hpcrun_by_ref.return_value = hpc_run
+
+    mock_ray_service = AsyncMock(spec=SimulationServiceRay)
+    mock_ray_service.get_chain_campaign_result = lambda job_ids: ChainCampaignPollResult(
+        terminal=True, succeeded_job_ids=["seed0-gen9-job", "seed1-gen9-job"]
+    )
+
+    with patch(
+        "viva_api.common.handlers.simulations.get_simulation_service_for_job",
+        return_value=mock_ray_service,
+    ):
+        result = await get_simulation_status(db_service=mock_db_service, id=214)
+
+    assert result.status == JobStatus.COMPLETED
+    mock_db_service.update_hpcrun_status.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_simulation_status_chain_campaign_terminal_zero_succeeded_reports_failed() -> None:
+    """Every tracked seed chain failed -- reports FAILED with an explanatory message, still
+    without writing the DB (same ownership rule as the success case above)."""
+    from viva_api.common.handlers.simulations import get_simulation_status
+    from viva_api.simulation.simulation_service_ray import ChainCampaignPollResult
+
+    hpc_run = _make_chain_campaign_hpc_run()
+    mock_db_service = AsyncMock()
+    mock_db_service.get_simulation.return_value = SimpleNamespace(database_id=214)
+    mock_db_service.get_hpcrun_by_ref.return_value = hpc_run
+
+    mock_ray_service = AsyncMock(spec=SimulationServiceRay)
+    mock_ray_service.get_chain_campaign_result = lambda job_ids: ChainCampaignPollResult(
+        terminal=True, succeeded_job_ids=[], failed_job_ids=["seed0-gen9-job", "seed1-gen9-job"]
+    )
+
+    with patch(
+        "viva_api.common.handlers.simulations.get_simulation_service_for_job",
+        return_value=mock_ray_service,
+    ):
+        result = await get_simulation_status(db_service=mock_db_service, id=214)
+
+    assert result.status == JobStatus.FAILED
+    assert result.error_message == "chain dispatch: zero seed chains succeeded"
+    mock_db_service.update_hpcrun_status.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_simulation_status_non_chain_run_unaffected() -> None:
+    """A plain (non-chain-campaign) simulation must keep the original behavior exactly --
+    read the single job's status and persist it once terminal. Guards against the chain-aware
+    branch above accidentally swallowing the normal, non-campaign path."""
+    from viva_api.common.handlers.simulations import get_simulation_status
+    from viva_api.common.hpc.job_service import JobStatusInfo
+
+    hpc_run = HpcRun(
+        database_id=99,
+        job_id=JobId.k8s("plain-sim-job"),
+        correlation_id="N/A",
+        job_type=JobType.SIMULATION,
+        ref_id=42,
+        status=JobStatus.RUNNING,
+        chain_n_generations=None,
+        chain_final_job_ids=None,
+    )
+    mock_db_service = AsyncMock()
+    mock_db_service.get_simulation.return_value = SimpleNamespace(database_id=42)
+    mock_db_service.get_hpcrun_by_ref.return_value = hpc_run
+
+    mock_service = AsyncMock()
+    mock_service.get_job_status.return_value = JobStatusInfo(
+        job_id=hpc_run.job_id, status=JobStatus.COMPLETED, start_time="t0", end_time="t1"
+    )
+
+    with patch(
+        "viva_api.common.handlers.simulations.get_simulation_service_for_job",
+        return_value=mock_service,
+    ):
+        result = await get_simulation_status(db_service=mock_db_service, id=42)
+
+    assert result.status == JobStatus.COMPLETED
+    mock_db_service.update_hpcrun_status.assert_called_once()

--- a/tests/common/storage/test_data_layout.py
+++ b/tests/common/storage/test_data_layout.py
@@ -44,6 +44,20 @@ class TestRayLayout:
         assert RayLayout.parca_cache_uri("abc123", upstream=True) == "s3://my-bucket/ray-upstream-parca-cache/abc123/"
         assert RayLayout.parca_cache_uri("abc123", upstream=True) != RayLayout.parca_cache_uri("abc123")
 
+    def test_wave_state_uri(self) -> None:
+        assert RayLayout.wave_state_uri("exp-abc", 4, 2) == "s3://my-bucket/vecoli-output/exp-abc/wave-state/seed4/gen2.pkl"
+
+    def test_wave_state_uri_generation_zero(self) -> None:
+        assert RayLayout.wave_state_uri("exp", 0, 0) == "s3://my-bucket/vecoli-output/exp/wave-state/seed0/gen0.pkl"
+
+    def test_wave_state_prefix_lives_under_experiment_prefix(self) -> None:
+        assert RayLayout.wave_state_prefix("exp").startswith(RayLayout.experiment_prefix("exp"))
+
+    def test_wave_state_uri_distinct_per_seed_and_generation(self) -> None:
+        base = RayLayout.wave_state_uri("exp", 1, 0)
+        assert RayLayout.wave_state_uri("exp", 2, 0) != base  # different seed
+        assert RayLayout.wave_state_uri("exp", 1, 1) != base  # different generation
+
 
 class TestNextflowLayout:
     def test_output_uri_is_single_nested(self) -> None:

--- a/tests/common/storage/test_data_layout.py
+++ b/tests/common/storage/test_data_layout.py
@@ -45,7 +45,10 @@ class TestRayLayout:
         assert RayLayout.parca_cache_uri("abc123", upstream=True) != RayLayout.parca_cache_uri("abc123")
 
     def test_wave_state_uri(self) -> None:
-        assert RayLayout.wave_state_uri("exp-abc", 4, 2) == "s3://my-bucket/vecoli-output/exp-abc/wave-state/seed4/gen2.pkl"
+        assert (
+            RayLayout.wave_state_uri("exp-abc", 4, 2)
+            == "s3://my-bucket/vecoli-output/exp-abc/wave-state/seed4/gen2.pkl"
+        )
 
     def test_wave_state_uri_generation_zero(self) -> None:
         assert RayLayout.wave_state_uri("exp", 0, 0) == "s3://my-bucket/vecoli-output/exp/wave-state/seed0/gen0.pkl"

--- a/tests/common/storage/test_data_layout.py
+++ b/tests/common/storage/test_data_layout.py
@@ -44,22 +44,25 @@ class TestRayLayout:
         assert RayLayout.parca_cache_uri("abc123", upstream=True) == "s3://my-bucket/ray-upstream-parca-cache/abc123/"
         assert RayLayout.parca_cache_uri("abc123", upstream=True) != RayLayout.parca_cache_uri("abc123")
 
-    def test_wave_state_uri(self) -> None:
+    def test_daughter_state_uri(self) -> None:
         assert (
-            RayLayout.wave_state_uri("exp-abc", 4, 2)
-            == "s3://my-bucket/vecoli-output/exp-abc/wave-state/seed4/gen2.pkl"
+            RayLayout.daughter_state_uri("exp-abc", 4, 2)
+            == "s3://my-bucket/vecoli-output/exp-abc/daughter-state/seed4/gen2.pkl"
         )
 
-    def test_wave_state_uri_generation_zero(self) -> None:
-        assert RayLayout.wave_state_uri("exp", 0, 0) == "s3://my-bucket/vecoli-output/exp/wave-state/seed0/gen0.pkl"
+    def test_daughter_state_uri_generation_zero(self) -> None:
+        assert (
+            RayLayout.daughter_state_uri("exp", 0, 0)
+            == "s3://my-bucket/vecoli-output/exp/daughter-state/seed0/gen0.pkl"
+        )
 
-    def test_wave_state_prefix_lives_under_experiment_prefix(self) -> None:
-        assert RayLayout.wave_state_prefix("exp").startswith(RayLayout.experiment_prefix("exp"))
+    def test_daughter_state_prefix_lives_under_experiment_prefix(self) -> None:
+        assert RayLayout.daughter_state_prefix("exp").startswith(RayLayout.experiment_prefix("exp"))
 
-    def test_wave_state_uri_distinct_per_seed_and_generation(self) -> None:
-        base = RayLayout.wave_state_uri("exp", 1, 0)
-        assert RayLayout.wave_state_uri("exp", 2, 0) != base  # different seed
-        assert RayLayout.wave_state_uri("exp", 1, 1) != base  # different generation
+    def test_daughter_state_uri_distinct_per_seed_and_generation(self) -> None:
+        base = RayLayout.daughter_state_uri("exp", 1, 0)
+        assert RayLayout.daughter_state_uri("exp", 2, 0) != base  # different seed
+        assert RayLayout.daughter_state_uri("exp", 1, 1) != base  # different generation
 
 
 class TestNextflowLayout:

--- a/tests/integration/test_aws_batch_e2e.py
+++ b/tests/integration/test_aws_batch_e2e.py
@@ -63,6 +63,7 @@ from pathlib import Path
 
 import pytest
 
+import viva_api.dependencies as deps
 from viva_api.common.hpc.job_service import JobStatusInfo
 from viva_api.common.models import JobId, JobStatus
 from viva_api.common.simulator_defaults import RepoUrl
@@ -168,70 +169,89 @@ async def test_chain_dispatch_multiseed_multigeneration_against_real_aws_batch(
         )
         simulation = await database_service.insert_simulation(sim_request=simulation_request)
 
-    campaign = await database_service.get_hpcrun_by_ref(ref_id=simulation.database_id, job_type=JobType.SIMULATION)
-    if campaign is None or not campaign.chain_final_job_ids:
-        job_id = await ray_service.submit_chain_dispatch_job(simulation, database_service)
-        assert job_id is not None
+    # submit_chain_dispatch_job stages run_pbg.py to S3 via the module-level
+    # FileService dependency (viva_api.dependencies.get_file_service()) -- a
+    # normal request has this set at app startup (dependencies.init_standalone);
+    # this test constructs SimulationServiceRay() directly, bypassing that, so
+    # it must set it up itself. Real S3, not a mock -- this test's whole point
+    # is exercising real infrastructure.
+    saved_file_service = deps.get_file_service()
+    dispatch_file_service = FileServiceS3()
+    deps.set_file_service(dispatch_file_service)
+    try:
         campaign = await database_service.get_hpcrun_by_ref(ref_id=simulation.database_id, job_type=JobType.SIMULATION)
+        if campaign is None or not campaign.chain_final_job_ids:
+            job_id = await ray_service.submit_chain_dispatch_job(simulation, database_service)
+            assert job_id is not None
+            campaign = await database_service.get_hpcrun_by_ref(
+                ref_id=simulation.database_id, job_type=JobType.SIMULATION
+            )
 
-    assert campaign is not None, "No campaign HpcRun row was recorded by submit_chain_dispatch_job"
-    tracked_job_ids = campaign.chain_final_job_ids or []
-    assert tracked_job_ids, "chain-dispatch tracked zero seed chains -- every seed failed generation 0 submission"
-    assert len(tracked_job_ids) == N_SEEDS, (
-        f"expected {N_SEEDS} tracked seed chains, got {len(tracked_job_ids)}: {tracked_job_ids}"
-    )
-
-    # Poll every tracked seed chain's own final job to terminal. Real AWS
-    # Batch dependency resolution advances each chain natively (generation
-    # g+1 doesn't start until generation g SUCCEEDED) -- this loop only
-    # detects completion, exactly like JobScheduler.update_chain_campaigns
-    # does on a real deployment's own polling interval.
-    start_time = time.time()
-    result = ray_service.get_chain_campaign_result(tracked_job_ids)
-    while not result.terminal and time.time() - start_time < POLL_TIMEOUT_SECONDS:
-        await asyncio.sleep(POLL_INTERVAL_SECONDS)
-        result = ray_service.get_chain_campaign_result(tracked_job_ids)
-
-    assert result.terminal, (
-        f"Chain-dispatch campaign did not reach terminal state within {POLL_TIMEOUT_SECONDS}s "
-        f"({len(result.succeeded_job_ids)} succeeded, {len(result.failed_job_ids)} failed so far, "
-        f"{len(tracked_job_ids) - len(result.succeeded_job_ids) - len(result.failed_job_ids)} still pending)"
-    )
-    assert result.succeeded_job_ids, f"Every one of {len(tracked_job_ids)} seed chains failed: {result.failed_job_ids}"
-
-    # Fire (or reuse, if already fired by a prior interrupted run) the
-    # analysis DAG node for real -- exactly what JobScheduler.
-    # _advance_chain_campaign does once its own poll detects all-terminal.
-    existing_analyses = await database_service.list_analyses(simulation_id=simulation.database_id)
-    non_failed = [a for a in existing_analyses if a.status != JobStatus.FAILED]
-    if non_failed:
-        analysis_job_id: str | None = non_failed[-1].job_id_ext
-    else:
-        analysis_job_id = await ray_service.submit_campaign_analysis(
-            simulation=simulation,
-            database_service=database_service,
-            commit=simulator.git_commit_hash,
-            total_n_seeds=N_SEEDS,
-            n_generations=N_GENERATIONS,
+        assert campaign is not None, "No campaign HpcRun row was recorded by submit_chain_dispatch_job"
+        tracked_job_ids = campaign.chain_final_job_ids or []
+        assert tracked_job_ids, "chain-dispatch tracked zero seed chains -- every seed failed generation 0 submission"
+        assert len(tracked_job_ids) == N_SEEDS, (
+            f"expected {N_SEEDS} tracked seed chains, got {len(tracked_job_ids)}: {tracked_job_ids}"
         )
-    assert analysis_job_id is not None, "Analysis DAG node submission failed -- see the recorded FAILED analyses row"
 
-    analysis_start = time.time()
-    analysis_status: JobStatusInfo | None = None
-    while time.time() - analysis_start < POLL_TIMEOUT_SECONDS:
-        analysis_status = await ray_service.get_job_status(JobId.ray(analysis_job_id))
-        if analysis_status is not None and analysis_status.status in (
-            JobStatus.COMPLETED,
-            JobStatus.FAILED,
-            JobStatus.CANCELLED,
-        ):
-            break
-        await asyncio.sleep(POLL_INTERVAL_SECONDS)
+        # Poll every tracked seed chain's own final job to terminal. Real AWS
+        # Batch dependency resolution advances each chain natively (generation
+        # g+1 doesn't start until generation g SUCCEEDED) -- this loop only
+        # detects completion, exactly like JobScheduler.update_chain_campaigns
+        # does on a real deployment's own polling interval.
+        start_time = time.time()
+        result = ray_service.get_chain_campaign_result(tracked_job_ids)
+        while not result.terminal and time.time() - start_time < POLL_TIMEOUT_SECONDS:
+            await asyncio.sleep(POLL_INTERVAL_SECONDS)
+            result = ray_service.get_chain_campaign_result(tracked_job_ids)
 
-    assert analysis_status is not None, "Analysis job status never resolved"
-    assert analysis_status.status == JobStatus.COMPLETED, (
-        f"Analysis job did not succeed: status={analysis_status.status}, error={analysis_status.error_message}"
-    )
+        assert result.terminal, (
+            f"Chain-dispatch campaign did not reach terminal state within {POLL_TIMEOUT_SECONDS}s "
+            f"({len(result.succeeded_job_ids)} succeeded, {len(result.failed_job_ids)} failed so far, "
+            f"{len(tracked_job_ids) - len(result.succeeded_job_ids) - len(result.failed_job_ids)} still pending)"
+        )
+        assert result.succeeded_job_ids, (
+            f"Every one of {len(tracked_job_ids)} seed chains failed: {result.failed_job_ids}"
+        )
+
+        # Fire (or reuse, if already fired by a prior interrupted run) the
+        # analysis DAG node for real -- exactly what JobScheduler.
+        # _advance_chain_campaign does once its own poll detects all-terminal.
+        existing_analyses = await database_service.list_analyses(simulation_id=simulation.database_id)
+        non_failed = [a for a in existing_analyses if a.status != JobStatus.FAILED]
+        if non_failed:
+            analysis_job_id: str | None = non_failed[-1].job_id_ext
+        else:
+            analysis_job_id = await ray_service.submit_campaign_analysis(
+                simulation=simulation,
+                database_service=database_service,
+                commit=simulator.git_commit_hash,
+                total_n_seeds=N_SEEDS,
+                n_generations=N_GENERATIONS,
+            )
+        assert analysis_job_id is not None, (
+            "Analysis DAG node submission failed -- see the recorded FAILED analyses row"
+        )
+
+        analysis_start = time.time()
+        analysis_status: JobStatusInfo | None = None
+        while time.time() - analysis_start < POLL_TIMEOUT_SECONDS:
+            analysis_status = await ray_service.get_job_status(JobId.ray(analysis_job_id))
+            if analysis_status is not None and analysis_status.status in (
+                JobStatus.COMPLETED,
+                JobStatus.FAILED,
+                JobStatus.CANCELLED,
+            ):
+                break
+            await asyncio.sleep(POLL_INTERVAL_SECONDS)
+
+        assert analysis_status is not None, "Analysis job status never resolved"
+        assert analysis_status.status == JobStatus.COMPLETED, (
+            f"Analysis job did not succeed: status={analysis_status.status}, error={analysis_status.error_message}"
+        )
+    finally:
+        deps.set_file_service(saved_file_service)
+        await dispatch_file_service.close()
 
     # Verify real cd1_*/ptools_* artifacts actually landed in S3 -- the whole
     # point of the canonical dispatch (see ecosystem/CLAUDE.md's own MVP

--- a/tests/integration/test_aws_batch_e2e.py
+++ b/tests/integration/test_aws_batch_e2e.py
@@ -1,7 +1,8 @@
 """AWS Batch End-to-End Integration Tests.
 
-These tests require real AWS infrastructure (Batch, S3, ECR, EKS).
-Skipped unless AWS_BATCH_INTEGRATION=1 is set.
+These tests require real AWS infrastructure (Batch, S3, ECR) and issue real,
+billable AWS Batch job submissions. Skipped unless AWS_BATCH_INTEGRATION=1 is
+set -- never run automatically by `make test` / CI.
 
 Run with:
     AWS_BATCH_INTEGRATION=1 AWS_PROFILE=stanford-sso \
@@ -12,34 +13,223 @@ Prerequisites:
 - CDK stack deployed (smsvpctest-batch)
 - AWS credentials configured (AWS_PROFILE=stanford-sso)
 - Kubeconfig for EKS cluster
-- ECR repository exists (vecoli)
-- Batch job queue configured
+- ECR repository exists (v2ecoli) with a built image for the resolved commit
+  (the LATEST commit on sms-ecoli's main branch, resolved live at test-run
+  time -- not hardcoded, see _get_or_create_sms_ecoli_simulator -- so make
+  sure that commit has actually been built and pushed before running this)
+
+What this covers (backlog item 33 -- individual per-seed AWS Batch job
+chains): a genuine, small, real multiseed x multigeneration chain-dispatch
+run against real AWS Batch on smsvpctest -- the actual pilot, formalized as a
+reproducible test rather than a one-off manual CLI run. Submits real ParCa +
+N_SEEDS independent per-seed job chains (N_GENERATIONS deep each), polls them
+to terminal for real via SimulationServiceRay.get_chain_campaign_result (the
+same mechanism JobScheduler.update_chain_campaigns polls on a real
+deployment's own interval), submits the real analysis DAG node
+(submit_campaign_analysis) once every chain is terminal, polls that to
+terminal too, then verifies real cd1_*/ptools_* analysis artifacts actually
+landed in S3 -- not just that the jobs exited zero.
+
+Deliberately small by default (N_SEEDS=2, N_GENERATIONS=2 -- 1 ParCa + 4
+per-seed-generation jobs + 1 analysis job = 6 real Batch submissions): this
+proves the chain-dispatch MECHANISM for real, cheaply and repeatably. The
+actual canonical 1000-seed x 10-generation dispatch is a separate, much more
+expensive, explicitly-gated exercise (the real production pilot / "big
+kahuna"), not something a routinely-rerunnable regression test should pay for
+by default -- override AWS_BATCH_E2E_N_SEEDS / AWS_BATCH_E2E_N_GENERATIONS if
+a larger real run is deliberately wanted.
+
+Idempotent, like tests/integration/test_hpc_workflow.py: re-running with the
+same resolved commit reuses the existing simulator/parca dataset/simulation/
+campaign rather than re-dispatching real jobs that already ran, so an
+interrupted or re-run test doesn't silently double-spend.
 """
 
+import asyncio
 import os
+import time
+from pathlib import Path
 
 import pytest
+
+from viva_api.common.hpc.job_service import JobStatusInfo
+from viva_api.common.models import JobId, JobStatus
+from viva_api.common.simulator_defaults import RepoUrl
+from viva_api.common.storage.data_layout import RayLayout
+from viva_api.common.storage.file_paths import S3FilePath
+from viva_api.common.storage.file_service_s3 import FileServiceS3
+from viva_api.simulation.database_service import DatabaseServiceSQL
+from viva_api.simulation.models import (
+    JobType,
+    ParcaDatasetRequest,
+    ParcaOptions,
+    SimulationConfig,
+    SimulationRequest,
+    SimulatorVersion,
+)
+from viva_api.simulation.simulation_service_ray import SimulationServiceRay
 
 pytestmark = pytest.mark.skipif(
     not os.getenv("AWS_BATCH_INTEGRATION"),
     reason="Set AWS_BATCH_INTEGRATION=1 to run real AWS Batch tests",
 )
 
+# Deliberately small and cheap by default -- see module docstring. Override via
+# env for a bigger real run without editing this file.
+N_SEEDS = int(os.getenv("AWS_BATCH_E2E_N_SEEDS", "2"))
+N_GENERATIONS = int(os.getenv("AWS_BATCH_E2E_N_GENERATIONS", "2"))
+# A real ParCa + N*G real generation jobs (each its own container start, cache
+# stage, and the actual v2ecoli computation) can take a while end to end even
+# at this small scale; poll generously rather than risk a false failure from
+# an over-tight timeout. 60 minutes default.
+POLL_TIMEOUT_SECONDS = int(os.getenv("AWS_BATCH_E2E_TIMEOUT_SECONDS", str(60 * 60)))
+POLL_INTERVAL_SECONDS = 20
+
+TEST_EXPERIMENT_ID_PREFIX = "test-e2e-chain-dispatch"
+
+
+async def _get_or_create_sms_ecoli_simulator(
+    database_service: DatabaseServiceSQL, ray_service: SimulationServiceRay
+) -> SimulatorVersion:
+    """Resolve the LATEST real sms-ecoli commit live (not a hardcoded value
+    that would drift out of date -- mirrors DEFAULT_COMMIT's own "should be
+    latest" intent for the vEcoli-private default), reusing an existing DB row
+    for that exact commit if a prior run already created one."""
+    commit = await ray_service.get_latest_commit_hash(git_repo_url=RepoUrl.SMS_ECOLI_REPO_URL, git_branch="main")
+    for simulator in await database_service.list_simulators():
+        if simulator.git_commit_hash == commit and simulator.git_repo_url == RepoUrl.SMS_ECOLI_REPO_URL:
+            return simulator
+    return await database_service.insert_simulator(
+        git_commit_hash=commit, git_repo_url=RepoUrl.SMS_ECOLI_REPO_URL, git_branch="main"
+    )
+
+
+async def _get_or_create_parca_dataset(database_service: DatabaseServiceSQL, simulator: SimulatorVersion) -> int:
+    for parca in await database_service.list_parca_datasets():
+        if parca.parca_dataset_request.simulator_version.database_id == simulator.database_id:
+            return parca.database_id
+    parca_dataset_request = ParcaDatasetRequest(simulator_version=simulator, parca_config=ParcaOptions())
+    parca_dataset = await database_service.insert_parca_dataset(parca_dataset_request=parca_dataset_request)
+    return parca_dataset.database_id
+
 
 @pytest.mark.asyncio
-async def test_placeholder_batch_integration() -> None:
-    """Placeholder for real AWS Batch integration tests.
+async def test_chain_dispatch_multiseed_multigeneration_against_real_aws_batch(
+    database_service: DatabaseServiceSQL,
+) -> None:
+    """Real, genuine multiseed x multigeneration chain-dispatch run against
+    real AWS Batch (backlog item 33). See module docstring for full context.
 
-    TODO: Implement when infrastructure is ready:
-    1. Build and push multi-arch vEcoli image to ECR (or verify existing)
-    2. Submit simulation via SimulationServiceK8s
-    3. Poll for K8s Job completion (init container + Nextflow)
-    4. Verify Batch tasks were submitted and completed
-    5. Verify outputs in S3 (vecoli-output/{experiment_id}/)
-    6. Test cancel: submit, then cancel, verify Batch tasks stopped
-    7. Test log retrieval from K8s pod logs
+    Calls SimulationServiceRay.submit_chain_dispatch_job directly (not through
+    the HTTP API or run_simulation_workflow): the real-entrypoint ROUTING
+    decision (does a canonical batch_baseline request actually reach
+    chain-dispatch) is already covered for real, at zero AWS cost, by
+    tests/integration/test_k8s_workflow_mock.py's
+    test_ray_canonical_batch_baseline_routes_through_real_entrypoint_to_chain_dispatch.
+    This test's job is different: prove the chain-dispatch MECHANISM itself
+    (per-seed job chains, dependsOn resolution, the analysis fan-in poll, and
+    the real analysis artifacts it produces) against real AWS infrastructure.
     """
-    # This test is a placeholder — it documents what needs to be tested
-    # against real AWS infrastructure. The mock integration tests in
-    # test_k8s_workflow_mock.py cover the same flow with mocked backends.
-    pytest.skip("Real AWS integration tests not yet implemented — use test_k8s_workflow_mock.py for now")
+    ray_service = SimulationServiceRay()
+    simulator = await _get_or_create_sms_ecoli_simulator(database_service, ray_service)
+    parca_dataset_id = await _get_or_create_parca_dataset(database_service, simulator)
+
+    experiment_id = f"{TEST_EXPERIMENT_ID_PREFIX}-{simulator.git_commit_hash}-{N_SEEDS}x{N_GENERATIONS}"
+
+    # Idempotency: reuse an existing simulation for this exact (commit, seeds,
+    # generations) shape if one already exists (e.g. a prior run interrupted
+    # mid-poll) instead of re-dispatching N*G real jobs a second time.
+    simulation = await database_service.get_simulation_by_experiment_id(experiment_id)
+    if simulation is None:
+        config = SimulationConfig(experiment_id=experiment_id, generations=N_GENERATIONS)
+        setattr(config, "n_init_sims", N_SEEDS)  # noqa: B010 -- extra field, SimulationConfig allows it
+        simulation_request = SimulationRequest(
+            simulation_config_filename="api_simulation_default.json",
+            experiment_id=experiment_id,
+            simulator_id=simulator.database_id,
+            parca_dataset_id=parca_dataset_id,
+            config=config,
+        )
+        simulation = await database_service.insert_simulation(sim_request=simulation_request)
+
+    campaign = await database_service.get_hpcrun_by_ref(ref_id=simulation.database_id, job_type=JobType.SIMULATION)
+    if campaign is None or not campaign.chain_final_job_ids:
+        job_id = await ray_service.submit_chain_dispatch_job(simulation, database_service)
+        assert job_id is not None
+        campaign = await database_service.get_hpcrun_by_ref(ref_id=simulation.database_id, job_type=JobType.SIMULATION)
+
+    assert campaign is not None, "No campaign HpcRun row was recorded by submit_chain_dispatch_job"
+    tracked_job_ids = campaign.chain_final_job_ids or []
+    assert tracked_job_ids, "chain-dispatch tracked zero seed chains -- every seed failed generation 0 submission"
+    assert len(tracked_job_ids) == N_SEEDS, (
+        f"expected {N_SEEDS} tracked seed chains, got {len(tracked_job_ids)}: {tracked_job_ids}"
+    )
+
+    # Poll every tracked seed chain's own final job to terminal. Real AWS
+    # Batch dependency resolution advances each chain natively (generation
+    # g+1 doesn't start until generation g SUCCEEDED) -- this loop only
+    # detects completion, exactly like JobScheduler.update_chain_campaigns
+    # does on a real deployment's own polling interval.
+    start_time = time.time()
+    result = ray_service.get_chain_campaign_result(tracked_job_ids)
+    while not result.terminal and time.time() - start_time < POLL_TIMEOUT_SECONDS:
+        await asyncio.sleep(POLL_INTERVAL_SECONDS)
+        result = ray_service.get_chain_campaign_result(tracked_job_ids)
+
+    assert result.terminal, (
+        f"Chain-dispatch campaign did not reach terminal state within {POLL_TIMEOUT_SECONDS}s "
+        f"({len(result.succeeded_job_ids)} succeeded, {len(result.failed_job_ids)} failed so far, "
+        f"{len(tracked_job_ids) - len(result.succeeded_job_ids) - len(result.failed_job_ids)} still pending)"
+    )
+    assert result.succeeded_job_ids, f"Every one of {len(tracked_job_ids)} seed chains failed: {result.failed_job_ids}"
+
+    # Fire (or reuse, if already fired by a prior interrupted run) the
+    # analysis DAG node for real -- exactly what JobScheduler.
+    # _advance_chain_campaign does once its own poll detects all-terminal.
+    existing_analyses = await database_service.list_analyses(simulation_id=simulation.database_id)
+    non_failed = [a for a in existing_analyses if a.status != JobStatus.FAILED]
+    if non_failed:
+        analysis_job_id: str | None = non_failed[-1].job_id_ext
+    else:
+        analysis_job_id = await ray_service.submit_campaign_analysis(
+            simulation=simulation,
+            database_service=database_service,
+            commit=simulator.git_commit_hash,
+            total_n_seeds=N_SEEDS,
+            n_generations=N_GENERATIONS,
+        )
+    assert analysis_job_id is not None, "Analysis DAG node submission failed -- see the recorded FAILED analyses row"
+
+    analysis_start = time.time()
+    analysis_status: JobStatusInfo | None = None
+    while time.time() - analysis_start < POLL_TIMEOUT_SECONDS:
+        analysis_status = await ray_service.get_job_status(JobId.ray(analysis_job_id))
+        if analysis_status is not None and analysis_status.status in (
+            JobStatus.COMPLETED,
+            JobStatus.FAILED,
+            JobStatus.CANCELLED,
+        ):
+            break
+        await asyncio.sleep(POLL_INTERVAL_SECONDS)
+
+    assert analysis_status is not None, "Analysis job status never resolved"
+    assert analysis_status.status == JobStatus.COMPLETED, (
+        f"Analysis job did not succeed: status={analysis_status.status}, error={analysis_status.error_message}"
+    )
+
+    # Verify real cd1_*/ptools_* artifacts actually landed in S3 -- the whole
+    # point of the canonical dispatch (see ecosystem/CLAUDE.md's own MVP
+    # definition: "ensure that all cd1_* and ptools_* analysis artifacts are
+    # generated as expected"), not just "the jobs exited zero."
+    file_service = FileServiceS3()
+    try:
+        analyses_prefix = f"{RayLayout.experiment_prefix(experiment_id)}/analyses"
+        listing = await file_service.get_listing(S3FilePath(s3_path=Path(analyses_prefix)))
+    finally:
+        await file_service.close()
+
+    artifact_keys = [item.Key for item in listing]
+    assert artifact_keys, f"No analysis artifacts found under s3://<bucket>/{analyses_prefix}/"
+    assert any("cd1_" in key or "ptools_" in key for key in artifact_keys), (
+        f"Landed artifacts don't include any cd1_*/ptools_* analysis output: {artifact_keys[:10]}"
+    )

--- a/tests/integration/test_aws_batch_e2e.py
+++ b/tests/integration/test_aws_batch_e2e.py
@@ -14,9 +14,20 @@ Prerequisites:
 - AWS credentials configured (AWS_PROFILE=stanford-sso)
 - Kubeconfig for EKS cluster
 - ECR repository exists (v2ecoli) with a built image for the resolved commit
-  (the LATEST commit on sms-ecoli's main branch, resolved live at test-run
-  time -- not hardcoded, see _get_or_create_sms_ecoli_simulator -- so make
-  sure that commit has actually been built and pushed before running this)
+  (the LATEST commit on AWS_BATCH_E2E_SMS_ECOLI_BRANCH, default "main",
+  resolved live at test-run time -- not hardcoded, see
+  _get_or_create_sms_ecoli_simulator -- so make sure that commit has actually
+  been built and pushed before running this)
+
+Pre-merge verification note (backlog items 33/34): the default branch is
+"main" for ongoing post-merge regression use, but sms-ecoli's own checkpoint/
+resume contract (PR #39 -- the 3 config keys _seed_generation_command always
+sends) isn't on main until that PR merges. Running this against main before
+then will reliably KeyError at container start (the exact bug PR #39's own
+2nd commit fixed) -- that's not a false alarm, it correctly reflects that
+main can't serve this dispatch shape yet. To actually pilot-verify PR #39
+pre-merge, override the branch:
+    AWS_BATCH_E2E_SMS_ECOLI_BRANCH=<PR #39's branch> AWS_BATCH_INTEGRATION=1 ...
 
 What this covers (backlog item 33 -- individual per-seed AWS Batch job
 chains): a genuine, small, real multiseed x multigeneration chain-dispatch
@@ -78,6 +89,9 @@ pytestmark = pytest.mark.skipif(
 # env for a bigger real run without editing this file.
 N_SEEDS = int(os.getenv("AWS_BATCH_E2E_N_SEEDS", "2"))
 N_GENERATIONS = int(os.getenv("AWS_BATCH_E2E_N_GENERATIONS", "2"))
+# "main" for ongoing post-merge regression use; override to pilot-verify an
+# unmerged sms-ecoli PR branch before it lands -- see module docstring.
+SMS_ECOLI_BRANCH = os.getenv("AWS_BATCH_E2E_SMS_ECOLI_BRANCH", "main")
 # A real ParCa + N*G real generation jobs (each its own container start, cache
 # stage, and the actual v2ecoli computation) can take a while end to end even
 # at this small scale; poll generously rather than risk a false failure from
@@ -91,16 +105,18 @@ TEST_EXPERIMENT_ID_PREFIX = "test-e2e-chain-dispatch"
 async def _get_or_create_sms_ecoli_simulator(
     database_service: DatabaseServiceSQL, ray_service: SimulationServiceRay
 ) -> SimulatorVersion:
-    """Resolve the LATEST real sms-ecoli commit live (not a hardcoded value
-    that would drift out of date -- mirrors DEFAULT_COMMIT's own "should be
-    latest" intent for the vEcoli-private default), reusing an existing DB row
-    for that exact commit if a prior run already created one."""
-    commit = await ray_service.get_latest_commit_hash(git_repo_url=RepoUrl.SMS_ECOLI_REPO_URL, git_branch="main")
+    """Resolve the LATEST real sms-ecoli commit live on SMS_ECOLI_BRANCH (not a
+    hardcoded value that would drift out of date -- mirrors DEFAULT_COMMIT's
+    own "should be latest" intent for the vEcoli-private default), reusing an
+    existing DB row for that exact commit if a prior run already created one."""
+    commit = await ray_service.get_latest_commit_hash(
+        git_repo_url=RepoUrl.SMS_ECOLI_REPO_URL, git_branch=SMS_ECOLI_BRANCH
+    )
     for simulator in await database_service.list_simulators():
         if simulator.git_commit_hash == commit and simulator.git_repo_url == RepoUrl.SMS_ECOLI_REPO_URL:
             return simulator
     return await database_service.insert_simulator(
-        git_commit_hash=commit, git_repo_url=RepoUrl.SMS_ECOLI_REPO_URL, git_branch="main"
+        git_commit_hash=commit, git_repo_url=RepoUrl.SMS_ECOLI_REPO_URL, git_branch=SMS_ECOLI_BRANCH
     )
 
 

--- a/tests/integration/test_k8s_workflow_mock.py
+++ b/tests/integration/test_k8s_workflow_mock.py
@@ -11,26 +11,32 @@ Prerequisites:
 """
 
 import json
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
+from sqlalchemy import func, select
 
+import viva_api.dependencies as deps
 from tests.fixtures.api_fixtures import SimulatorRepoInfo
 from viva_api.common.handlers import simulations as sim_handlers
 from viva_api.common.hpc.job_service import JobStatusInfo
 from viva_api.common.models import JobId, JobStatus
 from viva_api.common.simulator_defaults import RepoUrl
-from viva_api.config import ComputeBackend
+from viva_api.config import ComputeBackend, get_settings
 from viva_api.simulation.database_service import DatabaseServiceSQL
 from viva_api.simulation.models import (
     AnalysisOptions,
+    JobType,
     ParcaDatasetRequest,
     ParcaOptions,
     RepoDiscovery,
     SimulatorVersion,
 )
 from viva_api.simulation.simulation_service_k8s import SimulationServiceK8s
+from viva_api.simulation.simulation_service_ray import SimulationServiceRay
+from viva_api.simulation.tables_orm import ORMHpcRun
 
 CONFIG_TEMPLATE = json.dumps({
     "experiment_id": "EXPERIMENT_ID_PLACEHOLDER",
@@ -447,3 +453,127 @@ async def test_discovery_failure_does_not_block_workflow(
         )
     # Should succeed despite discovery failure
     assert simulation.database_id is not None
+
+
+@pytest.mark.asyncio
+async def test_ray_canonical_batch_baseline_routes_through_real_entrypoint_to_chain_dispatch(
+    database_service: DatabaseServiceSQL,
+) -> None:
+    """The REAL dispatch entrypoint (run_simulation_workflow ->
+    SimulationServiceRay.submit_ecoli_simulation_job), not
+    submit_chain_dispatch_job called directly, must reach chain-dispatch for a
+    canonical batch_baseline-shaped (composite unset, multiseed x
+    multigeneration) request against a real v2ecoli/sms-ecoli simulator.
+
+    This is the test that would have caught the real wiring gap found in
+    review: submit_chain_dispatch_job existed and was fully tested in
+    isolation from the moment it was built (tests/simulation/test_ray_backend.py),
+    but nothing on the real request path ever called it until backlog item
+    33's routing fix landed -- a real dispatch would have silently kept
+    exercising the old array-job path forever, since submit_ecoli_simulation_job
+    itself was never touched by the original rework.
+
+    The Ray backend is registered into the SAME per-repo service registry a
+    real deployment uses (viva_api.dependencies.global_simulation_services),
+    keyed by the real sms-ecoli repo URL -- exercising the actual repo-based
+    backend resolution (compute_backend_for_repo / get_simulation_service_for_repo)
+    a real request goes through, not just passing the service in as a raw
+    parameter. AWS Batch itself is mocked; everything else (config assembly,
+    backend routing, chain-dispatch submission, HpcRun bookkeeping) is real.
+    """
+    saved_registry = dict(deps.global_simulation_services)
+    saved_default = deps.get_simulation_service()
+    try:
+        ray_service = SimulationServiceRay()
+        ray_service.read_config_template = AsyncMock(return_value=CONFIG_TEMPLATE)  # type: ignore[method-assign]
+        deps.set_simulation_service_registry({ComputeBackend.RAY: ray_service})
+
+        simulator = await database_service.insert_simulator(
+            git_commit_hash="e2e1234",
+            git_repo_url=RepoUrl.SMS_ECOLI_REPO_URL,
+            git_branch="main",
+        )
+
+        # parca + 2 seeds x 3 generations = 7 real per-seed-generation submissions.
+        submit_ids = ["parca-1", "s0g0", "s0g1", "s0g2", "s1g0", "s1g1", "s1g2"]
+        mnp_base_props = {
+            "numNodes": 4,
+            "mainNode": 0,
+            "nodeRangeProperties": [{"targetNodes": "0:", "container": {"image": "x:tag", "vcpus": 16}}],
+        }
+        mock_batch = MagicMock()
+
+        def _describe(**kwargs: Any) -> dict[str, Any]:
+            if kwargs.get("jobDefinitionName") == get_settings().ray_mnp_job_definition:
+                return {"jobDefinitions": [{"revision": 1, "nodeProperties": mnp_base_props}]}
+            return {"jobDefinitions": []}
+
+        mock_batch.describe_job_definitions.side_effect = _describe
+        mock_batch.register_job_definition.side_effect = lambda **kw: {
+            "jobDefinitionName": kw["jobDefinitionName"],
+            "revision": 1,
+        }
+        mock_batch.submit_job.side_effect = [{"jobId": jid} for jid in submit_ids]
+
+        fake_file_service = AsyncMock()
+        fake_file_service.upload_file = AsyncMock()
+
+        with (
+            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
+            patch("viva_api.dependencies.get_file_service", return_value=fake_file_service),
+            patch("viva_api.simulation.simulation_service_ray.asyncio.sleep", new=AsyncMock()),
+        ):
+            simulation = await sim_handlers.run_simulation_workflow(
+                database_service=database_service,
+                simulation_service=ray_service,  # fallback only -- the registry above is what actually resolves
+                simulator_id=simulator.database_id,
+                experiment_id="e2e-canonical-batch-baseline",
+                simulation_config_filename="api_simulation_default.json",
+                num_generations=3,
+                num_seeds=2,
+            )
+
+        # Reached chain-dispatch, not the array path: N*G real per-seed
+        # generation jobs, never a single array-shaped submission.
+        assert mock_batch.submit_job.call_count == 7
+        calls = mock_batch.submit_job.call_args_list
+        for call in calls:
+            assert "arrayProperties" not in call.kwargs
+
+        _parca_call, s0g0, s0g1, s0g2, s1g0, s1g1, s1g2 = calls
+        assert s0g0.kwargs["dependsOn"] == [{"jobId": "parca-1", "type": "SEQUENTIAL"}]
+        assert s0g1.kwargs["dependsOn"] == [{"jobId": "s0g0", "type": "SEQUENTIAL"}]
+        assert s0g2.kwargs["dependsOn"] == [{"jobId": "s0g1", "type": "SEQUENTIAL"}]
+        assert s1g0.kwargs["dependsOn"] == [{"jobId": "parca-1", "type": "SEQUENTIAL"}]
+        assert s1g1.kwargs["dependsOn"] == [{"jobId": "s1g0", "type": "SEQUENTIAL"}]
+        assert s1g2.kwargs["dependsOn"] == [{"jobId": "s1g1", "type": "SEQUENTIAL"}]
+
+        # simulation.job_id reflects chain-dispatch's own return convention (the
+        # ParCa job -- there is no single "sim" job for a chain campaign).
+        assert simulation.job_id == "parca-1"
+
+        # Exactly ONE HpcRun row exists for this simulation: the real campaign
+        # row (chain_n_generations/chain_final_job_ids populated), never shadowed
+        # by a second, generic row from the handler's own insert_hpcrun call --
+        # the real, end-to-end proof that the idempotent-insert guard in
+        # viva_api.common.handlers.simulations actually works (not just an
+        # isolated unit-level claim about it). A raw row count, not just
+        # get_hpcrun_by_ref's most-recent-wins lookup, so a regression that
+        # reintroduces a shadowing duplicate can't hide behind "the newest row
+        # happens to look right."
+        async with database_service.async_sessionmaker() as session:
+            result = await session.execute(
+                select(func.count())
+                .select_from(ORMHpcRun)
+                .where(ORMHpcRun.jobref_simulation_id == simulation.database_id)
+            )
+            row_count = result.scalar_one()
+        assert row_count == 1
+
+        hpc_run = await database_service.get_hpcrun_by_ref(ref_id=simulation.database_id, job_type=JobType.SIMULATION)
+        assert hpc_run is not None
+        assert hpc_run.chain_n_generations == 3
+        assert hpc_run.chain_final_job_ids == ["s0g2", "s1g2"]
+    finally:
+        deps.set_simulation_service_registry(saved_registry)
+        deps.set_simulation_service(saved_default)

--- a/tests/simulation/test_db_reconcile.py
+++ b/tests/simulation/test_db_reconcile.py
@@ -4,21 +4,31 @@ These cover the state machine without touching a database. End-to-end
 stamp/upgrade behavior is exercised against a real Postgres by the migration
 Job in deployment; here we lock down the decision logic that drives it.
 
-The fingerprint vectors below are length-6, matching LEGACY_FINGERPRINTS:
+The fingerprint vectors below are length-7, matching LEGACY_FINGERPRINTS:
     [baseline, hpcrun-k8s, cancelled-enum, simulation.tags, analysis.n_tp,
-     compose_hpcrun.job_id_ext]
+     compose_hpcrun.job_id_ext, hpcrun.chain_final_job_ids]
 """
 
 from viva_api.simulation.db_reconcile import DbState, classify
 
-HEAD = "e5a7c9d10f21"
+HEAD = "f2b8e4a6c9d1"
 # Mirrors LEGACY_FINGERPRINTS ordering.
-REVS = ["fb7621a73e24", "0f991fad32ba", "a1c3e5f7b9d2", "c1a2b3d4e5f6", "d3f9a1c72b84", "e5a7c9d10f21"]
+REVS = [
+    "fb7621a73e24",
+    "0f991fad32ba",
+    "a1c3e5f7b9d2",
+    "c1a2b3d4e5f6",
+    "d3f9a1c72b84",
+    "e5a7c9d10f21",
+    "f2b8e4a6c9d1",
+]
 
 
 def test_managed_database_takes_upgrade_path() -> None:
     diag = classify(
-        alembic_revision="0f991fad32ba", fingerprint=[True, True, False, False, False, False], head_revision=HEAD
+        alembic_revision="0f991fad32ba",
+        fingerprint=[True, True, False, False, False, False, False],
+        head_revision=HEAD,
     )
     assert diag.state is DbState.MANAGED
     assert diag.current_revision == "0f991fad32ba"
@@ -28,69 +38,92 @@ def test_managed_database_takes_upgrade_path() -> None:
 
 
 def test_managed_takes_precedence_even_with_odd_fingerprint() -> None:
-    diag = classify(alembic_revision=HEAD, fingerprint=[False, False, False, False, False, False], head_revision=HEAD)
+    diag = classify(
+        alembic_revision=HEAD, fingerprint=[False, False, False, False, False, False, False], head_revision=HEAD
+    )
     assert diag.state is DbState.MANAGED
 
 
 def test_fresh_database_when_no_tables_and_no_version() -> None:
-    diag = classify(alembic_revision=None, fingerprint=[False, False, False, False, False, False], head_revision=HEAD)
+    diag = classify(
+        alembic_revision=None, fingerprint=[False, False, False, False, False, False, False], head_revision=HEAD
+    )
     assert diag.state is DbState.FRESH
     assert diag.matched_revision is None
     assert diag.can_upgrade is True
 
 
 def test_legacy_matches_baseline_only() -> None:
-    diag = classify(alembic_revision=None, fingerprint=[True, False, False, False, False, False], head_revision=HEAD)
+    diag = classify(
+        alembic_revision=None, fingerprint=[True, False, False, False, False, False, False], head_revision=HEAD
+    )
     assert diag.state is DbState.LEGACY
     assert diag.matched_revision == "fb7621a73e24"
 
 
 def test_legacy_matches_middle_revision() -> None:
-    diag = classify(alembic_revision=None, fingerprint=[True, True, False, False, False, False], head_revision=HEAD)
+    diag = classify(
+        alembic_revision=None, fingerprint=[True, True, False, False, False, False, False], head_revision=HEAD
+    )
     assert diag.state is DbState.LEGACY
     assert diag.matched_revision == "0f991fad32ba"
 
 
 def test_legacy_matches_cancelled_revision() -> None:
-    diag = classify(alembic_revision=None, fingerprint=[True, True, True, False, False, False], head_revision=HEAD)
+    diag = classify(
+        alembic_revision=None, fingerprint=[True, True, True, False, False, False, False], head_revision=HEAD
+    )
     assert diag.state is DbState.LEGACY
     assert diag.matched_revision == "a1c3e5f7b9d2"
 
 
 def test_legacy_matches_tags_revision() -> None:
-    diag = classify(alembic_revision=None, fingerprint=[True, True, True, True, False, False], head_revision=HEAD)
+    diag = classify(
+        alembic_revision=None, fingerprint=[True, True, True, True, False, False, False], head_revision=HEAD
+    )
     assert diag.state is DbState.LEGACY
     assert diag.matched_revision == "c1a2b3d4e5f6"
 
 
 def test_legacy_matches_analysis_revision() -> None:
-    diag = classify(alembic_revision=None, fingerprint=[True, True, True, True, True, False], head_revision=HEAD)
+    diag = classify(alembic_revision=None, fingerprint=[True, True, True, True, True, False, False], head_revision=HEAD)
     assert diag.state is DbState.LEGACY
     assert diag.matched_revision == "d3f9a1c72b84"
 
 
-def test_legacy_matches_head_when_all_markers_present() -> None:
-    diag = classify(alembic_revision=None, fingerprint=[True, True, True, True, True, True], head_revision=HEAD)
+def test_legacy_matches_compose_hpcrun_revision() -> None:
+    diag = classify(alembic_revision=None, fingerprint=[True, True, True, True, True, True, False], head_revision=HEAD)
     assert diag.state is DbState.LEGACY
     assert diag.matched_revision == "e5a7c9d10f21"
 
 
+def test_legacy_matches_head_when_all_markers_present() -> None:
+    diag = classify(alembic_revision=None, fingerprint=[True, True, True, True, True, True, True], head_revision=HEAD)
+    assert diag.state is DbState.LEGACY
+    assert diag.matched_revision == "f2b8e4a6c9d1"
+
+
 def test_inconsistent_when_later_marker_present_but_earlier_missing() -> None:
-    diag = classify(alembic_revision=None, fingerprint=[True, False, True, False, False, False], head_revision=HEAD)
+    diag = classify(
+        alembic_revision=None, fingerprint=[True, False, True, False, False, False, False], head_revision=HEAD
+    )
     assert diag.state is DbState.INCONSISTENT
     assert diag.matched_revision is None
     assert diag.can_upgrade is False
 
 
 def test_inconsistent_when_baseline_missing_but_later_present() -> None:
-    diag = classify(alembic_revision=None, fingerprint=[False, True, True, True, True, True], head_revision=HEAD)
+    diag = classify(alembic_revision=None, fingerprint=[False, True, True, True, True, True, True], head_revision=HEAD)
     assert diag.state is DbState.INCONSISTENT
     assert diag.can_upgrade is False
 
 
 def test_markers_are_reported_with_labels() -> None:
-    diag = classify(alembic_revision=None, fingerprint=[True, True, False, False, False, False], head_revision=HEAD)
+    diag = classify(
+        alembic_revision=None, fingerprint=[True, True, False, False, False, False, False], head_revision=HEAD
+    )
     labels = [label for label, _ in diag.markers]
     presence = [present for _, present in diag.markers]
-    assert presence == [True, True, False, False, False, False]
+    assert presence == [True, True, False, False, False, False, False]
     assert any("analysis.n_tp" in label for label in labels)
+    assert any("chain_final_job_ids" in label for label in labels)

--- a/tests/simulation/test_ray_backend.py
+++ b/tests/simulation/test_ray_backend.py
@@ -114,26 +114,6 @@ def _array_env(call: Any) -> dict[str, str]:
     return {e["name"]: e["value"] for e in call.kwargs["containerOverrides"]["environment"]}
 
 
-def _run_merge_prefix(cmd: str, array_index: int) -> dict[str, Any]:
-    """Actually execute a wave/array command's BASE_SEED/OVERRIDES merge prefix
-    (everything before ``&& cd {V2ECOLI_DIR}``) through real bash + python3,
-    with ``AWS_BATCH_JOB_ARRAY_INDEX`` set the way AWS Batch would inject it —
-    no mocking, the real mechanism the container runs. Returns the parsed
-    merged OVERRIDES JSON."""
-    merge_prefix = cmd.split(" && cd ", 1)[0]
-    bash = shutil.which("bash")
-    assert bash is not None, "bash not found on PATH"
-    result = subprocess.run(  # noqa: S603 -- test-only, fixed literal args
-        [bash, "-c", merge_prefix + ' && printf "%s" "$OVERRIDES"'],
-        env={**os.environ, "AWS_BATCH_JOB_ARRAY_INDEX": str(array_index)},
-        capture_output=True,
-        text=True,
-        timeout=10,
-    )
-    assert result.returncode == 0, result.stderr
-    return dict(json.loads(result.stdout))
-
-
 class TestJobIdRay:
     def test_ray_factory(self) -> None:
         job_id = JobId.ray("abc-123")
@@ -709,19 +689,34 @@ class TestSimulationServiceRayStatusCancel:
         assert mock_batch.terminate_job.call_args.kwargs["jobId"] == "sim-456"
 
 
-class TestGetWaveResult:
-    """get_wave_result polls ONE wave's array job: terminal-ness + which local
-    positions SUCCEEDED vs FAILED. The underlying AWS semantics (list_jobs(
-    arrayJobId=..., jobStatus=...) returning exactly the real children in that
-    status) were independently verified live against sim139's real job
-    history (backlog items 33-35 investigation) — these tests lock the LOCAL
-    decision logic built on top of that already-verified mechanism."""
+class TestGetChainCampaignResult:
+    """get_chain_campaign_result polls a chain-dispatch campaign's tracked
+    final-generation job ids (one per seed, real independent AWS Batch jobs)
+    for the analysis-fan-in condition — replacing the per-generation-array
+    design's own single-array-job TestGetWaveResult. No arrayProperties/
+    list_jobs involved at all: each tracked id is a genuinely independent
+    job, so this is a plain per-id describe_jobs status lookup, chunked at
+    AWS's real 100-id-per-call cap."""
 
-    def test_not_terminal_while_children_still_running(self) -> None:
+    def test_empty_job_ids_is_trivially_terminal_with_no_aws_call(self) -> None:
+        mock_batch = MagicMock()
+        service = SimulationServiceRay()
+        with (
+            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
+        ):
+            result = service.get_chain_campaign_result([])
+        assert result.terminal is True
+        assert result.succeeded_job_ids == []
+        assert result.failed_job_ids == []
+        mock_batch.describe_jobs.assert_not_called()
+
+    def test_not_terminal_while_any_tracked_job_still_running(self) -> None:
         mock_batch = MagicMock()
         mock_batch.describe_jobs.return_value = {
             "jobs": [
-                {"jobId": "wave-1", "arrayProperties": {"size": 4, "statusSummary": {"SUCCEEDED": 1, "RUNNING": 3}}}
+                {"jobId": "seed0-final", "status": "SUCCEEDED"},
+                {"jobId": "seed1-final", "status": "RUNNING"},
             ]
         }
         service = SimulationServiceRay()
@@ -729,124 +724,103 @@ class TestGetWaveResult:
             patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
             patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
         ):
-            result = service.get_wave_result("wave-1")
+            result = service.get_chain_campaign_result(["seed0-final", "seed1-final"])
         assert result.terminal is False
-        assert result.succeeded_local_indices == []
-        assert result.failed_local_indices == []
-        mock_batch.list_jobs.assert_not_called()
+        assert result.succeeded_job_ids == []
+        assert result.failed_job_ids == []
 
     def test_terminal_all_succeeded(self) -> None:
         mock_batch = MagicMock()
         mock_batch.describe_jobs.return_value = {
-            "jobs": [{"jobId": "wave-1", "arrayProperties": {"size": 3, "statusSummary": {"SUCCEEDED": 3}}}]
+            "jobs": [
+                {"jobId": "seed0-final", "status": "SUCCEEDED"},
+                {"jobId": "seed1-final", "status": "SUCCEEDED"},
+            ]
         }
-
-        def _list_jobs(**kwargs: Any) -> dict[str, Any]:
-            if kwargs["jobStatus"] == "SUCCEEDED":
-                return {"jobSummaryList": [{"arrayProperties": {"index": i}} for i in (0, 1, 2)]}
-            return {"jobSummaryList": []}
-
-        mock_batch.list_jobs.side_effect = _list_jobs
         service = SimulationServiceRay()
         with (
             patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
             patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
         ):
-            result = service.get_wave_result("wave-1")
+            result = service.get_chain_campaign_result(["seed0-final", "seed1-final"])
         assert result.terminal is True
-        assert result.succeeded_local_indices == [0, 1, 2]
-        assert result.failed_local_indices == []
+        assert result.succeeded_job_ids == ["seed0-final", "seed1-final"]
+        assert result.failed_job_ids == []
 
-    def test_terminal_partial_failure_is_still_terminal_not_an_error(self) -> None:
-        """FAILED-due-to-partial-loss counts as 'wave finished', matching the
-        closed design: Spot/OOM attrition is expected economics, not an
-        orchestrator error. Mirrors sim139's real 10-survivors-of-30 shape."""
-        survivors = (4, 5, 9, 10, 14, 15, 16, 18, 20, 27)
-        losses = [i for i in range(30) if i not in survivors]
-        mock_batch = MagicMock()
-        status_summary = {"SUCCEEDED": 10, "FAILED": 20}
-        mock_batch.describe_jobs.return_value = {
-            "jobs": [{"jobId": "wave-1", "arrayProperties": {"size": 30, "statusSummary": status_summary}}]
-        }
-
-        def _list_jobs(**kwargs: Any) -> dict[str, Any]:
-            indices = survivors if kwargs["jobStatus"] == "SUCCEEDED" else losses
-            return {"jobSummaryList": [{"arrayProperties": {"index": i}} for i in indices]}
-
-        mock_batch.list_jobs.side_effect = _list_jobs
-        service = SimulationServiceRay()
-        with (
-            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
-            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
-        ):
-            result = service.get_wave_result("wave-1")
-        assert result.terminal is True
-        assert result.succeeded_local_indices == list(survivors)
-        assert result.failed_local_indices == losses
-        # union covers every index with zero gaps/duplicates.
-        assert sorted(result.succeeded_local_indices + result.failed_local_indices) == list(range(30))
-
-    def test_paginates_list_jobs_via_next_token(self) -> None:
+    def test_terminal_with_mixed_success_and_failure(self) -> None:
+        """A permanently-failed seed's own final job showing FAILED is
+        expected economics, not an orchestrator error -- mirrors the
+        superseded design's own 'partial failure is still terminal'
+        philosophy, now evaluated per-seed instead of per-generation-wave."""
         mock_batch = MagicMock()
         mock_batch.describe_jobs.return_value = {
-            "jobs": [{"jobId": "wave-1", "arrayProperties": {"size": 2, "statusSummary": {"SUCCEEDED": 2}}}]
+            "jobs": [
+                {"jobId": "seed0-final", "status": "SUCCEEDED"},
+                {"jobId": "seed1-final", "status": "FAILED"},
+                {"jobId": "seed2-final", "status": "SUCCEEDED"},
+            ]
         }
-        pages: list[dict[str, Any]] = [
-            {"jobSummaryList": [{"arrayProperties": {"index": 0}}], "nextToken": "page2"},
-            {"jobSummaryList": [{"arrayProperties": {"index": 1}}]},
-        ]
-
-        def _list_jobs(**kwargs: Any) -> dict[str, Any]:
-            if kwargs["jobStatus"] == "FAILED":
-                return {"jobSummaryList": []}
-            return pages.pop(0)
-
-        mock_batch.list_jobs.side_effect = _list_jobs
         service = SimulationServiceRay()
         with (
             patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
             patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
         ):
-            result = service.get_wave_result("wave-1")
-        assert result.succeeded_local_indices == [0, 1]
-        list_calls = [c for c in mock_batch.list_jobs.call_args_list if c.kwargs["jobStatus"] == "SUCCEEDED"]
-        assert list_calls[1].kwargs["nextToken"] == "page2"
+            result = service.get_chain_campaign_result(["seed0-final", "seed1-final", "seed2-final"])
+        assert result.terminal is True
+        assert result.succeeded_job_ids == ["seed0-final", "seed2-final"]
+        assert result.failed_job_ids == ["seed1-final"]
 
-    def test_zero_match_status_returns_empty_list_not_error(self) -> None:
-        """A real 0/30-all-failed job history: jobStatus='SUCCEEDED' returns a
-        clean empty list, not an error -- confirmed live against a second real
-        job this session (items 33-35 investigation)."""
+    def test_all_failed_is_still_terminal(self) -> None:
         mock_batch = MagicMock()
         mock_batch.describe_jobs.return_value = {
-            "jobs": [{"jobId": "wave-1", "arrayProperties": {"size": 5, "statusSummary": {"FAILED": 5}}}]
+            "jobs": [{"jobId": f"seed{i}-final", "status": "FAILED"} for i in range(3)]
         }
-
-        def _list_jobs(**kwargs: Any) -> dict[str, Any]:
-            if kwargs["jobStatus"] == "SUCCEEDED":
-                return {"jobSummaryList": []}
-            return {"jobSummaryList": [{"arrayProperties": {"index": i}} for i in range(5)]}
-
-        mock_batch.list_jobs.side_effect = _list_jobs
         service = SimulationServiceRay()
         with (
             patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
             patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
         ):
-            result = service.get_wave_result("wave-1")
+            result = service.get_chain_campaign_result([f"seed{i}-final" for i in range(3)])
         assert result.terminal is True
-        assert result.succeeded_local_indices == []
-        assert result.failed_local_indices == [0, 1, 2, 3, 4]
+        assert result.succeeded_job_ids == []
+        assert result.failed_job_ids == [f"seed{i}-final" for i in range(3)]
 
-    def test_raises_if_job_not_found(self) -> None:
+    def test_job_id_missing_from_response_is_treated_as_not_terminal(self) -> None:
+        """Brief eventual-consistency lag right after submission -- a tracked
+        id describe_jobs doesn't (yet) return anything for must NOT be
+        mistaken for terminal; the poller just checks again next interval."""
         mock_batch = MagicMock()
-        mock_batch.describe_jobs.return_value = {"jobs": []}
+        mock_batch.describe_jobs.return_value = {"jobs": [{"jobId": "seed0-final", "status": "SUCCEEDED"}]}
         service = SimulationServiceRay()
         with (
             patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
             patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
-            pytest.raises(RuntimeError, match="not found"),
         ):
-            service.get_wave_result("missing")
+            result = service.get_chain_campaign_result(["seed0-final", "seed1-final-not-visible-yet"])
+        assert result.terminal is False
+
+    def test_chunks_describe_jobs_calls_at_the_real_100_id_cap(self) -> None:
+        """AWS Batch DescribeJobs accepts at most 100 job ids per call
+        (verified against the real API model this session) -- a 1000-seed
+        campaign's tracked ids must be split into 10 calls of <=100, never
+        one call of 1000."""
+        job_ids = [f"seed{i}-final" for i in range(1000)]
+
+        def _describe_jobs(**kwargs: Any) -> dict[str, Any]:
+            assert len(kwargs["jobs"]) <= 100
+            return {"jobs": [{"jobId": jid, "status": "SUCCEEDED"} for jid in kwargs["jobs"]]}
+
+        mock_batch = MagicMock()
+        mock_batch.describe_jobs.side_effect = _describe_jobs
+        service = SimulationServiceRay()
+        with (
+            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
+        ):
+            result = service.get_chain_campaign_result(job_ids)
+        assert result.terminal is True
+        assert len(result.succeeded_job_ids) == 1000
+        assert mock_batch.describe_jobs.call_count == 10
 
 
 def _v2ecoli_simulator() -> Any:
@@ -1054,127 +1028,116 @@ class TestArraySimCommand:
                 os.remove(canary)
 
 
-class TestWaveSimCommand:
-    """_wave_sim_command builds one wave's Array child command: ONE seed's ONE
-    generation, remapped through a sparse seed_indices LOOKUP TABLE (not an
-    offset like _array_sim_command's BASE_SEED) -- after a prior generation's
-    attrition, a later wave's array positions are still dense (0..len-1) but
-    the real seeds they represent are not."""
+class TestSeedGenerationCommand:
+    """_seed_generation_command builds ONE seed's ONE generation's command —
+    replacing the per-generation-array design's own _wave_sim_command. Unlike
+    that design, the WHOLE --overrides payload (seed, generation, carry-state
+    paths) is fully static and known Python-side at SUBMISSION time -- no
+    AWS_BATCH_JOB_ARRAY_INDEX, no lookup table, no container-start shell/
+    python3 merge step at all, so (mirroring TestAnalysisCommand's own
+    established pattern for another fully-static command) these tests parse
+    the embedded JSON via shlex.split rather than executing anything."""
 
-    def test_shape_generation_zero(self) -> None:
+    @staticmethod
+    def _overrides(cmd: str) -> dict[str, Any]:
+        tokens = shlex.split(cmd)
+        return dict(json.loads(tokens[tokens.index("--overrides") + 1]))
+
+    def test_shape_generation_zero_has_no_carry_state(self) -> None:
         service = SimulationServiceRay()
         with (
             patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
             patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
         ):
-            cmd = service._wave_sim_command(
+            cmd = service._seed_generation_command(
+                seed=7,
                 generation_index=0,
-                experiment_id="sim47-wave-experiment",
-                runner_s3_uri="s3://mybucket/vecoli-output/sim47-wave-experiment/run_pbg.py",
-                seed_indices=[0, 1, 2, 3],
+                experiment_id="sim47-chain-experiment",
+                runner_s3_uri="s3://mybucket/vecoli-output/sim47-chain-experiment/run_pbg.py",
             )
-        assert "aws s3 cp s3://mybucket/vecoli-output/sim47-wave-experiment/run_pbg.py /tmp/run_pbg.py" in cmd
+        assert "aws s3 cp s3://mybucket/vecoli-output/sim47-chain-experiment/run_pbg.py /tmp/run_pbg.py" in cmd
         assert "--composite-id v2ecoli.composites.batch_baseline.batch_baseline " in cmd
         assert "PBG_CORE_BUILDER=v2ecoli.core:build_core" in cmd
         assert "-n 1" in cmd
-        assert '"initial_generation_index": 0' in cmd
-        assert '"n_generations": 1' in cmd  # one wave = one generation per invocation
-        assert "AWS_BATCH_JOB_ARRAY_INDEX" in cmd
-        # A lookup table, not offset arithmetic -- _array_sim_command's BASE_SEED
-        # pattern can't express a sparse survivor remap.
-        assert "seeds=json.loads(sys.argv[2])" in cmd
-        assert "seed=seeds[int(sys.argv[3])]" in cmd
+        # No array-index resolution left anywhere -- the whole point of the rework.
+        assert "AWS_BATCH_JOB_ARRAY_INDEX" not in cmd
+        assert "python3 -c" not in cmd
 
-    def test_merge_resolves_seed_and_gen0_has_no_carry_state(self) -> None:
-        """Actually run the merge prefix through bash + python3 (no mocking) --
-        the same real-execution proof _array_sim_command's own test uses, so
-        this checks the ACTUAL mechanism the container runs, not a
-        re-derivation of it."""
+        overrides = self._overrides(cmd)
+        assert overrides["base_seed"] == 7
+        assert overrides["initial_generation_index"] == 0
+        assert overrides["initial_carry_state_path"] == ""
+        assert overrides["daughter_state_out_path"] == (
+            "s3://mybucket/vecoli-output/sim47-chain-experiment/daughter-state/seed7/gen0.pkl"
+        )
+        assert overrides["n_seeds"] == 1
+        assert overrides["n_generations"] == 1
+        assert overrides["analyses"] == "none"
+
+    def test_later_generation_carries_the_prior_generations_state(self) -> None:
         service = SimulationServiceRay()
         with (
             patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
             patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
         ):
-            cmd = service._wave_sim_command(
-                generation_index=0,
-                experiment_id="exp-a",
-                runner_s3_uri="s3://mybucket/vecoli-output/exp-a/run_pbg.py",
-                seed_indices=[7, 8],
-            )
-        merged = _run_merge_prefix(cmd, array_index=0)
-        assert merged["base_seed"] == 7  # seed_indices[0]
-        assert merged["initial_carry_state_path"] == ""
-        assert merged["daughter_state_out_path"] == "s3://mybucket/vecoli-output/exp-a/wave-state/seed7/gen0.pkl"
-        assert merged["initial_generation_index"] == 0
-
-    def test_merge_resolves_sparse_survivor_position_and_prior_gen_carry_state(self) -> None:
-        """After attrition, position 2 of survivors [4, 5, 9, 10] is seed 9,
-        NOT array index 2 -- the whole point of the lookup table."""
-        service = SimulationServiceRay()
-        with (
-            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
-            patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
-        ):
-            cmd = service._wave_sim_command(
-                generation_index=2,
+            cmd = service._seed_generation_command(
+                seed=42,
+                generation_index=3,
                 experiment_id="exp-b",
                 runner_s3_uri="s3://mybucket/vecoli-output/exp-b/run_pbg.py",
-                seed_indices=[4, 5, 9, 10],
             )
-        merged = _run_merge_prefix(cmd, array_index=2)
-        assert merged["base_seed"] == 9  # seed_indices[2], NOT array index 2
-        assert merged["initial_carry_state_path"] == "s3://mybucket/vecoli-output/exp-b/wave-state/seed9/gen1.pkl"
-        assert merged["daughter_state_out_path"] == "s3://mybucket/vecoli-output/exp-b/wave-state/seed9/gen2.pkl"
-        assert merged["initial_generation_index"] == 2
+        overrides = self._overrides(cmd)
+        assert overrides["base_seed"] == 42
+        assert overrides["initial_generation_index"] == 3
+        assert overrides["initial_carry_state_path"] == (
+            "s3://mybucket/vecoli-output/exp-b/daughter-state/seed42/gen2.pkl"
+        )
+        assert overrides["daughter_state_out_path"] == (
+            "s3://mybucket/vecoli-output/exp-b/daughter-state/seed42/gen3.pkl"
+        )
 
     def test_hostile_experiment_id_stays_data_not_shell_syntax(self) -> None:
-        """experiment_id is a caller-supplied, unconstrained string (no pattern
-        validation at the model/API boundary) -- proves the shlex-quoted blob
-        keeps arbitrary content as DATA, mirroring _array_sim_command's own
-        injection-canary proof."""
+        """experiment_id is a caller-supplied, unconstrained string (no
+        pattern validation at the model/API boundary) -- proves the
+        shlex-quoted blob keeps arbitrary content as DATA, mirroring
+        TestAnalysisCommand's own injection-canary proof for another
+        fully-static command."""
         service = SimulationServiceRay()
-        hostile = "exp'; touch /tmp/wave-sim-command-injection-canary; echo '$(echo pwned)"
+        hostile = "exp'; touch /tmp/seed-gen-command-injection-canary; echo '$(echo pwned)"
         with (
             patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
             patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
         ):
-            cmd = service._wave_sim_command(
+            cmd = service._seed_generation_command(
+                seed=3,
                 generation_index=1,
                 experiment_id=hostile,
                 runner_s3_uri="s3://mybucket/vecoli-output/exp/run_pbg.py",
-                seed_indices=[3, 4],
             )
-        canary = "/tmp/wave-sim-command-injection-canary"  # noqa: S108
-        if os.path.exists(canary):
-            os.remove(canary)
-        try:
-            merged = _run_merge_prefix(cmd, array_index=1)
-            assert not os.path.exists(canary), "hostile experiment_id executed as shell syntax, not data"
-            assert merged["experiment_id"] == hostile
-            assert hostile in merged["daughter_state_out_path"]
-        finally:
-            if os.path.exists(canary):
-                os.remove(canary)
+        assert "touch /tmp/seed-gen-command-injection-canary" not in shlex.split(cmd)
+        overrides = self._overrides(cmd)
+        assert overrides["experiment_id"] == hostile
+        assert hostile in overrides["daughter_state_out_path"]
 
-    def test_stays_under_the_batch_command_size_cap_at_1000_seeds(self) -> None:
+    def test_stays_comfortably_under_the_batch_command_size_cap(self) -> None:
         """AWS Batch caps a container override command at 8192 bytes (see
-        _stage_runner's docstring). The design deliberately embeds the
-        surviving-seed list as bare ints — not precomputed per-seed URIs,
-        which would blow this cap at 1000 seeds — precisely to fit under it.
-        Locks that sizing claim against a real measurement, not an assumption."""
+        _stage_runner's docstring). Even simpler than the design this
+        superseded (no seed_indices array embedded at all -- a standalone job
+        only ever needs its OWN seed), so this stays well under the cap
+        regardless of experiment_id length."""
         service = SimulationServiceRay()
         long_experiment_id = "sim1000-cd1-baseline-1000x10-" + "x" * 20
         with (
             patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
             patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
         ):
-            cmd = service._wave_sim_command(
+            cmd = service._seed_generation_command(
+                seed=999,
                 generation_index=9,
                 experiment_id=long_experiment_id,
                 runner_s3_uri=f"s3://mybucket/vecoli-output/{long_experiment_id}/run_pbg.py",
-                seed_indices=list(range(1000)),
             )
-        assert len(cmd) < 8192, f"wave command is {len(cmd)} bytes, over the real AWS Batch cap"
+        assert len(cmd) < 8192, f"seed-generation command is {len(cmd)} bytes, over the real AWS Batch cap"
 
 
 class TestIsUpstreamVecoli:
@@ -1323,9 +1286,62 @@ class TestEnsureArrayJobDef:
 
 
 @pytest.mark.asyncio
-class TestWaveDispatchSubmission:
-    """submit_wave_dispatch_job kicks off a wave campaign: ParCa + generation
-    0's Array wave over every requested seed (backlog item 33)."""
+class TestSubmitJobPacer:
+    """_SubmitJobPacer proactively caps AWS Batch SubmitJob calls below the
+    account-wide 50 TPS ceiling, computed from REAL elapsed wall-clock time
+    (not a fixed guess) -- backing the chain-dispatch campaign's upfront N*G
+    submission loop (backlog item 33 rework)."""
+
+    @pytest.mark.asyncio
+    async def test_first_call_never_sleeps(self) -> None:
+        from viva_api.simulation.simulation_service_ray import _SubmitJobPacer
+
+        pacer = _SubmitJobPacer(max_per_second=40.0)
+        with patch("viva_api.simulation.simulation_service_ray.asyncio.sleep", new=AsyncMock()) as mock_sleep:
+            await pacer.wait()
+        mock_sleep.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_back_to_back_calls_sleep_for_the_real_deficit(self) -> None:
+        """Drives a FAKE monotonic clock so the computed sleep duration is
+        exactly checkable, rather than asserting on real (flaky) wall-clock
+        timing."""
+        from viva_api.simulation.simulation_service_ray import _SubmitJobPacer
+
+        pacer = _SubmitJobPacer(max_per_second=10.0)  # min_interval = 0.1s
+        clock = iter([100.0, 100.0, 100.02])
+        with (
+            patch("viva_api.simulation.simulation_service_ray.time.monotonic", side_effect=lambda: next(clock)),
+            patch("viva_api.simulation.simulation_service_ray.asyncio.sleep", new=AsyncMock()) as mock_sleep,
+        ):
+            await pacer.wait()  # consumes 100.0 -- first call, no prior, no sleep
+            await pacer.wait()  # now=100.0 again -> deficit = 0.1 -> sleeps, re-reads -> 100.02
+        mock_sleep.assert_awaited_once()
+        (slept_for,) = mock_sleep.call_args.args
+        assert slept_for == pytest.approx(0.1)
+
+    @pytest.mark.asyncio
+    async def test_no_sleep_once_enough_real_time_has_elapsed(self) -> None:
+        from viva_api.simulation.simulation_service_ray import _SubmitJobPacer
+
+        pacer = _SubmitJobPacer(max_per_second=10.0)  # min_interval = 0.1s
+        clock = iter([100.0, 100.5])  # half a second later -- comfortably past the 0.1s floor
+        with (
+            patch("viva_api.simulation.simulation_service_ray.time.monotonic", side_effect=lambda: next(clock)),
+            patch("viva_api.simulation.simulation_service_ray.asyncio.sleep", new=AsyncMock()) as mock_sleep,
+        ):
+            await pacer.wait()
+            await pacer.wait()
+        mock_sleep.assert_not_called()
+
+
+@pytest.mark.asyncio
+class TestChainDispatchSubmission:
+    """submit_chain_dispatch_job kicks off a chain-dispatch campaign: ParCa +
+    every seed's full G-generation dependsOn chain, submitted upfront
+    (backlog item 33 rework — individual per-seed job chains, replacing the
+    per-generation-array "wave" design's own TestWaveDispatchSubmission /
+    TestSubmitNextWave)."""
 
     async def test_rejects_single_generation(
         self,
@@ -1341,37 +1357,52 @@ class TestWaveDispatchSubmission:
             patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
             pytest.raises(ValueError, match="requires generations > 1"),
         ):
-            await service.submit_wave_dispatch_job(ecoli_simulation=simulation, database_service=database_service)
+            await service.submit_chain_dispatch_job(ecoli_simulation=simulation, database_service=database_service)
 
-    async def test_rejects_single_seed(
+    async def test_single_seed_multi_generation_is_now_allowed(
         self,
         experiment_request: "SimulationRequest",
         database_service: "DatabaseServiceSQL",
     ) -> None:
+        """Unlike the superseded per-generation-array design, n_seeds >= 2 is
+        NOT required -- that floor was AWS Batch's own array-size minimum
+        (arrayProperties.size must be 2-10000, verified against the real API
+        model this session), which doesn't apply here: each seed's chain is
+        independent standalone MNP jobs, no array involved at all."""
         setattr(experiment_request.config, "n_init_sims", 1)  # noqa: B010
-        experiment_request.config.generations = 3
+        experiment_request.config.generations = 2
         simulation = await database_service.insert_simulation(sim_request=experiment_request)
+        mock_batch = _fake_batch(["parca-1", "s0g0", "s0g1"])
+        fake_file_service = AsyncMock()
+        fake_file_service.upload_file = AsyncMock()
         service = SimulationServiceRay()
         with (
             patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
             patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
-            pytest.raises(ValueError, match="requires n_seeds > 1"),
+            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
+            patch("viva_api.dependencies.get_file_service", return_value=fake_file_service),
+            patch("viva_api.simulation.simulation_service_ray.asyncio.sleep", new=AsyncMock()),
         ):
-            await service.submit_wave_dispatch_job(ecoli_simulation=simulation, database_service=database_service)
+            job_id = await service.submit_chain_dispatch_job(
+                ecoli_simulation=simulation, database_service=database_service
+            )
+        assert job_id == JobId.ray("parca-1")
+        assert mock_batch.submit_job.call_count == 3  # parca + 2 generations, one seed
 
-    async def test_submits_parca_then_wave0_over_all_seeds_not_final(
+    async def test_submits_parca_then_every_seeds_full_chain(
         self,
         experiment_request: "SimulationRequest",
         database_service: "DatabaseServiceSQL",
     ) -> None:
-        """3-generation campaign: generation 0 is NOT the final wave, so no
-        analysis node rides along yet -- that only happens once JobScheduler
-        drives the campaign to its last generation (see TestSubmitNextWave)."""
-        setattr(experiment_request.config, "n_init_sims", 4)  # noqa: B010
+        """2 seeds x 3 generations: locks the exact dependency structure for a
+        representative seed (right job count, right dependsOn linkage, right
+        deterministic daughter-state S3 paths) and the campaign HpcRun row's
+        shape."""
+        setattr(experiment_request.config, "n_init_sims", 2)  # noqa: B010
         experiment_request.config.generations = 3
         simulation = await database_service.insert_simulation(sim_request=experiment_request)
-
-        mock_batch = _fake_batch(["parca-123", "wave0-456"])
+        submit_ids = ["parca-1", "s0g0", "s0g1", "s0g2", "s1g0", "s1g1", "s1g2"]
+        mock_batch = _fake_batch(submit_ids)
         fake_file_service = AsyncMock()
         fake_file_service.upload_file = AsyncMock()
 
@@ -1381,202 +1412,285 @@ class TestWaveDispatchSubmission:
             patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
             patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
             patch("viva_api.dependencies.get_file_service", return_value=fake_file_service),
+            patch("viva_api.simulation.simulation_service_ray.asyncio.sleep", new=AsyncMock()),
         ):
-            job_id = await service.submit_wave_dispatch_job(
+            job_id = await service.submit_chain_dispatch_job(
                 ecoli_simulation=simulation, database_service=database_service
             )
 
-        assert job_id == JobId.ray("wave0-456")
-        assert mock_batch.submit_job.call_count == 2  # parca + wave0 only (not final -> no analysis)
-        parca_call, wave0_call = mock_batch.submit_job.call_args_list
+        assert job_id == JobId.ray("parca-1")
+        assert mock_batch.submit_job.call_count == 7  # parca + 2 seeds x 3 generations
+        parca_call, s0g0, s0g1, s0g2, s1g0, s1g1, s1g2 = mock_batch.submit_job.call_args_list
 
         assert "dependsOn" not in parca_call.kwargs
+        assert "retryStrategy" not in parca_call.kwargs  # ParCa's own behavior is unchanged
 
-        assert "nodeOverrides" not in wave0_call.kwargs
-        assert wave0_call.kwargs["arrayProperties"] == {"size": 4}
-        assert wave0_call.kwargs["dependsOn"] == [{"jobId": "parca-123"}]
-        assert wave0_call.kwargs["tags"]["Wave"] == "0"
-        assert wave0_call.kwargs["tags"]["Phase"] == "sim"
+        # Representative seed (seed 0)'s full chain: right linkage, right retry,
+        # right shape (MNP -- nodeOverrides, never arrayProperties at all).
+        assert s0g0.kwargs["dependsOn"] == [{"jobId": "parca-1", "type": "SEQUENTIAL"}]
+        assert s0g1.kwargs["dependsOn"] == [{"jobId": "s0g0", "type": "SEQUENTIAL"}]
+        assert s0g2.kwargs["dependsOn"] == [{"jobId": "s0g1", "type": "SEQUENTIAL"}]
+        for call in (s0g0, s0g1, s0g2, s1g0, s1g1, s1g2):
+            assert call.kwargs["retryStrategy"] == {"attempts": 2}
+            assert "nodeOverrides" in call.kwargs
+            assert "arrayProperties" not in call.kwargs
 
-        cmd = _array_env(wave0_call)["ARRAY_JOB_CMD"]
-        assert '"initial_generation_index": 0' in cmd
-        assert "[0, 1, 2, 3]" in cmd
+        # Seed 1's chain is entirely independent of seed 0's, both rooted at ParCa.
+        assert s1g0.kwargs["dependsOn"] == [{"jobId": "parca-1", "type": "SEQUENTIAL"}]
+        assert s1g1.kwargs["dependsOn"] == [{"jobId": "s1g0", "type": "SEQUENTIAL"}]
+        assert s1g2.kwargs["dependsOn"] == [{"jobId": "s1g1", "type": "SEQUENTIAL"}]
 
-        # The underlying Postgres container is module-scoped (rows from other
-        # tests in this file persist alongside it), so filter to THIS test's
-        # own simulation rather than assume global uniqueness.
-        active_waves = [
-            w for w in await database_service.list_active_wave_hpcruns() if w.ref_id == simulation.database_id
+        # Deterministic daughter-state S3 paths, embedded directly -- no
+        # AWS_BATCH_JOB_ARRAY_INDEX / container-start resolution at all.
+        experiment_id = simulation.config.experiment_id
+        env = _env_of(s0g1)
+        tokens = shlex.split(env["RAY_JOB_CMD"])
+        overrides = json.loads(tokens[tokens.index("--overrides") + 1])
+        assert overrides["base_seed"] == 0
+        assert overrides["initial_generation_index"] == 1
+        assert overrides["initial_carry_state_path"] == (
+            f"s3://mybucket/vecoli-output/{experiment_id}/daughter-state/seed0/gen0.pkl"
+        )
+        assert overrides["daughter_state_out_path"] == (
+            f"s3://mybucket/vecoli-output/{experiment_id}/daughter-state/seed0/gen1.pkl"
+        )
+        assert "AWS_BATCH_JOB_ARRAY_INDEX" not in env["RAY_JOB_CMD"]
+
+        # Tags carry seed/generation for cost-allocation granularity.
+        assert s0g1.kwargs["tags"]["Seed"] == "0"
+        assert s0g1.kwargs["tags"]["Generation"] == "1"
+        assert s0g1.kwargs["tags"]["Phase"] == "sim"
+
+        # ONE campaign-tracking HpcRun row, holding each seed's OWN final job id.
+        active_campaigns = [
+            c for c in await database_service.list_active_chain_campaigns() if c.ref_id == simulation.database_id
         ]
-        assert len(active_waves) == 1
-        assert active_waves[0].wave_index == 0
-        assert active_waves[0].wave_seed_indices == [0, 1, 2, 3]
-        assert active_waves[0].job_id == JobId.ray("wave0-456")
+        assert len(active_campaigns) == 1
+        campaign = active_campaigns[0]
+        assert campaign.chain_n_generations == 3
+        assert campaign.chain_final_job_ids == ["s0g2", "s1g2"]
+        assert campaign.job_id == JobId.ray("parca-1")
 
-        # Not the final wave (generation 0 of 3): no analysis submitted yet.
-        assert await database_service.list_analyses(simulation_id=simulation.database_id) == []
+    async def test_paces_every_submission_through_the_rate_limiter(
+        self,
+        experiment_request: "SimulationRequest",
+        database_service: "DatabaseServiceSQL",
+    ) -> None:
+        setattr(experiment_request.config, "n_init_sims", 2)  # noqa: B010
+        experiment_request.config.generations = 2
+        simulation = await database_service.insert_simulation(sim_request=experiment_request)
+        mock_batch = _fake_batch(["parca-1", "s0g0", "s0g1", "s1g0", "s1g1"])
+        fake_file_service = AsyncMock()
+        fake_file_service.upload_file = AsyncMock()
+
+        service = SimulationServiceRay()
+        with (
+            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
+            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
+            patch("viva_api.dependencies.get_file_service", return_value=fake_file_service),
+            patch(
+                "viva_api.simulation.simulation_service_ray._SubmitJobPacer.wait", new=AsyncMock()
+            ) as mock_pacer_wait,
+        ):
+            await service.submit_chain_dispatch_job(ecoli_simulation=simulation, database_service=database_service)
+        # Every one of the 5 real SubmitJob calls (parca + 2 seeds x 2
+        # generations) is paced -- not just the bulk per-seed chain jobs.
+        assert mock_pacer_wait.await_count == 5
+
+    async def test_seed_submission_failure_truncates_only_that_seeds_chain(
+        self,
+        experiment_request: "SimulationRequest",
+        database_service: "DatabaseServiceSQL",
+    ) -> None:
+        """seed 0's generation 1 submission fails (even after retry-on-throttle
+        is exhausted): seed 0's chain is truncated right there (its
+        ALREADY-submitted generation 0 job keeps running normally on Batch --
+        nothing here cancels it), generation 2 is NEVER attempted for seed 0,
+        and seed 0's TRACKED final job is generation 0's real id (not a
+        generation-2 id that never existed). Seed 1 is entirely unaffected."""
+        setattr(experiment_request.config, "n_init_sims", 2)  # noqa: B010
+        experiment_request.config.generations = 3
+        simulation = await database_service.insert_simulation(sim_request=experiment_request)
+
+        base_node_props = {
+            "numNodes": 4,
+            "mainNode": 0,
+            "nodeRangeProperties": [
+                {"targetNodes": "0:", "container": {"image": "111.dkr.ecr.x/vecoli:ray", "vcpus": 16}}
+            ],
+        }
+        mock_batch = MagicMock()
+
+        def _describe(**kwargs: Any) -> dict[str, Any]:
+            if kwargs.get("jobDefinitionName") == "smscdk-ray-mnp":
+                return {"jobDefinitions": [{"revision": 7, "nodeProperties": base_node_props}]}
+            return {"jobDefinitions": []}
+
+        mock_batch.describe_job_definitions.side_effect = _describe
+        mock_batch.register_job_definition.side_effect = lambda **kw: {
+            "jobDefinitionName": kw["jobDefinitionName"],
+            "revision": 1,
+        }
+        remaining_ids = iter(["parca-1", "s0g0", "s1g0", "s1g1", "s1g2"])
+
+        def _submit_job(**kwargs: Any) -> dict[str, Any]:
+            if kwargs["jobName"].startswith("chain-seed0-gen1-"):
+                raise RuntimeError("submit_job: rate exceeded (simulated, retries exhausted)")
+            return {"jobId": next(remaining_ids)}
+
+        mock_batch.submit_job.side_effect = _submit_job
+        fake_file_service = AsyncMock()
+        fake_file_service.upload_file = AsyncMock()
+
+        service = SimulationServiceRay()
+        with (
+            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
+            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
+            patch("viva_api.dependencies.get_file_service", return_value=fake_file_service),
+            patch("viva_api.simulation.simulation_service_ray.asyncio.sleep", new=AsyncMock()),
+        ):
+            await service.submit_chain_dispatch_job(ecoli_simulation=simulation, database_service=database_service)
+
+        submitted_names = [c.kwargs["jobName"] for c in mock_batch.submit_job.call_args_list]
+        assert any(n.startswith("chain-seed0-gen0-") for n in submitted_names)
+        assert any(n.startswith("chain-seed0-gen1-") for n in submitted_names)  # attempted (and failed)
+        assert not any(n.startswith("chain-seed0-gen2-") for n in submitted_names)  # never attempted
+        for gen in range(3):
+            assert any(n.startswith(f"chain-seed1-gen{gen}-") for n in submitted_names)
+
+        active_campaigns = [
+            c for c in await database_service.list_active_chain_campaigns() if c.ref_id == simulation.database_id
+        ]
+        assert len(active_campaigns) == 1
+        assert active_campaigns[0].chain_final_job_ids == ["s0g0", "s1g2"]
+
+    async def test_generation_zero_failure_excludes_that_seed_entirely(
+        self,
+        experiment_request: "SimulationRequest",
+        database_service: "DatabaseServiceSQL",
+    ) -> None:
+        """If even generation 0 fails to submit for a seed, that seed
+        contributes NOTHING to chain_final_job_ids -- there is no job of its
+        own at all for the analysis-fan-in poller to track."""
+        setattr(experiment_request.config, "n_init_sims", 2)  # noqa: B010
+        experiment_request.config.generations = 2
+        simulation = await database_service.insert_simulation(sim_request=experiment_request)
+
+        base_node_props = {
+            "numNodes": 4,
+            "mainNode": 0,
+            "nodeRangeProperties": [
+                {"targetNodes": "0:", "container": {"image": "111.dkr.ecr.x/vecoli:ray", "vcpus": 16}}
+            ],
+        }
+        mock_batch = MagicMock()
+
+        def _describe(**kwargs: Any) -> dict[str, Any]:
+            if kwargs.get("jobDefinitionName") == "smscdk-ray-mnp":
+                return {"jobDefinitions": [{"revision": 7, "nodeProperties": base_node_props}]}
+            return {"jobDefinitions": []}
+
+        mock_batch.describe_job_definitions.side_effect = _describe
+        mock_batch.register_job_definition.side_effect = lambda **kw: {
+            "jobDefinitionName": kw["jobDefinitionName"],
+            "revision": 1,
+        }
+        remaining_ids = iter(["parca-1", "s1g0", "s1g1"])
+
+        def _submit_job(**kwargs: Any) -> dict[str, Any]:
+            if kwargs["jobName"].startswith("chain-seed0-gen0-"):
+                raise RuntimeError("submit_job: rate exceeded (simulated, retries exhausted)")
+            return {"jobId": next(remaining_ids)}
+
+        mock_batch.submit_job.side_effect = _submit_job
+        fake_file_service = AsyncMock()
+        fake_file_service.upload_file = AsyncMock()
+
+        service = SimulationServiceRay()
+        with (
+            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
+            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
+            patch("viva_api.dependencies.get_file_service", return_value=fake_file_service),
+            patch("viva_api.simulation.simulation_service_ray.asyncio.sleep", new=AsyncMock()),
+        ):
+            await service.submit_chain_dispatch_job(ecoli_simulation=simulation, database_service=database_service)
+
+        active_campaigns = [
+            c for c in await database_service.list_active_chain_campaigns() if c.ref_id == simulation.database_id
+        ]
+        assert len(active_campaigns) == 1
+        # Only seed 1 contributed -- seed 0's generation-0 failure means it has
+        # no job at all to track.
+        assert active_campaigns[0].chain_final_job_ids == ["s1g1"]
 
 
 @pytest.mark.asyncio
-class TestSubmitNextWave:
-    """submit_next_wave is what JobScheduler calls for generation 1..N-1 once
-    the PREVIOUS wave's survivors are known (backlog item 33)."""
+class TestSubmitCampaignAnalysis:
+    """submit_campaign_analysis is what JobScheduler calls once the
+    analysis-fan-in poller confirms a chain-dispatch campaign is all-terminal
+    (backlog item 33 rework) -- reuses item 24's existing analysis-job
+    submission code (_submit_analysis_job) completely as-is, with NO native
+    dependsOn."""
 
-    async def test_submits_wave_with_no_parca_dependency(
-        self,
-        experiment_request: "SimulationRequest",
-        database_service: "DatabaseServiceSQL",
-    ) -> None:
-        """The ParCa cache is already in S3 from generation 0 -- ParCa already
-        SUCCEEDED long before a later wave is submitted, so there's no
-        ordering left to enforce."""
-        simulation = await database_service.insert_simulation(sim_request=experiment_request)
-        mock_batch = _fake_batch(["wave1-789"])
-        fake_file_service = AsyncMock()
-        fake_file_service.upload_file = AsyncMock()
-
-        service = SimulationServiceRay()
-        with (
-            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
-            patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
-            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
-            patch("viva_api.dependencies.get_file_service", return_value=fake_file_service),
-        ):
-            job_id = await service.submit_next_wave(
-                simulation=simulation,
-                database_service=database_service,
-                commit="abc1234",
-                generation_index=1,
-                seed_indices=[4, 5, 9],
-                total_n_seeds=30,
-                n_generations=3,
-            )
-
-        assert job_id == "wave1-789"
-        assert mock_batch.submit_job.call_count == 1
-        (wave_call,) = mock_batch.submit_job.call_args_list
-        assert "dependsOn" not in wave_call.kwargs
-        assert wave_call.kwargs["arrayProperties"] == {"size": 3}  # sparse survivor count, not total_n_seeds
-        assert wave_call.kwargs["tags"]["Wave"] == "1"
-
-    async def test_sparse_seed_indices_drive_array_size_and_are_embedded_verbatim(
+    async def test_submits_analysis_with_no_dependency(
         self,
         experiment_request: "SimulationRequest",
         database_service: "DatabaseServiceSQL",
     ) -> None:
         simulation = await database_service.insert_simulation(sim_request=experiment_request)
-        mock_batch = _fake_batch(["wave2-abc"])
-        fake_file_service = AsyncMock()
-        fake_file_service.upload_file = AsyncMock()
-
+        mock_batch = _fake_batch(["analysis-999"])
         service = SimulationServiceRay()
         with (
             patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
             patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
             patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
-            patch("viva_api.dependencies.get_file_service", return_value=fake_file_service),
         ):
-            await service.submit_next_wave(
+            job_id = await service.submit_campaign_analysis(
                 simulation=simulation,
                 database_service=database_service,
                 commit="abc1234",
-                generation_index=2,
-                seed_indices=[4, 5, 9, 10, 14],
                 total_n_seeds=30,
                 n_generations=10,
             )
-
-        (wave_call,) = mock_batch.submit_job.call_args_list
-        assert wave_call.kwargs["arrayProperties"] == {"size": 5}
-        cmd = _array_env(wave_call)["ARRAY_JOB_CMD"]
-        assert "[4, 5, 9, 10, 14]" in cmd
-
-        # Module-scoped Postgres container: filter to this test's own simulation.
-        active_waves = [
-            w for w in await database_service.list_active_wave_hpcruns() if w.ref_id == simulation.database_id
-        ]
-        assert len(active_waves) == 1
-        assert active_waves[0].wave_index == 2
-        assert active_waves[0].wave_seed_indices == [4, 5, 9, 10, 14]
-
-    async def test_non_final_wave_does_not_submit_analysis(
-        self,
-        experiment_request: "SimulationRequest",
-        database_service: "DatabaseServiceSQL",
-    ) -> None:
-        simulation = await database_service.insert_simulation(sim_request=experiment_request)
-        mock_batch = _fake_batch(["wave1-789"])
-        fake_file_service = AsyncMock()
-        fake_file_service.upload_file = AsyncMock()
-
-        service = SimulationServiceRay()
-        with (
-            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
-            patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
-            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
-            patch("viva_api.dependencies.get_file_service", return_value=fake_file_service),
-        ):
-            await service.submit_next_wave(
-                simulation=simulation,
-                database_service=database_service,
-                commit="abc1234",
-                generation_index=1,  # of 3 -- not final (final is index 2)
-                seed_indices=[4, 5, 9],
-                total_n_seeds=30,
-                n_generations=3,
-            )
-
-        assert mock_batch.submit_job.call_count == 1  # wave only, no analysis
-        assert await database_service.list_analyses(simulation_id=simulation.database_id) == []
-
-    async def test_final_wave_also_submits_analysis_depending_on_itself(
-        self,
-        experiment_request: "SimulationRequest",
-        database_service: "DatabaseServiceSQL",
-    ) -> None:
-        """generation_index == n_generations - 1 is the campaign's last wave --
-        the analysis DAG node (item 24's mechanism) must ride along, gated on
-        THIS wave's own array job id via the existing plain {"jobId": ...}
-        shape (no "type"), the same shape the single-shot Array path already
-        uses and that real AWS Batch requires for an array parent id."""
-        simulation = await database_service.insert_simulation(sim_request=experiment_request)
-        mock_batch = _fake_batch(["wave2-final", "analysis-999"])
-        fake_file_service = AsyncMock()
-        fake_file_service.upload_file = AsyncMock()
-
-        service = SimulationServiceRay()
-        with (
-            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
-            patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
-            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
-            patch("viva_api.dependencies.get_file_service", return_value=fake_file_service),
-        ):
-            job_id = await service.submit_next_wave(
-                simulation=simulation,
-                database_service=database_service,
-                commit="abc1234",
-                generation_index=2,  # n_generations - 1 == 2 -- final
-                seed_indices=[4, 5, 9],
-                total_n_seeds=30,
-                n_generations=3,
-            )
-
-        assert job_id == "wave2-final"
-        assert mock_batch.submit_job.call_count == 2
-        wave_call, analysis_call = mock_batch.submit_job.call_args_list
-        assert wave_call.kwargs["arrayProperties"] == {"size": 3}
-
-        # Analysis gated on the just-submitted FINAL wave, plain {"jobId": ...}.
-        assert analysis_call.kwargs["dependsOn"] == [{"jobId": "wave2-final"}]
-        assert "type" not in analysis_call.kwargs["dependsOn"][0]
-        assert analysis_call.kwargs["nodeOverrides"]["numNodes"] == 1  # analysis rides on MNP, not Array
+        assert job_id == "analysis-999"
+        assert mock_batch.submit_job.call_count == 1
+        (analysis_call,) = mock_batch.submit_job.call_args_list
+        # By construction everything this depends on has ALREADY finished --
+        # no native dependsOn at all (unlike item 24's single-shot-dispatch
+        # shape, which depends on the sim job it rides directly behind).
+        assert "dependsOn" not in analysis_call.kwargs
+        assert analysis_call.kwargs["nodeOverrides"]["numNodes"] == 1  # rides on MNP, matching item 24
 
         records = await database_service.list_analyses(simulation_id=simulation.database_id)
         assert len(records) == 1
         assert records[0].job_id_ext == "analysis-999"
         assert records[0].backend == "ray"
-        # n_seeds passed to the analysis is the ORIGINAL requested total, not
-        # the final wave's shrunken survivor count (3) -- the analysis
-        # resolves "applicable" modules against the campaign's intended shape.
-        env = _env_of(analysis_call)
-        assert "--n-seeds 30" in env["RAY_JOB_CMD"]
+
+    async def test_uses_the_originally_requested_seed_count_not_survivor_count(
+        self,
+        experiment_request: "SimulationRequest",
+        database_service: "DatabaseServiceSQL",
+    ) -> None:
+        """Matches the superseded design's own resolved semantics: analysis
+        modules resolve 'applicable' against the campaign's INTENDED shape,
+        not however many chains actually survived to completion."""
+        simulation = await database_service.insert_simulation(sim_request=experiment_request)
+        mock_batch = _fake_batch(["analysis-999"])
+        service = SimulationServiceRay()
+        with (
+            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
+            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
+        ):
+            await service.submit_campaign_analysis(
+                simulation=simulation,
+                database_service=database_service,
+                commit="abc1234",
+                total_n_seeds=1000,  # the originally requested total, even if fewer chains actually succeeded
+                n_generations=10,
+            )
+        env = _env_of(mock_batch.submit_job.call_args_list[0])
+        assert "--n-seeds 1000" in env["RAY_JOB_CMD"]

--- a/tests/simulation/test_ray_backend.py
+++ b/tests/simulation/test_ray_backend.py
@@ -764,8 +764,9 @@ class TestGetWaveResult:
         survivors = (4, 5, 9, 10, 14, 15, 16, 18, 20, 27)
         losses = [i for i in range(30) if i not in survivors]
         mock_batch = MagicMock()
+        status_summary = {"SUCCEEDED": 10, "FAILED": 20}
         mock_batch.describe_jobs.return_value = {
-            "jobs": [{"jobId": "wave-1", "arrayProperties": {"size": 30, "statusSummary": {"SUCCEEDED": 10, "FAILED": 20}}}]
+            "jobs": [{"jobId": "wave-1", "arrayProperties": {"size": 30, "statusSummary": status_summary}}]
         }
 
         def _list_jobs(**kwargs: Any) -> dict[str, Any]:

--- a/tests/simulation/test_ray_backend.py
+++ b/tests/simulation/test_ray_backend.py
@@ -869,6 +869,10 @@ class TestSeedGenerationCommand:
         assert overrides["n_seeds"] == 1
         assert overrides["n_generations"] == 1
         assert overrides["analyses"] == "none"
+        # Per-seed S3 prefix, not the flat ensemble one (backlog item 35: every
+        # job sharing the flat prefix clobbered the last job's summary.json/
+        # final_state.json -- the real bug the pilot found).
+        assert overrides["out_dir"] == "s3://mybucket/vecoli-output/sim47-chain-experiment/seed_07"
 
     def test_later_generation_carries_the_prior_generations_state(self) -> None:
         service = SimulationServiceRay()
@@ -914,6 +918,34 @@ class TestSeedGenerationCommand:
         overrides = self._overrides(cmd)
         assert overrides["experiment_id"] == hostile
         assert hostile in overrides["daughter_state_out_path"]
+
+    def test_out_dir_is_shared_within_a_seed_but_isolated_across_seeds(self) -> None:
+        """The real regression test for the item 35 pilot bug: every
+        per-generation job for the SAME seed must share one S3 prefix (so the
+        parquet sweep / zarr store / summary.json accumulate correctly across
+        the chain), but DIFFERENT seeds must never share a prefix (or their
+        jobs clobber each other's summary.json/final_state.json exactly as
+        the 4th pilot fire found -- confirmed via direct S3 reads, not
+        assumed)."""
+        service = SimulationServiceRay()
+        with (
+            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
+        ):
+            seed0_gen0 = self._overrides(service._seed_generation_command(
+                seed=0, generation_index=0, experiment_id="exp-c",
+                runner_s3_uri="s3://mybucket/vecoli-output/exp-c/run_pbg.py"))
+            seed0_gen5 = self._overrides(service._seed_generation_command(
+                seed=0, generation_index=5, experiment_id="exp-c",
+                runner_s3_uri="s3://mybucket/vecoli-output/exp-c/run_pbg.py"))
+            seed1_gen0 = self._overrides(service._seed_generation_command(
+                seed=1, generation_index=0, experiment_id="exp-c",
+                runner_s3_uri="s3://mybucket/vecoli-output/exp-c/run_pbg.py"))
+
+        assert seed0_gen0["out_dir"] == seed0_gen5["out_dir"] == (
+            "s3://mybucket/vecoli-output/exp-c/seed_00")
+        assert seed1_gen0["out_dir"] == "s3://mybucket/vecoli-output/exp-c/seed_01"
+        assert seed0_gen0["out_dir"] != seed1_gen0["out_dir"]
 
     def test_stays_comfortably_under_the_batch_command_size_cap(self) -> None:
         """AWS Batch caps a container override command at 8192 bytes (see

--- a/tests/simulation/test_ray_backend.py
+++ b/tests/simulation/test_ray_backend.py
@@ -932,18 +932,32 @@ class TestSeedGenerationCommand:
             patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
             patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
         ):
-            seed0_gen0 = self._overrides(service._seed_generation_command(
-                seed=0, generation_index=0, experiment_id="exp-c",
-                runner_s3_uri="s3://mybucket/vecoli-output/exp-c/run_pbg.py"))
-            seed0_gen5 = self._overrides(service._seed_generation_command(
-                seed=0, generation_index=5, experiment_id="exp-c",
-                runner_s3_uri="s3://mybucket/vecoli-output/exp-c/run_pbg.py"))
-            seed1_gen0 = self._overrides(service._seed_generation_command(
-                seed=1, generation_index=0, experiment_id="exp-c",
-                runner_s3_uri="s3://mybucket/vecoli-output/exp-c/run_pbg.py"))
+            seed0_gen0 = self._overrides(
+                service._seed_generation_command(
+                    seed=0,
+                    generation_index=0,
+                    experiment_id="exp-c",
+                    runner_s3_uri="s3://mybucket/vecoli-output/exp-c/run_pbg.py",
+                )
+            )
+            seed0_gen5 = self._overrides(
+                service._seed_generation_command(
+                    seed=0,
+                    generation_index=5,
+                    experiment_id="exp-c",
+                    runner_s3_uri="s3://mybucket/vecoli-output/exp-c/run_pbg.py",
+                )
+            )
+            seed1_gen0 = self._overrides(
+                service._seed_generation_command(
+                    seed=1,
+                    generation_index=0,
+                    experiment_id="exp-c",
+                    runner_s3_uri="s3://mybucket/vecoli-output/exp-c/run_pbg.py",
+                )
+            )
 
-        assert seed0_gen0["out_dir"] == seed0_gen5["out_dir"] == (
-            "s3://mybucket/vecoli-output/exp-c/seed_00")
+        assert seed0_gen0["out_dir"] == seed0_gen5["out_dir"] == ("s3://mybucket/vecoli-output/exp-c/seed_00")
         assert seed1_gen0["out_dir"] == "s3://mybucket/vecoli-output/exp-c/seed_01"
         assert seed0_gen0["out_dir"] != seed1_gen0["out_dir"]
 

--- a/tests/simulation/test_ray_backend.py
+++ b/tests/simulation/test_ray_backend.py
@@ -114,6 +114,26 @@ def _array_env(call: Any) -> dict[str, str]:
     return {e["name"]: e["value"] for e in call.kwargs["containerOverrides"]["environment"]}
 
 
+def _run_merge_prefix(cmd: str, array_index: int) -> dict[str, Any]:
+    """Actually execute a wave/array command's BASE_SEED/OVERRIDES merge prefix
+    (everything before ``&& cd {V2ECOLI_DIR}``) through real bash + python3,
+    with ``AWS_BATCH_JOB_ARRAY_INDEX`` set the way AWS Batch would inject it —
+    no mocking, the real mechanism the container runs. Returns the parsed
+    merged OVERRIDES JSON."""
+    merge_prefix = cmd.split(" && cd ", 1)[0]
+    bash = shutil.which("bash")
+    assert bash is not None, "bash not found on PATH"
+    result = subprocess.run(  # noqa: S603 -- test-only, fixed literal args
+        [bash, "-c", merge_prefix + ' && printf "%s" "$OVERRIDES"'],
+        env={**os.environ, "AWS_BATCH_JOB_ARRAY_INDEX": str(array_index)},
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, result.stderr
+    return dict(json.loads(result.stdout))
+
+
 class TestJobIdRay:
     def test_ray_factory(self) -> None:
         job_id = JobId.ray("abc-123")
@@ -689,6 +709,145 @@ class TestSimulationServiceRayStatusCancel:
         assert mock_batch.terminate_job.call_args.kwargs["jobId"] == "sim-456"
 
 
+class TestGetWaveResult:
+    """get_wave_result polls ONE wave's array job: terminal-ness + which local
+    positions SUCCEEDED vs FAILED. The underlying AWS semantics (list_jobs(
+    arrayJobId=..., jobStatus=...) returning exactly the real children in that
+    status) were independently verified live against sim139's real job
+    history (backlog items 33-35 investigation) — these tests lock the LOCAL
+    decision logic built on top of that already-verified mechanism."""
+
+    def test_not_terminal_while_children_still_running(self) -> None:
+        mock_batch = MagicMock()
+        mock_batch.describe_jobs.return_value = {
+            "jobs": [
+                {"jobId": "wave-1", "arrayProperties": {"size": 4, "statusSummary": {"SUCCEEDED": 1, "RUNNING": 3}}}
+            ]
+        }
+        service = SimulationServiceRay()
+        with (
+            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
+        ):
+            result = service.get_wave_result("wave-1")
+        assert result.terminal is False
+        assert result.succeeded_local_indices == []
+        assert result.failed_local_indices == []
+        mock_batch.list_jobs.assert_not_called()
+
+    def test_terminal_all_succeeded(self) -> None:
+        mock_batch = MagicMock()
+        mock_batch.describe_jobs.return_value = {
+            "jobs": [{"jobId": "wave-1", "arrayProperties": {"size": 3, "statusSummary": {"SUCCEEDED": 3}}}]
+        }
+
+        def _list_jobs(**kwargs: Any) -> dict[str, Any]:
+            if kwargs["jobStatus"] == "SUCCEEDED":
+                return {"jobSummaryList": [{"arrayProperties": {"index": i}} for i in (0, 1, 2)]}
+            return {"jobSummaryList": []}
+
+        mock_batch.list_jobs.side_effect = _list_jobs
+        service = SimulationServiceRay()
+        with (
+            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
+        ):
+            result = service.get_wave_result("wave-1")
+        assert result.terminal is True
+        assert result.succeeded_local_indices == [0, 1, 2]
+        assert result.failed_local_indices == []
+
+    def test_terminal_partial_failure_is_still_terminal_not_an_error(self) -> None:
+        """FAILED-due-to-partial-loss counts as 'wave finished', matching the
+        closed design: Spot/OOM attrition is expected economics, not an
+        orchestrator error. Mirrors sim139's real 10-survivors-of-30 shape."""
+        survivors = (4, 5, 9, 10, 14, 15, 16, 18, 20, 27)
+        losses = [i for i in range(30) if i not in survivors]
+        mock_batch = MagicMock()
+        mock_batch.describe_jobs.return_value = {
+            "jobs": [{"jobId": "wave-1", "arrayProperties": {"size": 30, "statusSummary": {"SUCCEEDED": 10, "FAILED": 20}}}]
+        }
+
+        def _list_jobs(**kwargs: Any) -> dict[str, Any]:
+            indices = survivors if kwargs["jobStatus"] == "SUCCEEDED" else losses
+            return {"jobSummaryList": [{"arrayProperties": {"index": i}} for i in indices]}
+
+        mock_batch.list_jobs.side_effect = _list_jobs
+        service = SimulationServiceRay()
+        with (
+            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
+        ):
+            result = service.get_wave_result("wave-1")
+        assert result.terminal is True
+        assert result.succeeded_local_indices == list(survivors)
+        assert result.failed_local_indices == losses
+        # union covers every index with zero gaps/duplicates.
+        assert sorted(result.succeeded_local_indices + result.failed_local_indices) == list(range(30))
+
+    def test_paginates_list_jobs_via_next_token(self) -> None:
+        mock_batch = MagicMock()
+        mock_batch.describe_jobs.return_value = {
+            "jobs": [{"jobId": "wave-1", "arrayProperties": {"size": 2, "statusSummary": {"SUCCEEDED": 2}}}]
+        }
+        pages = [
+            {"jobSummaryList": [{"arrayProperties": {"index": 0}}], "nextToken": "page2"},
+            {"jobSummaryList": [{"arrayProperties": {"index": 1}}]},
+        ]
+
+        def _list_jobs(**kwargs: Any) -> dict[str, Any]:
+            if kwargs["jobStatus"] == "FAILED":
+                return {"jobSummaryList": []}
+            return pages.pop(0)
+
+        mock_batch.list_jobs.side_effect = _list_jobs
+        service = SimulationServiceRay()
+        with (
+            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
+        ):
+            result = service.get_wave_result("wave-1")
+        assert result.succeeded_local_indices == [0, 1]
+        list_calls = [c for c in mock_batch.list_jobs.call_args_list if c.kwargs["jobStatus"] == "SUCCEEDED"]
+        assert list_calls[1].kwargs["nextToken"] == "page2"
+
+    def test_zero_match_status_returns_empty_list_not_error(self) -> None:
+        """A real 0/30-all-failed job history: jobStatus='SUCCEEDED' returns a
+        clean empty list, not an error -- confirmed live against a second real
+        job this session (items 33-35 investigation)."""
+        mock_batch = MagicMock()
+        mock_batch.describe_jobs.return_value = {
+            "jobs": [{"jobId": "wave-1", "arrayProperties": {"size": 5, "statusSummary": {"FAILED": 5}}}]
+        }
+
+        def _list_jobs(**kwargs: Any) -> dict[str, Any]:
+            if kwargs["jobStatus"] == "SUCCEEDED":
+                return {"jobSummaryList": []}
+            return {"jobSummaryList": [{"arrayProperties": {"index": i}} for i in range(5)]}
+
+        mock_batch.list_jobs.side_effect = _list_jobs
+        service = SimulationServiceRay()
+        with (
+            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
+        ):
+            result = service.get_wave_result("wave-1")
+        assert result.terminal is True
+        assert result.succeeded_local_indices == []
+        assert result.failed_local_indices == [0, 1, 2, 3, 4]
+
+    def test_raises_if_job_not_found(self) -> None:
+        mock_batch = MagicMock()
+        mock_batch.describe_jobs.return_value = {"jobs": []}
+        service = SimulationServiceRay()
+        with (
+            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
+            pytest.raises(RuntimeError, match="not found"),
+        ):
+            service.get_wave_result("missing")
+
+
 def _v2ecoli_simulator() -> Any:
     from viva_api.simulation.models import SimulatorVersion
 
@@ -894,6 +1053,129 @@ class TestArraySimCommand:
                 os.remove(canary)
 
 
+class TestWaveSimCommand:
+    """_wave_sim_command builds one wave's Array child command: ONE seed's ONE
+    generation, remapped through a sparse seed_indices LOOKUP TABLE (not an
+    offset like _array_sim_command's BASE_SEED) -- after a prior generation's
+    attrition, a later wave's array positions are still dense (0..len-1) but
+    the real seeds they represent are not."""
+
+    def test_shape_generation_zero(self) -> None:
+        service = SimulationServiceRay()
+        with (
+            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
+        ):
+            cmd = service._wave_sim_command(
+                generation_index=0,
+                experiment_id="sim47-wave-experiment",
+                runner_s3_uri="s3://mybucket/vecoli-output/sim47-wave-experiment/run_pbg.py",
+                seed_indices=[0, 1, 2, 3],
+            )
+        assert "aws s3 cp s3://mybucket/vecoli-output/sim47-wave-experiment/run_pbg.py /tmp/run_pbg.py" in cmd
+        assert "--composite-id v2ecoli.composites.batch_baseline.batch_baseline " in cmd
+        assert "PBG_CORE_BUILDER=v2ecoli.core:build_core" in cmd
+        assert "-n 1" in cmd
+        assert '"initial_generation_index": 0' in cmd
+        assert '"n_generations": 1' in cmd  # one wave = one generation per invocation
+        assert "AWS_BATCH_JOB_ARRAY_INDEX" in cmd
+        # A lookup table, not offset arithmetic -- _array_sim_command's BASE_SEED
+        # pattern can't express a sparse survivor remap.
+        assert "seeds=json.loads(sys.argv[2])" in cmd
+        assert "seed=seeds[int(sys.argv[3])]" in cmd
+
+    def test_merge_resolves_seed_and_gen0_has_no_carry_state(self) -> None:
+        """Actually run the merge prefix through bash + python3 (no mocking) --
+        the same real-execution proof _array_sim_command's own test uses, so
+        this checks the ACTUAL mechanism the container runs, not a
+        re-derivation of it."""
+        service = SimulationServiceRay()
+        with (
+            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
+        ):
+            cmd = service._wave_sim_command(
+                generation_index=0,
+                experiment_id="exp-a",
+                runner_s3_uri="s3://mybucket/vecoli-output/exp-a/run_pbg.py",
+                seed_indices=[7, 8],
+            )
+        merged = _run_merge_prefix(cmd, array_index=0)
+        assert merged["base_seed"] == 7  # seed_indices[0]
+        assert merged["initial_carry_state_path"] == ""
+        assert merged["daughter_state_out_path"] == "s3://mybucket/vecoli-output/exp-a/wave-state/seed7/gen0.pkl"
+        assert merged["initial_generation_index"] == 0
+
+    def test_merge_resolves_sparse_survivor_position_and_prior_gen_carry_state(self) -> None:
+        """After attrition, position 2 of survivors [4, 5, 9, 10] is seed 9,
+        NOT array index 2 -- the whole point of the lookup table."""
+        service = SimulationServiceRay()
+        with (
+            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
+        ):
+            cmd = service._wave_sim_command(
+                generation_index=2,
+                experiment_id="exp-b",
+                runner_s3_uri="s3://mybucket/vecoli-output/exp-b/run_pbg.py",
+                seed_indices=[4, 5, 9, 10],
+            )
+        merged = _run_merge_prefix(cmd, array_index=2)
+        assert merged["base_seed"] == 9  # seed_indices[2], NOT array index 2
+        assert merged["initial_carry_state_path"] == "s3://mybucket/vecoli-output/exp-b/wave-state/seed9/gen1.pkl"
+        assert merged["daughter_state_out_path"] == "s3://mybucket/vecoli-output/exp-b/wave-state/seed9/gen2.pkl"
+        assert merged["initial_generation_index"] == 2
+
+    def test_hostile_experiment_id_stays_data_not_shell_syntax(self) -> None:
+        """experiment_id is a caller-supplied, unconstrained string (no pattern
+        validation at the model/API boundary) -- proves the shlex-quoted blob
+        keeps arbitrary content as DATA, mirroring _array_sim_command's own
+        injection-canary proof."""
+        service = SimulationServiceRay()
+        hostile = "exp'; touch /tmp/wave-sim-command-injection-canary; echo '$(echo pwned)"
+        with (
+            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
+        ):
+            cmd = service._wave_sim_command(
+                generation_index=1,
+                experiment_id=hostile,
+                runner_s3_uri="s3://mybucket/vecoli-output/exp/run_pbg.py",
+                seed_indices=[3, 4],
+            )
+        canary = "/tmp/wave-sim-command-injection-canary"  # noqa: S108
+        if os.path.exists(canary):
+            os.remove(canary)
+        try:
+            merged = _run_merge_prefix(cmd, array_index=1)
+            assert not os.path.exists(canary), "hostile experiment_id executed as shell syntax, not data"
+            assert merged["experiment_id"] == hostile
+            assert hostile in merged["daughter_state_out_path"]
+        finally:
+            if os.path.exists(canary):
+                os.remove(canary)
+
+    def test_stays_under_the_batch_command_size_cap_at_1000_seeds(self) -> None:
+        """AWS Batch caps a container override command at 8192 bytes (see
+        _stage_runner's docstring). The design deliberately embeds the
+        surviving-seed list as bare ints — not precomputed per-seed URIs,
+        which would blow this cap at 1000 seeds — precisely to fit under it.
+        Locks that sizing claim against a real measurement, not an assumption."""
+        service = SimulationServiceRay()
+        long_experiment_id = "sim1000-cd1-baseline-1000x10-" + "x" * 20
+        with (
+            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
+        ):
+            cmd = service._wave_sim_command(
+                generation_index=9,
+                experiment_id=long_experiment_id,
+                runner_s3_uri=f"s3://mybucket/vecoli-output/{long_experiment_id}/run_pbg.py",
+                seed_indices=list(range(1000)),
+            )
+        assert len(cmd) < 8192, f"wave command is {len(cmd)} bytes, over the real AWS Batch cap"
+
+
 class TestIsUpstreamVecoli:
     """The single routing predicate shared by submit_ecoli_simulation_job and _sim_command."""
 
@@ -1037,3 +1319,263 @@ class TestEnsureArrayJobDef:
             pytest.raises(RuntimeError, match="Base Array job definition"),
         ):
             service._ensure_array_job_def("some:image", "abc1234")
+
+
+@pytest.mark.asyncio
+class TestWaveDispatchSubmission:
+    """submit_wave_dispatch_job kicks off a wave campaign: ParCa + generation
+    0's Array wave over every requested seed (backlog item 33)."""
+
+    async def test_rejects_single_generation(
+        self,
+        experiment_request: "SimulationRequest",
+        database_service: "DatabaseServiceSQL",
+    ) -> None:
+        setattr(experiment_request.config, "n_init_sims", 4)  # noqa: B010
+        experiment_request.config.generations = 1
+        simulation = await database_service.insert_simulation(sim_request=experiment_request)
+        service = SimulationServiceRay()
+        with (
+            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
+            pytest.raises(ValueError, match="requires generations > 1"),
+        ):
+            await service.submit_wave_dispatch_job(ecoli_simulation=simulation, database_service=database_service)
+
+    async def test_rejects_single_seed(
+        self,
+        experiment_request: "SimulationRequest",
+        database_service: "DatabaseServiceSQL",
+    ) -> None:
+        setattr(experiment_request.config, "n_init_sims", 1)  # noqa: B010
+        experiment_request.config.generations = 3
+        simulation = await database_service.insert_simulation(sim_request=experiment_request)
+        service = SimulationServiceRay()
+        with (
+            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
+            pytest.raises(ValueError, match="requires n_seeds > 1"),
+        ):
+            await service.submit_wave_dispatch_job(ecoli_simulation=simulation, database_service=database_service)
+
+    async def test_submits_parca_then_wave0_over_all_seeds_not_final(
+        self,
+        experiment_request: "SimulationRequest",
+        database_service: "DatabaseServiceSQL",
+    ) -> None:
+        """3-generation campaign: generation 0 is NOT the final wave, so no
+        analysis node rides along yet -- that only happens once JobScheduler
+        drives the campaign to its last generation (see TestSubmitNextWave)."""
+        setattr(experiment_request.config, "n_init_sims", 4)  # noqa: B010
+        experiment_request.config.generations = 3
+        simulation = await database_service.insert_simulation(sim_request=experiment_request)
+
+        mock_batch = _fake_batch(["parca-123", "wave0-456"])
+        fake_file_service = AsyncMock()
+        fake_file_service.upload_file = AsyncMock()
+
+        service = SimulationServiceRay()
+        with (
+            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
+            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
+            patch("viva_api.dependencies.get_file_service", return_value=fake_file_service),
+        ):
+            job_id = await service.submit_wave_dispatch_job(
+                ecoli_simulation=simulation, database_service=database_service
+            )
+
+        assert job_id == JobId.ray("wave0-456")
+        assert mock_batch.submit_job.call_count == 2  # parca + wave0 only (not final -> no analysis)
+        parca_call, wave0_call = mock_batch.submit_job.call_args_list
+
+        assert "dependsOn" not in parca_call.kwargs
+
+        assert "nodeOverrides" not in wave0_call.kwargs
+        assert wave0_call.kwargs["arrayProperties"] == {"size": 4}
+        assert wave0_call.kwargs["dependsOn"] == [{"jobId": "parca-123"}]
+        assert wave0_call.kwargs["tags"]["Wave"] == "0"
+        assert wave0_call.kwargs["tags"]["Phase"] == "sim"
+
+        cmd = _array_env(wave0_call)["ARRAY_JOB_CMD"]
+        assert '"initial_generation_index": 0' in cmd
+        assert "[0, 1, 2, 3]" in cmd
+
+        # The underlying Postgres container is module-scoped (rows from other
+        # tests in this file persist alongside it), so filter to THIS test's
+        # own simulation rather than assume global uniqueness.
+        active_waves = [
+            w for w in await database_service.list_active_wave_hpcruns() if w.ref_id == simulation.database_id
+        ]
+        assert len(active_waves) == 1
+        assert active_waves[0].wave_index == 0
+        assert active_waves[0].wave_seed_indices == [0, 1, 2, 3]
+        assert active_waves[0].job_id == JobId.ray("wave0-456")
+
+        # Not the final wave (generation 0 of 3): no analysis submitted yet.
+        assert await database_service.list_analyses(simulation_id=simulation.database_id) == []
+
+
+@pytest.mark.asyncio
+class TestSubmitNextWave:
+    """submit_next_wave is what JobScheduler calls for generation 1..N-1 once
+    the PREVIOUS wave's survivors are known (backlog item 33)."""
+
+    async def test_submits_wave_with_no_parca_dependency(
+        self,
+        experiment_request: "SimulationRequest",
+        database_service: "DatabaseServiceSQL",
+    ) -> None:
+        """The ParCa cache is already in S3 from generation 0 -- ParCa already
+        SUCCEEDED long before a later wave is submitted, so there's no
+        ordering left to enforce."""
+        simulation = await database_service.insert_simulation(sim_request=experiment_request)
+        mock_batch = _fake_batch(["wave1-789"])
+        fake_file_service = AsyncMock()
+        fake_file_service.upload_file = AsyncMock()
+
+        service = SimulationServiceRay()
+        with (
+            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
+            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
+            patch("viva_api.dependencies.get_file_service", return_value=fake_file_service),
+        ):
+            job_id = await service.submit_next_wave(
+                simulation=simulation,
+                database_service=database_service,
+                commit="abc1234",
+                generation_index=1,
+                seed_indices=[4, 5, 9],
+                total_n_seeds=30,
+                n_generations=3,
+            )
+
+        assert job_id == "wave1-789"
+        assert mock_batch.submit_job.call_count == 1
+        (wave_call,) = mock_batch.submit_job.call_args_list
+        assert "dependsOn" not in wave_call.kwargs
+        assert wave_call.kwargs["arrayProperties"] == {"size": 3}  # sparse survivor count, not total_n_seeds
+        assert wave_call.kwargs["tags"]["Wave"] == "1"
+
+    async def test_sparse_seed_indices_drive_array_size_and_are_embedded_verbatim(
+        self,
+        experiment_request: "SimulationRequest",
+        database_service: "DatabaseServiceSQL",
+    ) -> None:
+        simulation = await database_service.insert_simulation(sim_request=experiment_request)
+        mock_batch = _fake_batch(["wave2-abc"])
+        fake_file_service = AsyncMock()
+        fake_file_service.upload_file = AsyncMock()
+
+        service = SimulationServiceRay()
+        with (
+            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
+            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
+            patch("viva_api.dependencies.get_file_service", return_value=fake_file_service),
+        ):
+            await service.submit_next_wave(
+                simulation=simulation,
+                database_service=database_service,
+                commit="abc1234",
+                generation_index=2,
+                seed_indices=[4, 5, 9, 10, 14],
+                total_n_seeds=30,
+                n_generations=10,
+            )
+
+        (wave_call,) = mock_batch.submit_job.call_args_list
+        assert wave_call.kwargs["arrayProperties"] == {"size": 5}
+        cmd = _array_env(wave_call)["ARRAY_JOB_CMD"]
+        assert "[4, 5, 9, 10, 14]" in cmd
+
+        # Module-scoped Postgres container: filter to this test's own simulation.
+        active_waves = [
+            w for w in await database_service.list_active_wave_hpcruns() if w.ref_id == simulation.database_id
+        ]
+        assert len(active_waves) == 1
+        assert active_waves[0].wave_index == 2
+        assert active_waves[0].wave_seed_indices == [4, 5, 9, 10, 14]
+
+    async def test_non_final_wave_does_not_submit_analysis(
+        self,
+        experiment_request: "SimulationRequest",
+        database_service: "DatabaseServiceSQL",
+    ) -> None:
+        simulation = await database_service.insert_simulation(sim_request=experiment_request)
+        mock_batch = _fake_batch(["wave1-789"])
+        fake_file_service = AsyncMock()
+        fake_file_service.upload_file = AsyncMock()
+
+        service = SimulationServiceRay()
+        with (
+            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
+            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
+            patch("viva_api.dependencies.get_file_service", return_value=fake_file_service),
+        ):
+            await service.submit_next_wave(
+                simulation=simulation,
+                database_service=database_service,
+                commit="abc1234",
+                generation_index=1,  # of 3 -- not final (final is index 2)
+                seed_indices=[4, 5, 9],
+                total_n_seeds=30,
+                n_generations=3,
+            )
+
+        assert mock_batch.submit_job.call_count == 1  # wave only, no analysis
+        assert await database_service.list_analyses(simulation_id=simulation.database_id) == []
+
+    async def test_final_wave_also_submits_analysis_depending_on_itself(
+        self,
+        experiment_request: "SimulationRequest",
+        database_service: "DatabaseServiceSQL",
+    ) -> None:
+        """generation_index == n_generations - 1 is the campaign's last wave --
+        the analysis DAG node (item 24's mechanism) must ride along, gated on
+        THIS wave's own array job id via the existing plain {"jobId": ...}
+        shape (no "type"), the same shape the single-shot Array path already
+        uses and that real AWS Batch requires for an array parent id."""
+        simulation = await database_service.insert_simulation(sim_request=experiment_request)
+        mock_batch = _fake_batch(["wave2-final", "analysis-999"])
+        fake_file_service = AsyncMock()
+        fake_file_service.upload_file = AsyncMock()
+
+        service = SimulationServiceRay()
+        with (
+            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
+            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
+            patch("viva_api.dependencies.get_file_service", return_value=fake_file_service),
+        ):
+            job_id = await service.submit_next_wave(
+                simulation=simulation,
+                database_service=database_service,
+                commit="abc1234",
+                generation_index=2,  # n_generations - 1 == 2 -- final
+                seed_indices=[4, 5, 9],
+                total_n_seeds=30,
+                n_generations=3,
+            )
+
+        assert job_id == "wave2-final"
+        assert mock_batch.submit_job.call_count == 2
+        wave_call, analysis_call = mock_batch.submit_job.call_args_list
+        assert wave_call.kwargs["arrayProperties"] == {"size": 3}
+
+        # Analysis gated on the just-submitted FINAL wave, plain {"jobId": ...}.
+        assert analysis_call.kwargs["dependsOn"] == [{"jobId": "wave2-final"}]
+        assert "type" not in analysis_call.kwargs["dependsOn"][0]
+        assert analysis_call.kwargs["nodeOverrides"]["numNodes"] == 1  # analysis rides on MNP, not Array
+
+        records = await database_service.list_analyses(simulation_id=simulation.database_id)
+        assert len(records) == 1
+        assert records[0].job_id_ext == "analysis-999"
+        assert records[0].backend == "ray"
+        # n_seeds passed to the analysis is the ORIGINAL requested total, not
+        # the final wave's shrunken survivor count (3) -- the analysis
+        # resolves "applicable" modules against the campaign's intended shape.
+        env = _env_of(analysis_call)
+        assert "--n-seeds 30" in env["RAY_JOB_CMD"]

--- a/tests/simulation/test_ray_backend.py
+++ b/tests/simulation/test_ray_backend.py
@@ -2,10 +2,7 @@
 and SimulationServiceRay submission/status/cancel (boto3 mocked, Postgres via testcontainers)."""
 
 import json
-import os
 import shlex
-import shutil
-import subprocess
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -53,12 +50,15 @@ def _ray_settings() -> MagicMock:
 
 
 def _fake_batch(submit_ids: list[str]) -> MagicMock:
-    """A boto3 Batch mock that supports the per-commit job-def derivation (both the
-    MNP and Array shapes) + submits.
+    """A boto3 Batch mock that supports the per-commit MNP job-def derivation +
+    submits. (The Array job-def branch this used to also support was removed
+    along with _ensure_array_job_def/_submit_array/_array_sim_command --
+    backlog item 33's canonical-dispatch routing made them dead code, their
+    only caller having been the array branch that rework replaced.)
 
-    describe_job_definitions returns the CDK base (with properties to clone) for
-    either base name, and "no existing revision" for any per-commit name; register
-    returns rev 1.
+    describe_job_definitions returns the CDK MNP base (with properties to
+    clone) for the base name, and "no existing revision" for any per-commit
+    name; register returns rev 1.
     """
     b = MagicMock()
     base_node_props = {
@@ -66,26 +66,11 @@ def _fake_batch(submit_ids: list[str]) -> MagicMock:
         "mainNode": 0,
         "nodeRangeProperties": [{"targetNodes": "0:", "container": {"image": "111.dkr.ecr.x/vecoli:ray", "vcpus": 16}}],
     }
-    base_container_props = {
-        "image": "111.dkr.ecr.x/vecoli:ray",
-        "resourceRequirements": [{"type": "VCPU", "value": "2"}, {"type": "MEMORY", "value": "16384"}],
-    }
 
     def _describe(**kwargs: Any) -> dict[str, Any]:
         name = kwargs.get("jobDefinitionName")
         if name == "smscdk-ray-mnp":  # MNP base
             return {"jobDefinitions": [{"revision": 7, "nodeProperties": base_node_props}]}
-        if name == "smscdk-ray-array":  # Array base
-            return {
-                "jobDefinitions": [
-                    {
-                        "revision": 3,
-                        "containerProperties": base_container_props,
-                        "retryStrategy": {"attempts": 2},
-                        "platformCapabilities": ["EC2"],
-                    }
-                ]
-            }
         return {"jobDefinitions": []}  # per-commit: none yet
 
     b.describe_job_definitions.side_effect = _describe
@@ -107,11 +92,6 @@ def _env_at(call: Any, index: int) -> dict[str, str]:
 def _env_of(call: Any) -> dict[str, str]:
     """Head (node 0) environment dict."""
     return _env_at(call, 0)
-
-
-def _array_env(call: Any) -> dict[str, str]:
-    """Environment dict for an Array job submission (containerOverrides, not nodeOverrides)."""
-    return {e["name"]: e["value"] for e in call.kwargs["containerOverrides"]["environment"]}
 
 
 class TestJobIdRay:
@@ -248,26 +228,137 @@ class TestSimulationServiceRaySubmit:
         reg_images = {nr["container"]["image"] for nr in reg.kwargs["nodeProperties"]["nodeRangeProperties"]}
         assert reg_images == {f"476270107793.dkr.ecr.us-gov-west-1.amazonaws.com/v2ecoli:{commit}"}
 
-    async def test_submit_routes_batch_baseline_to_array_jobs_when_multiseed(
+    async def test_submit_routes_canonical_batch_baseline_to_chain_dispatch_when_multiseed(
         self,
         experiment_request: "SimulationRequest",
         database_service: "DatabaseServiceSQL",
     ) -> None:
-        """The canonical batch_baseline sweep (n_seeds>1, generations>1, no composite
-        override) is Array-jobs-shaped: dispatched as N independent single-seed AWS
-        Batch Array children instead of an MNP Ray cluster -- ray-vs-batch-array-jobs
-        decision: Array jobs for canonical, Ray-MNP stays for colonies/anything that
-        genuinely needs Ray coordination. ParCa itself is unaffected (still a single
-        MNP job -- one deterministic computation, no seed-parallelism to exploit).
-        Also covers what the old MNP-routing test covered: the real request's own
-        experiment_id reaches the overrides (previously silently defaulted), the
-        generic run_pbg.py runner is used (not a v2ecoli-specific script), and the
-        runner is staged to S3 exactly once before the sim job is built."""
-        setattr(experiment_request.config, "n_init_sims", 4)  # noqa: B010
+        """The canonical batch_baseline sweep (composite is None, generations>1)
+        is now delegated ENTIRELY to submit_chain_dispatch_job (backlog item 33
+        rework) -- individual per-seed AWS Batch job chains, never the array-job
+        path (removed: _submit_array/_array_sim_command/_ensure_array_job_def no
+        longer exist at all -- a fresh repo-wide grep confirmed their only
+        caller was the array branch this replaced, before they were deleted).
+
+        This is the test that would have caught the real wiring gap found in
+        review: submit_chain_dispatch_job existed and was fully tested in
+        isolation from the moment it was built, but nothing on the REAL
+        submit_ecoli_simulation_job entrypoint ever called it until this
+        routing landed -- a real request would have silently kept exercising
+        the old array/wave-style path forever."""
+        setattr(experiment_request.config, "n_init_sims", 2)  # noqa: B010
         experiment_request.config.generations = 3
         simulation = await database_service.insert_simulation(sim_request=experiment_request)
 
-        mock_batch = _fake_batch(["parca-123", "sim-456", "analysis-789"])
+        # parca + 2 seeds x 3 generations = 7 real submissions -- not 1 array job.
+        submit_ids = ["parca-1", "s0g0", "s0g1", "s0g2", "s1g0", "s1g1", "s1g2"]
+        mock_batch = _fake_batch(submit_ids)
+        fake_file_service = AsyncMock()
+        fake_file_service.upload_file = AsyncMock()
+
+        service = SimulationServiceRay()
+        with (
+            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
+            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
+            patch("viva_api.dependencies.get_file_service", return_value=fake_file_service),
+            patch("viva_api.simulation.simulation_service_ray.asyncio.sleep", new=AsyncMock()),
+        ):
+            job_id = await service.submit_ecoli_simulation_job(
+                ecoli_simulation=simulation, database_service=database_service, correlation_id="corr-real-entry"
+            )
+
+        # Chain-dispatch's own return convention: the ParCa job id, never a
+        # single "sim" job id (there isn't one anymore).
+        assert job_id == JobId.ray("parca-1")
+        assert mock_batch.submit_job.call_count == 7
+        calls = mock_batch.submit_job.call_args_list
+
+        # Every submission is a plain MNP job -- arrayProperties never appears
+        # anywhere in this call sequence.
+        for call in calls:
+            assert "arrayProperties" not in call.kwargs
+        for call in calls[1:]:
+            assert "nodeOverrides" in call.kwargs
+
+        # Dependency chain for a representative seed (seed 0) and confirmation
+        # seed 1's chain is entirely independent, both rooted at the SAME ParCa job.
+        _parca_call, s0g0, s0g1, s0g2, s1g0, s1g1, s1g2 = calls
+        assert s0g0.kwargs["dependsOn"] == [{"jobId": "parca-1", "type": "SEQUENTIAL"}]
+        assert s0g1.kwargs["dependsOn"] == [{"jobId": "s0g0", "type": "SEQUENTIAL"}]
+        assert s0g2.kwargs["dependsOn"] == [{"jobId": "s0g1", "type": "SEQUENTIAL"}]
+        assert s1g0.kwargs["dependsOn"] == [{"jobId": "parca-1", "type": "SEQUENTIAL"}]
+        assert s1g1.kwargs["dependsOn"] == [{"jobId": "s1g0", "type": "SEQUENTIAL"}]
+        assert s1g2.kwargs["dependsOn"] == [{"jobId": "s1g1", "type": "SEQUENTIAL"}]
+
+        # The campaign row was recorded under the CALLER's OWN correlation_id
+        # (threaded through, not a fresh internally-generated one) -- this is
+        # what lets a real status lookup by that id resolve to the actual
+        # campaign row, not a stale duplicate a caller's own generic
+        # insert_hpcrun would otherwise shadow it with (see the idempotent-
+        # insert guard in viva_api.common.handlers.simulations).
+        campaign_hpcrun_id = await database_service.get_hpcrun_id_by_correlation_id(correlation_id="corr-real-entry")
+        assert campaign_hpcrun_id is not None
+        campaign = await database_service.get_hpcrun(campaign_hpcrun_id)
+        assert campaign is not None
+        assert campaign.chain_n_generations == 3
+        assert campaign.chain_final_job_ids == ["s0g2", "s1g2"]
+
+    async def test_submit_routes_canonical_batch_baseline_to_chain_dispatch_when_single_seed(
+        self,
+        experiment_request: "SimulationRequest",
+        database_service: "DatabaseServiceSQL",
+    ) -> None:
+        """Unlike the superseded array-job design (which required n_seeds > 1 --
+        AWS Batch's own array-size floor, verified against the real API model),
+        a single-seed canonical batch_baseline request is now ALSO routed to
+        chain-dispatch: that floor doesn't apply at all to independent per-seed
+        MNP jobs, confirmed here at the REAL entrypoint (not just in
+        TestChainDispatchSubmission's own isolated coverage of the same claim)."""
+        setattr(experiment_request.config, "n_init_sims", 1)  # noqa: B010
+        experiment_request.config.generations = 3
+        simulation = await database_service.insert_simulation(sim_request=experiment_request)
+
+        submit_ids = ["parca-1", "s0g0", "s0g1", "s0g2"]
+        mock_batch = _fake_batch(submit_ids)
+        fake_file_service = AsyncMock()
+        fake_file_service.upload_file = AsyncMock()
+
+        service = SimulationServiceRay()
+        with (
+            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
+            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
+            patch("viva_api.dependencies.get_file_service", return_value=fake_file_service),
+            patch("viva_api.simulation.simulation_service_ray.asyncio.sleep", new=AsyncMock()),
+        ):
+            job_id = await service.submit_ecoli_simulation_job(
+                ecoli_simulation=simulation, database_service=database_service, correlation_id="corr-single-real"
+            )
+
+        assert job_id == JobId.ray("parca-1")
+        assert mock_batch.submit_job.call_count == 4  # parca + 1 seed x 3 generations
+        _parca_call, g0, g1, g2 = mock_batch.submit_job.call_args_list
+        assert "arrayProperties" not in g0.kwargs
+        assert g0.kwargs["dependsOn"] == [{"jobId": "parca-1", "type": "SEQUENTIAL"}]
+        assert g1.kwargs["dependsOn"] == [{"jobId": "s0g0", "type": "SEQUENTIAL"}]
+        assert g2.kwargs["dependsOn"] == [{"jobId": "s0g1", "type": "SEQUENTIAL"}]
+
+    async def test_composite_comparison_ensemble_with_multiple_generations_stays_on_mnp(
+        self,
+        experiment_request: "SimulationRequest",
+        database_service: "DatabaseServiceSQL",
+    ) -> None:
+        """Chain-dispatch is v2ecoli-only (backlog item 33). A composite-driven
+        two-engine comparison-ensemble request must NOT be routed there even
+        with generations > 1 -- guards against the real regression risk this
+        rework's new routing guard could introduce (an over-broad condition
+        that also swallows composite requests)."""
+        setattr(experiment_request.config, "composite", "vecoli")  # noqa: B010
+        experiment_request.config.generations = 3
+        simulation = await database_service.insert_simulation(sim_request=experiment_request)
+
+        mock_batch = _fake_batch(["parca-123", "sim-456"])
         fake_file_service = AsyncMock()
         fake_file_service.upload_file = AsyncMock()
 
@@ -279,106 +370,19 @@ class TestSimulationServiceRaySubmit:
             patch("viva_api.dependencies.get_file_service", return_value=fake_file_service),
         ):
             job_id = await service.submit_ecoli_simulation_job(
-                ecoli_simulation=simulation, database_service=database_service, correlation_id="corr-2"
+                ecoli_simulation=simulation, database_service=database_service, correlation_id="corr-composite"
             )
 
-        fake_file_service.upload_file.assert_awaited_once()
+        # A single MNP sim job, gated on parca -- not chain-dispatch's N*G shape.
         assert job_id == JobId.ray("sim-456")
-        # parca -> sim(array) -> analysis: the analysis DAG node rides along.
-        assert mock_batch.submit_job.call_count == 3
-        parca_call, sim_call, _analysis_call = mock_batch.submit_job.call_args_list
-
-        # ParCa: unchanged -- still a 1-node MNP job, no dependency.
-        assert parca_call.kwargs["nodeOverrides"]["numNodes"] == 1
-        assert "dependsOn" not in parca_call.kwargs
-
-        # Sim: an Array job, NOT MNP -- no nodeOverrides at all.
-        assert "nodeOverrides" not in sim_call.kwargs
-        assert sim_call.kwargs["arrayProperties"] == {"size": 4}
-        assert sim_call.kwargs["jobQueue"] == "smscdk-vecoli-task-amd64"
-        # Plain dependency, NO "type" key -- real AWS Batch rejects {"type": "SEQUENTIAL"}
-        # combined with an explicit jobId when the submitting job itself sets
-        # arrayProperties (live error hit 2026-08-06: "Job Id cannot be set when
-        # dependency type is SEQUENTIAL"). Do not "simplify" this back to match
-        # _submit_mnp's shape -- that's the exact regression this assertion guards.
-        assert sim_call.kwargs["dependsOn"] == [{"jobId": "parca-123"}]
-
-        sim_env = _array_env(sim_call)
-        cmd = sim_env["ARRAY_JOB_CMD"]
-        assert "run_batch_baseline_ray.py" not in cmd
-        assert "run_phase0_xarray_ensemble.py" not in cmd
-        assert "aws s3 cp" in cmd and "/tmp/run_pbg.py" in cmd  # noqa: S108
-        assert "AWS_BATCH_JOB_ARRAY_INDEX" in cmd
-        # Exact match, not a substring check. sms-ecoli has no "ecoli_baseline" module
-        # at all -- two real pilot dispatches (2026-08-06) failed chasing that name
-        # before the real module (v2ecoli/composites/batch_baseline.py, decorated
-        # name="batch_baseline") was confirmed directly against the deployed sms-ecoli
-        # image at commit e38f742, never the separate/diverged local v2ecoli checkout.
-        assert "--composite-id v2ecoli.composites.batch_baseline.batch_baseline " in cmd
-        assert "PBG_CORE_BUILDER=v2ecoli.core:build_core" in cmd
-        assert sim_env["ARRAY_OUT_DIR"] == SIM_OUT_DIR
-        assert sim_env["ARRAY_OUT_S3"] == "s3://mybucket/vecoli-output/" + simulation.config.experiment_id + "/"
-
-        # Cache hand-off: sim stages exactly what parca produced (same ARRAY_*
-        # naming convention as the MNP path's RAY_* staging, renamed so the two
-        # dispatch paths' env vars can never be cross-wired).
-        parca_env = _env_of(parca_call)
-        assert sim_env["ARRAY_STAGE_S3"] == parca_env["RAY_OUT_S3"]
-        assert sim_env["ARRAY_STAGE_DIR"] == PARCA_CACHE_DIR
-
-        # Per-commit Array job-def, cloned from the CDK base with the image swapped
-        # (container jobs can't override the image via containerOverrides either --
-        # verified against the real AWS Batch API, same limitation as MNP).
-        simulator = await database_service.get_simulator(simulator_id=simulation.simulator_id)
-        assert simulator is not None
-        commit = simulator.git_commit_hash
-        assert sim_call.kwargs["jobDefinition"] == f"smscdk-ray-array-{commit}:1"
-        array_reg_calls = [
-            c for c in mock_batch.register_job_definition.call_args_list if c.kwargs["type"] == "container"
-        ]
-        assert len(array_reg_calls) == 1
-        assert array_reg_calls[0].kwargs["containerProperties"]["image"] == (
-            f"476270107793.dkr.ecr.us-gov-west-1.amazonaws.com/v2ecoli:{commit}"
-        )
-        # The CDK base's retryStrategy must survive the clone -- register_job_definition
-        # does not inherit it automatically from an existing revision.
-        assert array_reg_calls[0].kwargs["retryStrategy"] == {"attempts": 2}
-
-    async def test_submit_batch_baseline_single_seed_stays_on_mnp(
-        self,
-        experiment_request: "SimulationRequest",
-        database_service: "DatabaseServiceSQL",
-    ) -> None:
-        """AWS Batch array jobs require size>=2 (verified against the real API);
-        a single-seed batch_baseline request also has no parallelism to gain from
-        Array-izing, so it stays on the existing, already-correct MNP path."""
-        setattr(experiment_request.config, "n_init_sims", 1)  # noqa: B010
-        experiment_request.config.generations = 3
-        simulation = await database_service.insert_simulation(sim_request=experiment_request)
-
-        mock_batch = _fake_batch(["parca-123", "sim-456", "analysis-789"])
-        fake_file_service = AsyncMock()
-        fake_file_service.upload_file = AsyncMock()
-
-        service = SimulationServiceRay()
-        with (
-            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
-            patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
-            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
-            patch("viva_api.dependencies.get_file_service", return_value=fake_file_service),
-        ):
-            await service.submit_ecoli_simulation_job(
-                ecoli_simulation=simulation, database_service=database_service, correlation_id="corr-single"
-            )
-
-        _, sim_call, analysis_call = mock_batch.submit_job.call_args_list
+        assert mock_batch.submit_job.call_count == 2
+        parca_call, sim_call = mock_batch.submit_job.call_args_list
         assert "nodeOverrides" in sim_call.kwargs
         assert "arrayProperties" not in sim_call.kwargs
-        assert sim_call.kwargs["jobQueue"] == "smscdk-ray-mnp"
-        assert "--composite-id v2ecoli.composites.batch_baseline.batch_baseline " in _env_of(sim_call)["RAY_JOB_CMD"]
-        # An MNP sim job is NOT array-shaped, so the analysis node keeps the
-        # long-standing SEQUENTIAL dependency shape this path has always used.
-        assert analysis_call.kwargs["dependsOn"] == [{"jobId": "sim-456", "type": "SEQUENTIAL"}]
+        assert sim_call.kwargs["dependsOn"] == [{"jobId": "parca-123", "type": "SEQUENTIAL"}]
+        assert "run_comparison_ensemble.py" in _env_of(sim_call)["RAY_JOB_CMD"]
+        assert "--composite vecoli" in _env_of(sim_call)["RAY_JOB_CMD"]
+        assert parca_call.kwargs["nodeOverrides"]["numNodes"] == 1
 
 
 class TestAnalysisModulesFor:
@@ -473,107 +477,19 @@ class TestAnalysisCommand:
 @pytest.mark.asyncio
 class TestAnalysisDagNode:
     """Item 24: the analysis must fire from the pipeline DAG itself, with no
-    separate manual step and no external watcher."""
+    separate manual step and no external watcher.
 
-    async def test_analysis_job_depends_on_the_array_sim_and_is_recorded(
-        self,
-        experiment_request: "SimulationRequest",
-        database_service: "DatabaseServiceSQL",
-    ) -> None:
-        """REGRESSION (backlog item 24): before this, the Ray backend never read
-        `config.analysis_options` and submitted no analysis at all — a completed
-        remote simulation produced zero cd1_*/ptools_* artifacts until somebody ran
-        the CLI by hand. The analysis is now the DAG's third node, gated on the sim
-        job, and tracked in the same `analyses` table the on-demand trigger uses."""
-        setattr(experiment_request.config, "n_init_sims", 4)  # noqa: B010
-        experiment_request.config.generations = 3
-        simulation = await database_service.insert_simulation(sim_request=experiment_request)
-
-        mock_batch = _fake_batch(["parca-123", "sim-456", "analysis-789"])
-        fake_file_service = AsyncMock()
-        fake_file_service.upload_file = AsyncMock()
-
-        service = SimulationServiceRay()
-        with (
-            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
-            patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
-            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
-            patch("viva_api.dependencies.get_file_service", return_value=fake_file_service),
-        ):
-            await service.submit_ecoli_simulation_job(
-                ecoli_simulation=simulation, database_service=database_service, correlation_id="corr-analysis"
-            )
-
-        _parca_call, _sim_call, analysis_call = mock_batch.submit_job.call_args_list
-        experiment_id = simulation.config.experiment_id
-
-        # Gated on the SIM job (not ParCa): the sweep is only whole once every
-        # array child's output has landed in S3.
-        assert analysis_call.kwargs["dependsOn"] == [{"jobId": "sim-456"}]
-        # An array parent id under a SEQUENTIAL type is rejected by real AWS Batch —
-        # this is the shape that guard produces, and must not be "simplified" back.
-        assert "type" not in analysis_call.kwargs["dependsOn"][0]
-        assert analysis_call.kwargs["nodeOverrides"]["numNodes"] == 1
-
-        env = _env_of(analysis_call)
-        assert "run_standalone_analysis.py" in env["RAY_JOB_CMD"]
-        assert f"--out-uri s3://mybucket/vecoli-output/{experiment_id}" in env["RAY_JOB_CMD"]
-        assert "--n-seeds 4" in env["RAY_JOB_CMD"]
-        # No ParCa staging: sim_data is named explicitly as an S3 URI instead.
-        assert "RAY_STAGE_S3" not in env
-        assert "V2ECOLI_SIM_DATA=s3://mybucket/ray-parca-cache/" in env["RAY_JOB_CMD"]
-        assert analysis_call.kwargs["tags"]["Phase"] == "analysis"
-
-        # Tracked: GET /simulations/{id}/analyses and GET /analyses/{id}/status must
-        # both resolve an auto-triggered analysis, exactly like a hand-triggered one.
-        records = await database_service.list_analyses(simulation_id=simulation.database_id)
-        assert len(records) == 1
-        record = records[0]
-        assert record.backend == "ray"
-        assert record.job_id_ext == "analysis-789"
-        assert record.status == JobStatus.RUNNING
-        # result_uri is where the job's own _manifest.json lands — the S3-exists probe
-        # in handle_get_ray_analysis_status reads exactly this path.
-        assert record.result_uri == f"s3://mybucket/vecoli-output/{experiment_id}/analyses/{record.name}"
-        assert f"--analysis-name {record.name}" in env["RAY_JOB_CMD"]
-
-    async def test_configured_analysis_options_reach_the_analysis_job(
-        self,
-        experiment_request: "SimulationRequest",
-        database_service: "DatabaseServiceSQL",
-    ) -> None:
-        """REGRESSION: `config.analysis_options` (set by the run endpoint from the
-        caller's --analysis-options, and by the workbench from a study's
-        spec.analyses) was read by no Ray code path at all."""
-        from viva_api.simulation.models import AnalysisOptions
-
-        setattr(experiment_request.config, "n_init_sims", 4)  # noqa: B010
-        experiment_request.config.generations = 3
-        experiment_request.config.analysis_options = AnalysisOptions.model_validate({
-            "multiseed": {"cd1_fluxomics": {"generation_lower_bound": 5}}
-        })
-        simulation = await database_service.insert_simulation(sim_request=experiment_request)
-
-        mock_batch = _fake_batch(["parca-123", "sim-456", "analysis-789"])
-        fake_file_service = AsyncMock()
-        fake_file_service.upload_file = AsyncMock()
-
-        service = SimulationServiceRay()
-        with (
-            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
-            patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
-            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
-            patch("viva_api.dependencies.get_file_service", return_value=fake_file_service),
-        ):
-            await service.submit_ecoli_simulation_job(
-                ecoli_simulation=simulation, database_service=database_service, correlation_id="corr-opts"
-            )
-
-        cmd = _env_of(mock_batch.submit_job.call_args_list[2])["RAY_JOB_CMD"]
-        tokens = shlex.split(cmd.split("&&", 1)[1].replace("V2ECOLI_SIM_DATA=", "", 1))
-        assert json.loads(tokens[tokens.index("--modules") + 1]) == {
-            "multiseed": {"cd1_fluxomics": {"generation_lower_bound": 5}}
-        }
+    Originally this covered the canonical batch_baseline shape too (composite
+    is None, multiseed, multigenerational), reached through
+    submit_ecoli_simulation_job's own inline array-path analysis submission.
+    Backlog item 33 moved that shape's analysis trigger entirely to
+    submit_campaign_analysis (fired by the poller once every seed's chain is
+    terminal, not inline at submission time) -- submit_ecoli_simulation_job no
+    longer submits an analysis job for ANY shape it can still reach (the
+    comparison-ensemble and phase0 paths never did either). That coverage
+    moved to TestSubmitCampaignAnalysis, retargeted at the real mechanism;
+    only the single-generation "no analysis at all" guard still belongs here,
+    since it's still a submit_ecoli_simulation_job-level property."""
 
     async def test_no_analysis_node_for_the_single_generation_ensemble(
         self,
@@ -600,48 +516,6 @@ class TestAnalysisDagNode:
 
         assert mock_batch.submit_job.call_count == 2
         assert await database_service.list_analyses(simulation_id=simulation.database_id) == []
-
-    async def test_a_failed_analysis_submission_is_recorded_not_swallowed(
-        self,
-        experiment_request: "SimulationRequest",
-        database_service: "DatabaseServiceSQL",
-    ) -> None:
-        """The sim job is already running by then, so raising would orphan a real,
-        expensive job — but a silently-missing analysis is the exact failure mode
-        item 24 exists to eliminate. It must land as a FAILED row instead."""
-        setattr(experiment_request.config, "n_init_sims", 4)  # noqa: B010
-        experiment_request.config.generations = 3
-        simulation = await database_service.insert_simulation(sim_request=experiment_request)
-
-        mock_batch = _fake_batch(["parca-123", "sim-456"])
-        submits = [{"jobId": "parca-123"}, {"jobId": "sim-456"}]
-
-        def _submit(**kwargs: Any) -> dict[str, str]:
-            if submits:
-                return submits.pop(0)
-            raise RuntimeError("Batch said no")
-
-        mock_batch.submit_job.side_effect = _submit
-        fake_file_service = AsyncMock()
-        fake_file_service.upload_file = AsyncMock()
-
-        service = SimulationServiceRay()
-        with (
-            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
-            patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
-            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
-            patch("viva_api.dependencies.get_file_service", return_value=fake_file_service),
-        ):
-            job_id = await service.submit_ecoli_simulation_job(
-                ecoli_simulation=simulation, database_service=database_service, correlation_id="corr-fail"
-            )
-
-        # The simulation dispatch itself still succeeds and stays tracked.
-        assert job_id == JobId.ray("sim-456")
-        records = await database_service.list_analyses(simulation_id=simulation.database_id)
-        assert len(records) == 1
-        assert records[0].status == JobStatus.FAILED
-        assert "Batch said no" in (records[0].error_message or "")
 
 
 @pytest.mark.asyncio
@@ -950,84 +824,6 @@ class TestSimulationServiceRayBuild:
         assert "--vecoli-source" not in v2ecoli
 
 
-class TestArraySimCommand:
-    """_array_sim_command builds one Array child's run_pbg.py invocation."""
-
-    def test_shape(self) -> None:
-        service = SimulationServiceRay()
-        cmd = service._array_sim_command(
-            n_generations=3,
-            experiment_id="sim47-real-experiment",
-            runner_s3_uri="s3://mybucket/vecoli-output/sim47-real-experiment/run_pbg.py",
-        )
-        assert "run_batch_baseline_ray.py" not in cmd
-        assert "run_phase0_xarray_ensemble.py" not in cmd
-        assert "aws s3 cp s3://mybucket/vecoli-output/sim47-real-experiment/run_pbg.py /tmp/run_pbg.py" in cmd
-        assert "--composite-id v2ecoli.composites.batch_baseline.batch_baseline " in cmd
-        assert "PBG_CORE_BUILDER=v2ecoli.core:build_core" in cmd
-        assert "-n 1" in cmd
-        # base_seed is resolved by the shell at container-start time (AWS_BATCH_JOB_
-        # ARRAY_INDEX is only known once the container starts), not baked in here.
-        assert "BASE_SEED=$((0 + AWS_BATCH_JOB_ARRAY_INDEX))" in cmd
-
-    def test_base_seed_offset_propagates_into_the_arithmetic_expansion(self) -> None:
-        service = SimulationServiceRay()
-        cmd = service._array_sim_command(
-            n_generations=1, experiment_id="exp-1", runner_s3_uri="s3://b/run_pbg.py", base_seed_offset=100
-        )
-        assert "BASE_SEED=$((100 + AWS_BATCH_JOB_ARRAY_INDEX))" in cmd
-
-    def test_merge_produces_correct_overrides_and_is_safe_against_shell_metacharacters(self) -> None:
-        """Actually run the BASE_SEED/OVERRIDES merge prefix through bash + python3
-        (no mocking) with a hostile experiment_id -- experiment_id is a caller-
-        supplied, unconstrained string (no pattern validation at the model/API
-        boundary), so this proves the shlex-quoted static blob keeps arbitrary
-        content as DATA rather than shell syntax, AND that
-        AWS_BATCH_JOB_ARRAY_INDEX correctly resolves into the merged JSON --
-        the actual mechanism the entrypoint runs, not a re-derivation of it."""
-        service = SimulationServiceRay()
-        hostile = "exp'; touch /tmp/array-sim-command-injection-canary; echo '$(echo pwned)"
-        cmd = service._array_sim_command(
-            n_generations=5,
-            experiment_id=hostile,
-            runner_s3_uri="s3://mybucket/vecoli-output/exp/run_pbg.py",
-            base_seed_offset=10,
-        )
-        # Everything before "&& cd {V2ECOLI_DIR}" is the self-contained BASE_SEED/
-        # OVERRIDES merge -- safe to actually execute (arithmetic + one python3
-        # subprocess call, no aws/v2ecoli dependency).
-        merge_prefix = cmd.split(" && cd ", 1)[0]
-        canary = "/tmp/array-sim-command-injection-canary"  # noqa: S108
-        if os.path.exists(canary):
-            os.remove(canary)
-        bash = shutil.which("bash")
-        assert bash is not None, "bash not found on PATH"
-        try:
-            result = subprocess.run(  # noqa: S603 -- test-only, fixed literal args
-                [bash, "-c", merge_prefix + ' && printf "%s" "$OVERRIDES"'],
-                env={**os.environ, "AWS_BATCH_JOB_ARRAY_INDEX": "7"},
-                capture_output=True,
-                text=True,
-                timeout=10,
-            )
-            assert result.returncode == 0, result.stderr
-            assert not os.path.exists(canary), "hostile experiment_id executed as shell syntax, not data"
-            merged = json.loads(result.stdout)
-            assert merged == {
-                "n_seeds": 1,
-                "n_generations": 5,
-                "cache_dir": PARCA_CACHE_DIR,
-                "out_dir": SIM_OUT_DIR,
-                "experiment_id": hostile,
-                "analyses": "none",
-                "parallel": "",
-                "base_seed": 17,  # base_seed_offset(10) + AWS_BATCH_JOB_ARRAY_INDEX(7)
-            }
-        finally:
-            if os.path.exists(canary):
-                os.remove(canary)
-
-
 class TestSeedGenerationCommand:
     """_seed_generation_command builds ONE seed's ONE generation's command —
     replacing the per-generation-array design's own _wave_sim_command. Unlike
@@ -1208,81 +1004,6 @@ class TestEnsureMnpJobDef:
             jd = service._ensure_mnp_job_def(image, "abc1234")
         assert jd == "smscdk-ray-mnp-abc1234:5"
         mock_batch.register_job_definition.assert_not_called()
-
-
-class TestEnsureArrayJobDef:
-    """Per-commit Array job-def derivation. Container jobs can't override the image
-    via containerOverrides either (verified against the real AWS Batch API: only
-    EKS jobs' eksPropertiesOverride has an image field) -- same limitation as MNP,
-    just for a different reason, so this mirrors _ensure_mnp_job_def's shape."""
-
-    def test_reuses_existing_revision_for_same_image(self) -> None:
-        image = "476270107793.dkr.ecr.us-gov-west-1.amazonaws.com/v2ecoli:abc1234"
-        mock_batch = MagicMock()
-        mock_batch.describe_job_definitions.return_value = {
-            "jobDefinitions": [{"revision": 5, "containerProperties": {"image": image}}]
-        }
-        service = SimulationServiceRay()
-        with (
-            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
-            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
-        ):
-            jd = service._ensure_array_job_def(image, "abc1234")
-        assert jd == "smscdk-ray-array-abc1234:5"
-        mock_batch.register_job_definition.assert_not_called()
-
-    def test_clones_base_and_carries_forward_retry_strategy_and_platform_capabilities(self) -> None:
-        mock_batch = MagicMock()
-
-        def _describe(**kwargs: Any) -> dict[str, Any]:
-            if kwargs.get("jobDefinitionName") == "smscdk-ray-array":
-                return {
-                    "jobDefinitions": [
-                        {
-                            "revision": 3,
-                            "containerProperties": {
-                                "image": "old:tag",
-                                "resourceRequirements": [{"type": "VCPU", "value": "2"}],
-                            },
-                            "retryStrategy": {"attempts": 2},
-                            "platformCapabilities": ["EC2"],
-                        }
-                    ]
-                }
-            return {"jobDefinitions": []}  # per-commit: none yet
-
-        mock_batch.describe_job_definitions.side_effect = _describe
-        mock_batch.register_job_definition.side_effect = lambda **kw: {
-            "jobDefinitionName": kw["jobDefinitionName"],
-            "revision": 1,
-        }
-        service = SimulationServiceRay()
-        new_image = "476270107793.dkr.ecr.us-gov-west-1.amazonaws.com/v2ecoli:def5678"
-        with (
-            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
-            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
-        ):
-            jd = service._ensure_array_job_def(new_image, "def5678")
-        assert jd == "smscdk-ray-array-def5678:1"
-
-        reg = mock_batch.register_job_definition.call_args
-        assert reg.kwargs["type"] == "container"
-        assert reg.kwargs["containerProperties"]["image"] == new_image
-        # Everything else the base sets survives the clone, not just the image.
-        assert reg.kwargs["containerProperties"]["resourceRequirements"] == [{"type": "VCPU", "value": "2"}]
-        assert reg.kwargs["retryStrategy"] == {"attempts": 2}
-        assert reg.kwargs["platformCapabilities"] == ["EC2"]
-
-    def test_raises_if_base_job_def_missing(self) -> None:
-        mock_batch = MagicMock()
-        mock_batch.describe_job_definitions.return_value = {"jobDefinitions": []}
-        service = SimulationServiceRay()
-        with (
-            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
-            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
-            pytest.raises(RuntimeError, match="Base Array job definition"),
-        ):
-            service._ensure_array_job_def("some:image", "abc1234")
 
 
 @pytest.mark.asyncio
@@ -1694,3 +1415,75 @@ class TestSubmitCampaignAnalysis:
             )
         env = _env_of(mock_batch.submit_job.call_args_list[0])
         assert "--n-seeds 1000" in env["RAY_JOB_CMD"]
+
+    async def test_configured_analysis_options_reach_the_analysis_job(
+        self,
+        experiment_request: "SimulationRequest",
+        database_service: "DatabaseServiceSQL",
+    ) -> None:
+        """REGRESSION (item 24, retargeted for backlog item 33): config.
+        analysis_options (set by the run endpoint from the caller's
+        --analysis-options, and by the workbench from a study's spec.analyses)
+        must reach the analysis job's --modules flag. Originally verified
+        through submit_ecoli_simulation_job's own inline array-path analysis
+        submission (now removed -- that shape's analysis fires exclusively
+        through submit_campaign_analysis, exercised directly here)."""
+        from viva_api.simulation.models import AnalysisOptions
+
+        experiment_request.config.analysis_options = AnalysisOptions.model_validate({
+            "multiseed": {"cd1_fluxomics": {"generation_lower_bound": 5}}
+        })
+        simulation = await database_service.insert_simulation(sim_request=experiment_request)
+        mock_batch = _fake_batch(["analysis-789"])
+        service = SimulationServiceRay()
+        with (
+            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
+            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
+        ):
+            await service.submit_campaign_analysis(
+                simulation=simulation,
+                database_service=database_service,
+                commit="abc1234",
+                total_n_seeds=4,
+                n_generations=3,
+            )
+        cmd = _env_of(mock_batch.submit_job.call_args_list[0])["RAY_JOB_CMD"]
+        tokens = shlex.split(cmd.split("&&", 1)[1].replace("V2ECOLI_SIM_DATA=", "", 1))
+        assert json.loads(tokens[tokens.index("--modules") + 1]) == {
+            "multiseed": {"cd1_fluxomics": {"generation_lower_bound": 5}}
+        }
+
+    async def test_a_failed_analysis_submission_is_recorded_not_swallowed(
+        self,
+        experiment_request: "SimulationRequest",
+        database_service: "DatabaseServiceSQL",
+    ) -> None:
+        """By the time this runs, every seed chain the poller was watching has
+        already reached a terminal state -- raising here would just lose the
+        analysis silently. It must land as a FAILED analyses-table row
+        instead (item 24's guarantee, retargeted for backlog item 33: this is
+        now the canonical shape's own analysis trigger, replacing
+        submit_ecoli_simulation_job's removed inline path)."""
+        simulation = await database_service.insert_simulation(sim_request=experiment_request)
+        mock_batch = _fake_batch([])
+        mock_batch.submit_job.side_effect = RuntimeError("Batch said no")
+
+        service = SimulationServiceRay()
+        with (
+            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
+            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
+        ):
+            result = await service.submit_campaign_analysis(
+                simulation=simulation,
+                database_service=database_service,
+                commit="abc1234",
+                total_n_seeds=4,
+                n_generations=3,
+            )
+        assert result is None
+        records = await database_service.list_analyses(simulation_id=simulation.database_id)
+        assert len(records) == 1
+        assert records[0].status == JobStatus.FAILED
+        assert "Batch said no" in (records[0].error_message or "")

--- a/tests/simulation/test_ray_backend.py
+++ b/tests/simulation/test_ray_backend.py
@@ -791,7 +791,7 @@ class TestGetWaveResult:
         mock_batch.describe_jobs.return_value = {
             "jobs": [{"jobId": "wave-1", "arrayProperties": {"size": 2, "statusSummary": {"SUCCEEDED": 2}}}]
         }
-        pages = [
+        pages: list[dict[str, Any]] = [
             {"jobSummaryList": [{"arrayProperties": {"index": 0}}], "nextToken": "page2"},
             {"jobSummaryList": [{"arrayProperties": {"index": 1}}]},
         ]

--- a/tests/simulation/test_scheduler.py
+++ b/tests/simulation/test_scheduler.py
@@ -5,6 +5,7 @@ import string
 import tempfile
 import uuid
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -32,6 +33,7 @@ from viva_api.simulation.models import (
     SimulationRequest,
     WorkerEventMessagePayload,
 )
+from viva_api.simulation.simulation_service_ray import WavePollResult
 
 
 def is_ci_environment() -> bool:
@@ -78,6 +80,236 @@ async def insert_job(database_service: DatabaseServiceSQL, slurmjobid: int) -> t
     )
 
     return simulation, slurm_job, hpcrun
+
+
+async def insert_wave_job(
+    database_service: DatabaseServiceSQL,
+    *,
+    job_id_ext: str,
+    wave_index: int,
+    wave_seed_indices: list[int],
+    n_generations: int,
+    n_seeds: int | None = None,
+) -> tuple[Simulation, HpcRun]:
+    """Insert a Simulation + a wave-shaped HpcRun row (backlog item 33), the
+    fixture shape JobScheduler.update_wave_jobs/_advance_wave consumes."""
+    latest_commit_hash = str(uuid.uuid4())
+    simulator = await database_service.insert_simulator(
+        git_commit_hash=latest_commit_hash,
+        git_repo_url="https://github.com/CovertLabEcoli/sms-ecoli",
+        git_branch="main",
+    )
+    parca_dataset = await database_service.insert_parca_dataset(
+        parca_dataset_request=ParcaDatasetRequest(simulator_version=simulator, parca_config=ParcaOptions())
+    )
+    experiment_id = f"test-wave-job-{str(uuid.uuid4())[:8]!s}"
+    config = SimulationConfig(experiment_id=experiment_id, generations=n_generations)
+    if n_seeds is not None:
+        setattr(config, "n_init_sims", n_seeds)  # noqa: B010
+    simulation_request = SimulationRequest(
+        simulation_config_filename="config_filename",
+        experiment_id=experiment_id,
+        parca_dataset_id=parca_dataset.database_id,
+        simulator_id=simulator.database_id,
+        config=config,
+    )
+    simulation = await database_service.insert_simulation(sim_request=simulation_request)
+    hpcrun = await database_service.insert_hpcrun(
+        job_id=JobId.ray(job_id_ext),
+        job_type=JobType.SIMULATION,
+        ref_id=simulation.database_id,
+        correlation_id=f"wave-{wave_index}-{experiment_id}",
+        wave_index=wave_index,
+        wave_seed_indices=wave_seed_indices,
+    )
+    return simulation, hpcrun
+
+
+class TestAdvanceWave:
+    """JobScheduler._advance_wave / update_wave_jobs (backlog item 33): the
+    wave-polling path extending the existing poll-loop + DB-state pattern.
+    simulation_service_ray is mocked here (its own AWS Batch call shapes are
+    proven for real in TestGetWaveResult/TestSubmitNextWave,
+    tests/simulation/test_ray_backend.py) so these tests isolate JobScheduler's
+    OWN orchestration decisions against a REAL Postgres database (testcontainers)."""
+
+    @pytest.mark.asyncio
+    async def test_update_wave_jobs_is_a_noop_without_a_ray_service(self) -> None:
+        """SLURM-only deployments wire simulation_service_ray=None -- the poll
+        loop must not touch the database at all in that case, not just skip
+        the AWS calls."""
+        mock_database = AsyncMock()
+        scheduler = JobScheduler(
+            messaging_service=MagicMock(),
+            database_service=mock_database,
+            simulation_service_ray=None,
+        )
+        await scheduler.update_wave_jobs()
+        mock_database.list_active_wave_hpcruns.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_not_terminal_leaves_the_wave_untouched(self, database_service: DatabaseServiceSQL) -> None:
+        _simulation, hpcrun = await insert_wave_job(
+            database_service,
+            job_id_ext="wave-not-terminal",
+            wave_index=0,
+            wave_seed_indices=[0, 1, 2, 3],
+            n_generations=3,
+        )
+        mock_ray = MagicMock()
+        mock_ray.get_wave_result.return_value = WavePollResult(terminal=False)
+        scheduler = JobScheduler(
+            messaging_service=MagicMock(), database_service=database_service, simulation_service_ray=mock_ray
+        )
+
+        await scheduler._advance_wave(hpcrun, mock_ray)
+
+        mock_ray.get_wave_result.assert_called_once_with("wave-not-terminal")
+        mock_ray.submit_next_wave.assert_not_called()
+        refetched = await database_service.get_hpcrun(hpcrun.database_id)
+        assert refetched is not None
+        assert refetched.status == JobStatus.RUNNING  # unchanged from insert_hpcrun's default
+
+    @pytest.mark.asyncio
+    async def test_terminal_with_survivors_submits_the_next_wave_with_sparse_remap(
+        self, database_service: DatabaseServiceSQL
+    ) -> None:
+        """seed_indices=[4, 5, 9, 10, 14], succeeded_local_indices=[0, 2, 4] ->
+        survivors must be [4, 9, 14] (the REAL seeds at those positions), never
+        [0, 2, 4] (the local array positions themselves)."""
+        simulation, hpcrun = await insert_wave_job(
+            database_service,
+            job_id_ext="wave-partial",
+            wave_index=1,
+            wave_seed_indices=[4, 5, 9, 10, 14],
+            n_generations=5,
+            n_seeds=30,
+        )
+        mock_ray = MagicMock()
+        mock_ray.get_wave_result.return_value = WavePollResult(
+            terminal=True, succeeded_local_indices=[0, 2, 4], failed_local_indices=[1, 3]
+        )
+        mock_ray.submit_next_wave = AsyncMock(return_value="wave2-job-id")
+        scheduler = JobScheduler(
+            messaging_service=MagicMock(), database_service=database_service, simulation_service_ray=mock_ray
+        )
+
+        await scheduler._advance_wave(hpcrun, mock_ray)
+
+        mock_ray.submit_next_wave.assert_awaited_once()
+        call_kwargs = mock_ray.submit_next_wave.call_args.kwargs
+        assert call_kwargs["generation_index"] == 2
+        assert call_kwargs["seed_indices"] == [4, 9, 14]
+        assert call_kwargs["total_n_seeds"] == 30
+        assert call_kwargs["n_generations"] == 5
+        assert call_kwargs["simulation"].database_id == simulation.database_id
+        simulator = await database_service.get_simulator(simulation.simulator_id)
+        assert simulator is not None
+        assert call_kwargs["commit"] == simulator.git_commit_hash
+
+        refetched = await database_service.get_hpcrun(hpcrun.database_id)
+        assert refetched is not None
+        assert refetched.status == JobStatus.COMPLETED
+        assert refetched.error_message is None
+
+    @pytest.mark.asyncio
+    async def test_terminal_final_wave_does_not_submit_a_next_wave(self, database_service: DatabaseServiceSQL) -> None:
+        """generation next_generation >= n_generations means THIS wave (index
+        n_generations - 1) was already the campaign's final wave -- its
+        analysis node was submitted alongside IT at submission time
+        (SimulationServiceRay._submit_wave_and_maybe_analysis), not here."""
+        _simulation, hpcrun = await insert_wave_job(
+            database_service,
+            job_id_ext="wave-final",
+            wave_index=2,
+            wave_seed_indices=[4, 9],
+            n_generations=3,  # generation 2 IS the final generation (0, 1, 2)
+            n_seeds=30,
+        )
+        mock_ray = MagicMock()
+        mock_ray.get_wave_result.return_value = WavePollResult(terminal=True, succeeded_local_indices=[0, 1])
+        mock_ray.submit_next_wave = AsyncMock()
+        scheduler = JobScheduler(
+            messaging_service=MagicMock(), database_service=database_service, simulation_service_ray=mock_ray
+        )
+
+        await scheduler._advance_wave(hpcrun, mock_ray)
+
+        mock_ray.submit_next_wave.assert_not_called()
+        refetched = await database_service.get_hpcrun(hpcrun.database_id)
+        assert refetched is not None
+        assert refetched.status == JobStatus.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_zero_survivors_marks_the_campaign_failed(self, database_service: DatabaseServiceSQL) -> None:
+        _simulation, hpcrun = await insert_wave_job(
+            database_service,
+            job_id_ext="wave-wiped-out",
+            wave_index=1,
+            wave_seed_indices=[4, 5, 9],
+            n_generations=5,
+        )
+        mock_ray = MagicMock()
+        mock_ray.get_wave_result.return_value = WavePollResult(terminal=True, failed_local_indices=[0, 1, 2])
+        mock_ray.submit_next_wave = AsyncMock()
+        scheduler = JobScheduler(
+            messaging_service=MagicMock(), database_service=database_service, simulation_service_ray=mock_ray
+        )
+
+        await scheduler._advance_wave(hpcrun, mock_ray)
+
+        mock_ray.submit_next_wave.assert_not_called()
+        refetched = await database_service.get_hpcrun(hpcrun.database_id)
+        assert refetched is not None
+        assert refetched.status == JobStatus.FAILED
+        assert refetched.error_message is not None and "zero seeds survived" in refetched.error_message
+
+    @pytest.mark.asyncio
+    async def test_update_wave_jobs_processes_every_active_wave_row(self, database_service: DatabaseServiceSQL) -> None:
+        """End-to-end through update_wave_jobs (not calling _advance_wave
+        directly): two independent wave campaigns, each gets polled and
+        advanced correctly, using list_active_wave_hpcruns's real WHERE
+        clause (status IN (PENDING, RUNNING) AND wave_index IS NOT NULL)."""
+        _sim_a, hpcrun_a = await insert_wave_job(
+            database_service,
+            job_id_ext="camp-a-wave0",
+            wave_index=0,
+            wave_seed_indices=[0, 1],
+            n_generations=2,
+            n_seeds=2,
+        )
+        _sim_b, hpcrun_b = await insert_wave_job(
+            database_service,
+            job_id_ext="camp-b-wave0",
+            wave_index=0,
+            wave_seed_indices=[0, 1, 2],
+            n_generations=2,
+            n_seeds=3,
+        )
+
+        def _wave_result(job_id: str) -> WavePollResult:
+            if job_id == "camp-a-wave0":
+                return WavePollResult(terminal=True, succeeded_local_indices=[0, 1])
+            return WavePollResult(terminal=False)
+
+        mock_ray = MagicMock()
+        mock_ray.get_wave_result.side_effect = _wave_result
+        mock_ray.submit_next_wave = AsyncMock(return_value="camp-a-wave1")
+        scheduler = JobScheduler(
+            messaging_service=MagicMock(), database_service=database_service, simulation_service_ray=mock_ray
+        )
+
+        await scheduler.update_wave_jobs()
+
+        # Campaign A: terminal, generation 1 of 2 is final -> next wave submitted.
+        mock_ray.submit_next_wave.assert_awaited_once()
+        assert mock_ray.submit_next_wave.call_args.kwargs["generation_index"] == 1
+        refetched_a = await database_service.get_hpcrun(hpcrun_a.database_id)
+        assert refetched_a is not None and refetched_a.status == JobStatus.COMPLETED
+
+        # Campaign B: not terminal -> left untouched.
+        refetched_b = await database_service.get_hpcrun(hpcrun_b.database_id)
+        assert refetched_b is not None and refetched_b.status == JobStatus.RUNNING
 
 
 @pytest.mark.integration

--- a/tests/simulation/test_scheduler.py
+++ b/tests/simulation/test_scheduler.py
@@ -33,7 +33,7 @@ from viva_api.simulation.models import (
     SimulationRequest,
     WorkerEventMessagePayload,
 )
-from viva_api.simulation.simulation_service_ray import WavePollResult
+from viva_api.simulation.simulation_service_ray import ChainCampaignPollResult
 
 
 def is_ci_environment() -> bool:
@@ -82,17 +82,17 @@ async def insert_job(database_service: DatabaseServiceSQL, slurmjobid: int) -> t
     return simulation, slurm_job, hpcrun
 
 
-async def insert_wave_job(
+async def insert_chain_campaign_job(
     database_service: DatabaseServiceSQL,
     *,
     job_id_ext: str,
-    wave_index: int,
-    wave_seed_indices: list[int],
-    n_generations: int,
+    chain_n_generations: int,
+    chain_final_job_ids: list[str],
     n_seeds: int | None = None,
 ) -> tuple[Simulation, HpcRun]:
-    """Insert a Simulation + a wave-shaped HpcRun row (backlog item 33), the
-    fixture shape JobScheduler.update_wave_jobs/_advance_wave consumes."""
+    """Insert a Simulation + a chain-dispatch-campaign-shaped HpcRun row
+    (backlog item 33 rework), the fixture shape
+    JobScheduler.update_chain_campaigns/_advance_chain_campaign consumes."""
     latest_commit_hash = str(uuid.uuid4())
     simulator = await database_service.insert_simulator(
         git_commit_hash=latest_commit_hash,
@@ -102,8 +102,8 @@ async def insert_wave_job(
     parca_dataset = await database_service.insert_parca_dataset(
         parca_dataset_request=ParcaDatasetRequest(simulator_version=simulator, parca_config=ParcaOptions())
     )
-    experiment_id = f"test-wave-job-{str(uuid.uuid4())[:8]!s}"
-    config = SimulationConfig(experiment_id=experiment_id, generations=n_generations)
+    experiment_id = f"test-chain-campaign-{str(uuid.uuid4())[:8]!s}"
+    config = SimulationConfig(experiment_id=experiment_id, generations=chain_n_generations)
     if n_seeds is not None:
         setattr(config, "n_init_sims", n_seeds)  # noqa: B010
     simulation_request = SimulationRequest(
@@ -118,23 +118,25 @@ async def insert_wave_job(
         job_id=JobId.ray(job_id_ext),
         job_type=JobType.SIMULATION,
         ref_id=simulation.database_id,
-        correlation_id=f"wave-{wave_index}-{experiment_id}",
-        wave_index=wave_index,
-        wave_seed_indices=wave_seed_indices,
+        correlation_id=f"chain-campaign-{experiment_id}",
+        chain_n_generations=chain_n_generations,
+        chain_final_job_ids=chain_final_job_ids,
     )
     return simulation, hpcrun
 
 
-class TestAdvanceWave:
-    """JobScheduler._advance_wave / update_wave_jobs (backlog item 33): the
-    wave-polling path extending the existing poll-loop + DB-state pattern.
+class TestAdvanceChainCampaign:
+    """JobScheduler._advance_chain_campaign / update_chain_campaigns (backlog
+    item 33 rework — individual per-seed job chains, replacing the
+    per-generation-array design's own TestAdvanceWave): the analysis-fan-in
+    polling path extending the existing poll-loop + DB-state pattern.
     simulation_service_ray is mocked here (its own AWS Batch call shapes are
-    proven for real in TestGetWaveResult/TestSubmitNextWave,
+    proven for real in TestGetChainCampaignResult/TestSubmitCampaignAnalysis,
     tests/simulation/test_ray_backend.py) so these tests isolate JobScheduler's
     OWN orchestration decisions against a REAL Postgres database (testcontainers)."""
 
     @pytest.mark.asyncio
-    async def test_update_wave_jobs_is_a_noop_without_a_ray_service(self) -> None:
+    async def test_update_chain_campaigns_is_a_noop_without_a_ray_service(self) -> None:
         """SLURM-only deployments wire simulation_service_ray=None -- the poll
         loop must not touch the database at all in that case, not just skip
         the AWS calls."""
@@ -144,62 +146,55 @@ class TestAdvanceWave:
             database_service=mock_database,
             simulation_service_ray=None,
         )
-        await scheduler.update_wave_jobs()
-        mock_database.list_active_wave_hpcruns.assert_not_called()
+        await scheduler.update_chain_campaigns()
+        mock_database.list_active_chain_campaigns.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_not_terminal_leaves_the_wave_untouched(self, database_service: DatabaseServiceSQL) -> None:
-        _simulation, hpcrun = await insert_wave_job(
+    async def test_not_terminal_leaves_the_campaign_untouched(self, database_service: DatabaseServiceSQL) -> None:
+        _simulation, hpcrun = await insert_chain_campaign_job(
             database_service,
-            job_id_ext="wave-not-terminal",
-            wave_index=0,
-            wave_seed_indices=[0, 1, 2, 3],
-            n_generations=3,
+            job_id_ext="parca-not-terminal",
+            chain_n_generations=3,
+            chain_final_job_ids=["s0-final", "s1-final", "s2-final", "s3-final"],
         )
         mock_ray = MagicMock()
-        mock_ray.get_wave_result.return_value = WavePollResult(terminal=False)
+        mock_ray.get_chain_campaign_result.return_value = ChainCampaignPollResult(terminal=False)
         scheduler = JobScheduler(
             messaging_service=MagicMock(), database_service=database_service, simulation_service_ray=mock_ray
         )
 
-        await scheduler._advance_wave(hpcrun, mock_ray)
+        await scheduler._advance_chain_campaign(hpcrun, mock_ray)
 
-        mock_ray.get_wave_result.assert_called_once_with("wave-not-terminal")
-        mock_ray.submit_next_wave.assert_not_called()
+        mock_ray.get_chain_campaign_result.assert_called_once_with(["s0-final", "s1-final", "s2-final", "s3-final"])
+        mock_ray.submit_campaign_analysis.assert_not_called()
         refetched = await database_service.get_hpcrun(hpcrun.database_id)
         assert refetched is not None
         assert refetched.status == JobStatus.RUNNING  # unchanged from insert_hpcrun's default
 
     @pytest.mark.asyncio
-    async def test_terminal_with_survivors_submits_the_next_wave_with_sparse_remap(
+    async def test_terminal_with_at_least_one_success_submits_the_analysis(
         self, database_service: DatabaseServiceSQL
     ) -> None:
-        """seed_indices=[4, 5, 9, 10, 14], succeeded_local_indices=[0, 2, 4] ->
-        survivors must be [4, 9, 14] (the REAL seeds at those positions), never
-        [0, 2, 4] (the local array positions themselves)."""
-        simulation, hpcrun = await insert_wave_job(
+        simulation, hpcrun = await insert_chain_campaign_job(
             database_service,
-            job_id_ext="wave-partial",
-            wave_index=1,
-            wave_seed_indices=[4, 5, 9, 10, 14],
-            n_generations=5,
+            job_id_ext="parca-partial",
+            chain_n_generations=5,
+            chain_final_job_ids=["s0-final", "s1-final", "s2-final"],
             n_seeds=30,
         )
         mock_ray = MagicMock()
-        mock_ray.get_wave_result.return_value = WavePollResult(
-            terminal=True, succeeded_local_indices=[0, 2, 4], failed_local_indices=[1, 3]
+        mock_ray.get_chain_campaign_result.return_value = ChainCampaignPollResult(
+            terminal=True, succeeded_job_ids=["s0-final", "s2-final"], failed_job_ids=["s1-final"]
         )
-        mock_ray.submit_next_wave = AsyncMock(return_value="wave2-job-id")
+        mock_ray.submit_campaign_analysis = AsyncMock(return_value="analysis-job-id")
         scheduler = JobScheduler(
             messaging_service=MagicMock(), database_service=database_service, simulation_service_ray=mock_ray
         )
 
-        await scheduler._advance_wave(hpcrun, mock_ray)
+        await scheduler._advance_chain_campaign(hpcrun, mock_ray)
 
-        mock_ray.submit_next_wave.assert_awaited_once()
-        call_kwargs = mock_ray.submit_next_wave.call_args.kwargs
-        assert call_kwargs["generation_index"] == 2
-        assert call_kwargs["seed_indices"] == [4, 9, 14]
+        mock_ray.submit_campaign_analysis.assert_awaited_once()
+        call_kwargs = mock_ray.submit_campaign_analysis.call_args.kwargs
         assert call_kwargs["total_n_seeds"] == 30
         assert call_kwargs["n_generations"] == 5
         assert call_kwargs["simulation"].database_id == simulation.database_id
@@ -213,97 +208,121 @@ class TestAdvanceWave:
         assert refetched.error_message is None
 
     @pytest.mark.asyncio
-    async def test_terminal_final_wave_does_not_submit_a_next_wave(self, database_service: DatabaseServiceSQL) -> None:
-        """generation next_generation >= n_generations means THIS wave (index
-        n_generations - 1) was already the campaign's final wave -- its
-        analysis node was submitted alongside IT at submission time
-        (SimulationServiceRay._submit_wave_and_maybe_analysis), not here."""
-        _simulation, hpcrun = await insert_wave_job(
+    async def test_zero_succeeded_marks_the_campaign_failed_no_analysis(
+        self, database_service: DatabaseServiceSQL
+    ) -> None:
+        _simulation, hpcrun = await insert_chain_campaign_job(
             database_service,
-            job_id_ext="wave-final",
-            wave_index=2,
-            wave_seed_indices=[4, 9],
-            n_generations=3,  # generation 2 IS the final generation (0, 1, 2)
-            n_seeds=30,
+            job_id_ext="parca-wiped-out",
+            chain_n_generations=5,
+            chain_final_job_ids=["s0-final", "s1-final", "s2-final"],
         )
         mock_ray = MagicMock()
-        mock_ray.get_wave_result.return_value = WavePollResult(terminal=True, succeeded_local_indices=[0, 1])
-        mock_ray.submit_next_wave = AsyncMock()
+        mock_ray.get_chain_campaign_result.return_value = ChainCampaignPollResult(
+            terminal=True, failed_job_ids=["s0-final", "s1-final", "s2-final"]
+        )
+        mock_ray.submit_campaign_analysis = AsyncMock()
         scheduler = JobScheduler(
             messaging_service=MagicMock(), database_service=database_service, simulation_service_ray=mock_ray
         )
 
-        await scheduler._advance_wave(hpcrun, mock_ray)
+        await scheduler._advance_chain_campaign(hpcrun, mock_ray)
 
-        mock_ray.submit_next_wave.assert_not_called()
-        refetched = await database_service.get_hpcrun(hpcrun.database_id)
-        assert refetched is not None
-        assert refetched.status == JobStatus.COMPLETED
-
-    @pytest.mark.asyncio
-    async def test_zero_survivors_marks_the_campaign_failed(self, database_service: DatabaseServiceSQL) -> None:
-        _simulation, hpcrun = await insert_wave_job(
-            database_service,
-            job_id_ext="wave-wiped-out",
-            wave_index=1,
-            wave_seed_indices=[4, 5, 9],
-            n_generations=5,
-        )
-        mock_ray = MagicMock()
-        mock_ray.get_wave_result.return_value = WavePollResult(terminal=True, failed_local_indices=[0, 1, 2])
-        mock_ray.submit_next_wave = AsyncMock()
-        scheduler = JobScheduler(
-            messaging_service=MagicMock(), database_service=database_service, simulation_service_ray=mock_ray
-        )
-
-        await scheduler._advance_wave(hpcrun, mock_ray)
-
-        mock_ray.submit_next_wave.assert_not_called()
+        mock_ray.submit_campaign_analysis.assert_not_called()
         refetched = await database_service.get_hpcrun(hpcrun.database_id)
         assert refetched is not None
         assert refetched.status == JobStatus.FAILED
-        assert refetched.error_message is not None and "zero seeds survived" in refetched.error_message
+        assert refetched.error_message is not None and "zero seed chains succeeded" in refetched.error_message
 
     @pytest.mark.asyncio
-    async def test_update_wave_jobs_processes_every_active_wave_row(self, database_service: DatabaseServiceSQL) -> None:
-        """End-to-end through update_wave_jobs (not calling _advance_wave
-        directly): two independent wave campaigns, each gets polled and
-        advanced correctly, using list_active_wave_hpcruns's real WHERE
-        clause (status IN (PENDING, RUNNING) AND wave_index IS NOT NULL)."""
-        _sim_a, hpcrun_a = await insert_wave_job(
+    async def test_terminal_with_mixed_results_only_updates_the_campaign_row_never_individual_jobs(self) -> None:
+        """A permanently-failed seed's own final job is ALREADY FAILED via AWS
+        Batch's own dependency-failure propagation (an earlier generation in
+        its chain failed, so the job(s) depending on it auto-transitioned to
+        FAILED with no orchestrator action) -- this method must not duplicate
+        or fight that by writing any PER-JOB status itself. The only database
+        write here is to the campaign's OWN tracking row, exactly once."""
+        mock_database = AsyncMock()
+        mock_database.get_simulation = AsyncMock(
+            return_value=MagicMock(
+                database_id=1,
+                simulator_id=2,
+                config=MagicMock(generations=3, experiment_id="exp"),
+                num_seeds=3,
+            )
+        )
+        mock_database.get_simulator = AsyncMock(return_value=MagicMock(git_commit_hash="abc1234"))
+        campaign = HpcRun(
+            database_id=99,
+            job_id=JobId.ray("parca-1"),
+            correlation_id="chain-campaign-exp",
+            job_type=JobType.SIMULATION,
+            ref_id=1,
+            status=JobStatus.RUNNING,
+            chain_n_generations=3,
+            chain_final_job_ids=["s0-final", "s1-final", "s2-final"],
+        )
+        mock_ray = MagicMock()
+        mock_ray.get_chain_campaign_result.return_value = ChainCampaignPollResult(
+            terminal=True, succeeded_job_ids=["s0-final", "s2-final"], failed_job_ids=["s1-final"]
+        )
+        mock_ray.submit_campaign_analysis = AsyncMock(return_value="analysis-1")
+        scheduler = JobScheduler(
+            messaging_service=MagicMock(), database_service=mock_database, simulation_service_ray=mock_ray
+        )
+
+        await scheduler._advance_chain_campaign(campaign, mock_ray)
+
+        # Exactly ONE status write -- the campaign row itself, never a
+        # per-seed job (there is no per-job update_hpcrun_status call to
+        # find here at all: the failed seed's job id never appears as an
+        # hpcrun_id argument anywhere).
+        mock_database.update_hpcrun_status.assert_awaited_once()
+        call_kwargs = mock_database.update_hpcrun_status.call_args.kwargs
+        assert call_kwargs["hpcrun_id"] == 99
+        assert call_kwargs["update"].status == JobStatus.COMPLETED
+        mock_ray.submit_campaign_analysis.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_update_chain_campaigns_processes_every_active_campaign_row(
+        self, database_service: DatabaseServiceSQL
+    ) -> None:
+        """End-to-end through update_chain_campaigns (not calling
+        _advance_chain_campaign directly): two independent chain-dispatch
+        campaigns, each gets polled and advanced correctly, using
+        list_active_chain_campaigns's real WHERE clause (status IN (PENDING,
+        RUNNING) AND chain_n_generations IS NOT NULL)."""
+        _sim_a, hpcrun_a = await insert_chain_campaign_job(
             database_service,
-            job_id_ext="camp-a-wave0",
-            wave_index=0,
-            wave_seed_indices=[0, 1],
-            n_generations=2,
+            job_id_ext="camp-a-parca",
+            chain_n_generations=2,
+            chain_final_job_ids=["camp-a-s0-final", "camp-a-s1-final"],
             n_seeds=2,
         )
-        _sim_b, hpcrun_b = await insert_wave_job(
+        _sim_b, hpcrun_b = await insert_chain_campaign_job(
             database_service,
-            job_id_ext="camp-b-wave0",
-            wave_index=0,
-            wave_seed_indices=[0, 1, 2],
-            n_generations=2,
+            job_id_ext="camp-b-parca",
+            chain_n_generations=2,
+            chain_final_job_ids=["camp-b-s0-final", "camp-b-s1-final", "camp-b-s2-final"],
             n_seeds=3,
         )
 
-        def _wave_result(job_id: str) -> WavePollResult:
-            if job_id == "camp-a-wave0":
-                return WavePollResult(terminal=True, succeeded_local_indices=[0, 1])
-            return WavePollResult(terminal=False)
+        def _chain_result(job_ids: list[str]) -> ChainCampaignPollResult:
+            if job_ids == ["camp-a-s0-final", "camp-a-s1-final"]:
+                return ChainCampaignPollResult(terminal=True, succeeded_job_ids=list(job_ids))
+            return ChainCampaignPollResult(terminal=False)
 
         mock_ray = MagicMock()
-        mock_ray.get_wave_result.side_effect = _wave_result
-        mock_ray.submit_next_wave = AsyncMock(return_value="camp-a-wave1")
+        mock_ray.get_chain_campaign_result.side_effect = _chain_result
+        mock_ray.submit_campaign_analysis = AsyncMock(return_value="camp-a-analysis")
         scheduler = JobScheduler(
             messaging_service=MagicMock(), database_service=database_service, simulation_service_ray=mock_ray
         )
 
-        await scheduler.update_wave_jobs()
+        await scheduler.update_chain_campaigns()
 
-        # Campaign A: terminal, generation 1 of 2 is final -> next wave submitted.
-        mock_ray.submit_next_wave.assert_awaited_once()
-        assert mock_ray.submit_next_wave.call_args.kwargs["generation_index"] == 1
+        # Campaign A: terminal, at least one success -> analysis submitted.
+        mock_ray.submit_campaign_analysis.assert_awaited_once()
         refetched_a = await database_service.get_hpcrun(hpcrun_a.database_id)
         assert refetched_a is not None and refetched_a.status == JobStatus.COMPLETED
 

--- a/uv.lock
+++ b/uv.lock
@@ -3655,7 +3655,7 @@ wheels = [
 
 [[package]]
 name = "viva-api"
-version = "0.9.41"
+version = "0.9.42"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },

--- a/viva_api/common/handlers/simulations.py
+++ b/viva_api/common/handlers/simulations.py
@@ -338,12 +338,23 @@ async def run_workflow_legacy(
     job_id = await simulation_service.submit_ecoli_simulation_job(
         ecoli_simulation=simulation, database_service=database_service, correlation_id=correlation_id
     )
-    _ = await database_service.insert_hpcrun(
-        job_id=job_id,
-        job_type=JobType.SIMULATION,
-        ref_id=simulation.database_id,
-        correlation_id=correlation_id,
-    )
+    # Some dispatch shapes (chain-dispatch campaigns — backlog item 33) already
+    # record their OWN HpcRun row internally, using this SAME correlation_id,
+    # because that row needs fields (chain_n_generations/chain_final_job_ids) a
+    # generic caller has no way to populate. Guard against inserting a SECOND,
+    # generic row on top of it: get_hpcrun_by_ref (used by every real status
+    # endpoint) resolves to whichever row was inserted MOST RECENTLY, so a
+    # blind second insert here would permanently shadow the real, pollable
+    # campaign row with a stale one nobody ever updates. For every OTHER
+    # dispatch shape this is a pure no-op (a freshly-generated correlation_id
+    # can never already have a row), so behavior is unchanged for them.
+    if await database_service.get_hpcrun_id_by_correlation_id(correlation_id=correlation_id) is None:
+        _ = await database_service.insert_hpcrun(
+            job_id=job_id,
+            job_type=JobType.SIMULATION,
+            ref_id=simulation.database_id,
+            correlation_id=correlation_id,
+        )
 
     simulation.job_id = str(job_id)
     return simulation
@@ -649,13 +660,23 @@ async def run_simulation_workflow(  # noqa: C901
         ecoli_simulation=simulation, database_service=database_service, correlation_id=correlation_id
     )
 
-    # 8. Record HPC run
-    _ = await database_service.insert_hpcrun(
-        job_id=job_id,
-        job_type=JobType.SIMULATION,
-        ref_id=simulation.database_id,
-        correlation_id=correlation_id,
-    )
+    # 8. Record HPC run -- unless the dispatch shape already recorded its OWN
+    # row internally under this SAME correlation_id (chain-dispatch campaigns,
+    # backlog item 33: that row carries chain_n_generations/chain_final_job_ids,
+    # fields this generic call site has no way to populate). A blind second
+    # insert here would outrank it in get_hpcrun_by_ref (every real status
+    # endpoint's lookup resolves to the MOST RECENTLY inserted row for a given
+    # ref_id), permanently shadowing the real, pollable campaign row with a
+    # stale one nobody ever updates. For every other dispatch shape this check
+    # is a pure no-op (a freshly-generated correlation_id can't already have a
+    # row), so behavior is unchanged for them.
+    if await database_service.get_hpcrun_id_by_correlation_id(correlation_id=correlation_id) is None:
+        _ = await database_service.insert_hpcrun(
+            job_id=job_id,
+            job_type=JobType.SIMULATION,
+            ref_id=simulation.database_id,
+            correlation_id=correlation_id,
+        )
 
     simulation.job_id = str(job_id)
     return simulation

--- a/viva_api/common/handlers/simulations.py
+++ b/viva_api/common/handlers/simulations.py
@@ -50,6 +50,7 @@ from viva_api.simulation.models import (
     VecoliSource,
 )
 from viva_api.simulation.simulation_service import SimulationService
+from viva_api.simulation.simulation_service_ray import SimulationServiceRay
 from viva_api.simulation.tables_orm import AnalysisStatusDB
 
 logger = logging.getLogger(__name__)
@@ -749,6 +750,27 @@ async def get_simulation_status(db_service: DatabaseService, id: int) -> Simulat
     hpc_run = await db_service.get_hpcrun_by_ref(ref_id=id, job_type=JobType.SIMULATION)
     if hpc_run is None:
         raise RuntimeError(f"No HPC run found for simulation {id}")
+
+    # Chain-dispatch campaigns (backlog item 33) track N per-seed job chains, not
+    # one job -- `hpc_run.job_id` is only the ParCa kickoff job. The plain path
+    # below reads THAT job's status and writes it onto the whole campaign row,
+    # which corrupts it: ParCa finishing legitimately marks the entire campaign
+    # COMPLETED while the real per-seed chains are still mid-flight, permanently
+    # dropping it out of JobScheduler.list_active_chain_campaigns()'s poll set
+    # and silently preventing analysis auto-fire forever. Report read-only status
+    # instead for a chain campaign -- mirroring JobScheduler._advance_chain_campaign's
+    # own already-correct terminal-check logic -- and never write here; only the
+    # scheduler's own poll loop may transition a campaign row's status.
+    if hpc_run.chain_final_job_ids is not None:
+        chain_service = get_simulation_service_for_job(hpc_run.job_id)
+        if not isinstance(chain_service, SimulationServiceRay):
+            raise RuntimeError("Chain-dispatch campaign requires the Ray/Batch simulation service")
+        result = chain_service.get_chain_campaign_result(hpc_run.chain_final_job_ids)
+        if not result.terminal:
+            return SimulationRun(id=int(id), status=hpc_run.status or JobStatus.RUNNING)
+        status = JobStatus.COMPLETED if result.succeeded_job_ids else JobStatus.FAILED
+        error_message = None if result.succeeded_job_ids else "chain dispatch: zero seed chains succeeded"
+        return SimulationRun(id=int(id), status=status, error_message=error_message)
 
     # Route to the service that owns this run (by the run's backend), not the global default.
     simulation_service = get_simulation_service_for_job(hpc_run.job_id)

--- a/viva_api/common/storage/data_layout.py
+++ b/viva_api/common/storage/data_layout.py
@@ -102,6 +102,31 @@ class RayLayout:
         kind = "ray-upstream-parca-cache" if upstream else "ray-parca-cache"
         return s3_uri(f"{kind}/{commit}/")
 
+    @staticmethod
+    def wave_state_prefix(experiment_id: str) -> str:
+        """Bucket-relative key prefix under which wave-dispatch checkpoints live
+        (backlog item 33: per-generation task decomposition)."""
+        return f"{RayLayout.experiment_prefix(experiment_id)}/wave-state"
+
+    @staticmethod
+    def wave_state_uri(experiment_id: str, seed: int, generation: int) -> str:
+        """Per-seed, per-generation daughter-state checkpoint URI.
+
+        Mirrors vEcoli-private's own Nextflow task I/O hand-off (``sim.nf``): a
+        wave orchestrator writes THIS generation's daughter state here
+        (``LineageProcess.daughter_state_out_path``) so the NEXT wave can load it
+        as its carry-state in (``initial_carry_state_path``) -- task retry at
+        generation granularity IS checkpoint/resume, no in-process pickling
+        needed. Ephemeral hand-off, never browsed/sorted by a human, so unlike
+        ``seed_store_uri`` this deliberately skips zero-padding: the plain
+        ``seed{seed}``/``gen{generation}`` form is what the wave orchestrator
+        (Python, via this function) and the v2ecoli container's own inline
+        ``python3 -c`` merge script (which has no import path back to this
+        module) both reconstruct, so keeping the format trivial keeps the two
+        independent implementations trivially in sync.
+        """
+        return s3_uri(f"{RayLayout.wave_state_prefix(experiment_id)}/seed{seed}/gen{generation}.pkl")
+
 
 class NextflowLayout:
     """vEcoli / parquet output layout (Batch + SLURM)."""

--- a/viva_api/common/storage/data_layout.py
+++ b/viva_api/common/storage/data_layout.py
@@ -91,6 +91,29 @@ class RayLayout:
         return f"{RayLayout.experiment_prefix(experiment_id)}/summary.json"
 
     @staticmethod
+    def seed_results_prefix(experiment_id: str, seed: int) -> str:
+        """Bucket-relative key prefix for ONE seed's own results (backlog item
+        33/35: per-generation chain-dispatch). Every generation's job for a
+        given seed shares this prefix, so the parquet sweep / zarr store /
+        summary.json accumulate under one seed-scoped location instead of the
+        ensemble-wide ``experiment_prefix`` every seed's job would otherwise
+        collide on. ``seed_{seed:02d}`` (zero-padded, underscored) matches the
+        multiseed analysis step's own real, confirmed lookup convention (
+        ``v2ecoli.workflow.analysis_runner``'s per-seed sweep_dir) — a
+        DIFFERENT format from this class's other two per-seed conventions
+        (``seed_store_uri``'s ``v2ecoli_seed{NN}``, ``daughter_state_uri``'s
+        unpadded ``seed{N}``); each pre-dates this one and is owned by a
+        different reader, so unifying them is out of scope here.
+        """
+        return f"{RayLayout.experiment_prefix(experiment_id)}/seed_{seed:02d}"
+
+    @staticmethod
+    def seed_results_uri(experiment_id: str, seed: int) -> str:
+        """Where ONE seed's chain-dispatch jobs write their results (trailing
+        slash = sync/prefix dir). See ``seed_results_prefix``."""
+        return s3_uri(f"{RayLayout.seed_results_prefix(experiment_id, seed)}/")
+
+    @staticmethod
     def parca_cache_uri(commit: str, *, upstream: bool = False) -> str:
         """S3 URI for a commit's ParCa cache (trailing slash = 'directory').
 

--- a/viva_api/common/storage/data_layout.py
+++ b/viva_api/common/storage/data_layout.py
@@ -103,29 +103,37 @@ class RayLayout:
         return s3_uri(f"{kind}/{commit}/")
 
     @staticmethod
-    def wave_state_prefix(experiment_id: str) -> str:
-        """Bucket-relative key prefix under which wave-dispatch checkpoints live
-        (backlog item 33: per-generation task decomposition)."""
-        return f"{RayLayout.experiment_prefix(experiment_id)}/wave-state"
+    def daughter_state_prefix(experiment_id: str) -> str:
+        """Bucket-relative key prefix under which per-seed chain-dispatch
+        daughter-state checkpoints live (backlog item 33: per-generation task
+        decomposition)."""
+        return f"{RayLayout.experiment_prefix(experiment_id)}/daughter-state"
 
     @staticmethod
-    def wave_state_uri(experiment_id: str, seed: int, generation: int) -> str:
+    def daughter_state_uri(experiment_id: str, seed: int, generation: int) -> str:
         """Per-seed, per-generation daughter-state checkpoint URI.
 
-        Mirrors vEcoli-private's own Nextflow task I/O hand-off (``sim.nf``): a
-        wave orchestrator writes THIS generation's daughter state here
-        (``LineageProcess.daughter_state_out_path``) so the NEXT wave can load it
+        Mirrors vEcoli-private's own Nextflow task I/O hand-off (``sim.nf``):
+        each seed's per-generation Batch job writes THIS generation's daughter
+        state here (``LineageProcess.daughter_state_out_path``) so the NEXT
+        generation's job (chained via that job's own ``dependsOn``) can load it
         as its carry-state in (``initial_carry_state_path``) -- task retry at
         generation granularity IS checkpoint/resume, no in-process pickling
         needed. Ephemeral hand-off, never browsed/sorted by a human, so unlike
         ``seed_store_uri`` this deliberately skips zero-padding: the plain
-        ``seed{seed}``/``gen{generation}`` form is what the wave orchestrator
-        (Python, via this function) and the v2ecoli container's own inline
-        ``python3 -c`` merge script (which has no import path back to this
-        module) both reconstruct, so keeping the format trivial keeps the two
-        independent implementations trivially in sync.
+        ``seed{seed}``/``gen{generation}`` form is what the submitting Python
+        code (via this function) and the v2ecoli container's own command
+        (embedded verbatim at submission time -- see ``_seed_generation_command``)
+        both reference, so keeping the format trivial keeps the two independent
+        call sites trivially in sync.
+
+        Nothing has been dispatched against the old ``wave-state`` key prefix
+        yet (this whole capability is still unwired from any HTTP router --
+        see ``SimulationServiceRay.submit_chain_dispatch_job``), so renaming
+        the prefix alongside the accessor methods costs nothing: there is no
+        already-landed S3 data under the old name to migrate.
         """
-        return s3_uri(f"{RayLayout.wave_state_prefix(experiment_id)}/seed{seed}/gen{generation}.pkl")
+        return s3_uri(f"{RayLayout.daughter_state_prefix(experiment_id)}/seed{seed}/gen{generation}.pkl")
 
 
 class NextflowLayout:

--- a/viva_api/dependencies.py
+++ b/viva_api/dependencies.py
@@ -364,9 +364,9 @@ async def init_standalone(enable_ssl: bool = True) -> None:
         logger.info("✓ Messaging service connected")
         set_messaging_service(messaging_service)
 
-        # Initialize JobScheduler. Wave-dispatch polling (backlog item 33) only
-        # applies when the Ray/Batch backend is actually configured for this
-        # deployment -- registry-only lookup (no default-backend fallback),
+        # Initialize JobScheduler. Chain-dispatch campaign polling (backlog item
+        # 33) only applies when the Ray/Batch backend is actually configured for
+        # this deployment -- registry-only lookup (no default-backend fallback),
         # since `simulation_service_ray` must be a real SimulationServiceRay or
         # None, never some OTHER backend's service standing in for it.
         logger.info("Initializing JobScheduler...")

--- a/viva_api/dependencies.py
+++ b/viva_api/dependencies.py
@@ -295,6 +295,7 @@ def _init_ssh_service(job_backend: str, settings: Settings) -> None:
 async def init_standalone(enable_ssl: bool = True) -> None:
     from viva_api.common.hpc.slurm_service import SlurmService
     from viva_api.simulation.job_scheduler import JobScheduler
+    from viva_api.simulation.simulation_service_ray import SimulationServiceRay
 
     _settings = get_settings()
     job_backend = get_job_backend()
@@ -363,12 +364,19 @@ async def init_standalone(enable_ssl: bool = True) -> None:
         logger.info("✓ Messaging service connected")
         set_messaging_service(messaging_service)
 
-        # Initialize JobScheduler
+        # Initialize JobScheduler. Wave-dispatch polling (backlog item 33) only
+        # applies when the Ray/Batch backend is actually configured for this
+        # deployment -- registry-only lookup (no default-backend fallback),
+        # since `simulation_service_ray` must be a real SimulationServiceRay or
+        # None, never some OTHER backend's service standing in for it.
         logger.info("Initializing JobScheduler...")
+        ray_service = global_simulation_services.get(ComputeBackend.RAY)
+        simulation_service_ray = ray_service if isinstance(ray_service, SimulationServiceRay) else None
         job_scheduler = JobScheduler(
             messaging_service=messaging_service,
             database_service=db_service,
             slurm_service=slurm_service,
+            simulation_service_ray=simulation_service_ray,
         )
         set_job_scheduler(job_scheduler)
         logger.info("✓ JobScheduler initialized")

--- a/viva_api/simulation/database_service.py
+++ b/viva_api/simulation/database_service.py
@@ -130,12 +130,18 @@ class DatabaseService(ABC):
         job_type: JobType,
         ref_id: int,
         correlation_id: str,
+        wave_index: int | None = None,
+        wave_seed_indices: list[int] | None = None,
     ) -> HpcRun:
         """
         :param job_id: Backend-tagged job identifier.
         :param job_type: (`JobType`) job type to be run. Choose one of the following:
             `JobType.SIMULATION`(/vecoli/run), `JobType.PARCA`(/vecoli/parca), `JobType.BUILD_IMAGE`(/simulator/new)
         :param ref_id: primary key of the object this HPC run is associated with (sim, parca, etc.).
+        :param wave_index: 0-based generation this row's Array job ran (wave-dispatch campaigns only,
+            backlog item 33). Omit for every non-wave HpcRun.
+        :param wave_seed_indices: the real seed dispatched at each local array position (position i ->
+            seed wave_seed_indices[i]). Omit for every non-wave HpcRun.
         """
         pass
 
@@ -216,6 +222,13 @@ class DatabaseService(ABC):
     @abstractmethod
     async def list_active_hpcruns(self) -> list[HpcRun]:
         """Return all HpcRun jobs with status PENDING or RUNNING."""
+        pass
+
+    @abstractmethod
+    async def list_active_wave_hpcruns(self) -> list[HpcRun]:
+        """Return active (PENDING/RUNNING) HpcRun rows belonging to a wave-dispatch
+        campaign (``wave_index is not None``) -- backlog item 33. The set
+        ``JobScheduler.update_wave_jobs`` polls each interval."""
         pass
 
     @abstractmethod
@@ -508,6 +521,8 @@ class DatabaseServiceSQL(DatabaseService):
         job_type: JobType,
         ref_id: int,
         correlation_id: str,
+        wave_index: int | None = None,
+        wave_seed_indices: list[int] | None = None,
     ) -> HpcRun:
         jobref_simulation_id = ref_id if job_type == JobType.SIMULATION else None
         jobref_parca_dataset_id = ref_id if job_type == JobType.PARCA else None
@@ -524,6 +539,8 @@ class DatabaseServiceSQL(DatabaseService):
                 jobref_parca_dataset_id=jobref_parca_dataset_id,
                 start_time=datetime.datetime.now(),
                 correlation_id=correlation_id,
+                wave_index=wave_index,
+                wave_seed_indices=list(wave_seed_indices) if wave_seed_indices is not None else None,
             )
             session.add(orm_hpc_run)
             await session.flush()
@@ -889,6 +906,17 @@ class DatabaseServiceSQL(DatabaseService):
     async def list_active_hpcruns(self) -> list[HpcRun]:
         async with self.async_sessionmaker() as session:
             stmt = select(ORMHpcRun).where(ORMHpcRun.status.in_([JobStatusDB.PENDING, JobStatusDB.RUNNING]))
+            result: Result[tuple[ORMHpcRun]] = await session.execute(stmt)
+            orm_hpcruns = result.scalars().all()
+            return [orm_hpcrun.to_hpc_run() for orm_hpcrun in orm_hpcruns]
+
+    @override
+    async def list_active_wave_hpcruns(self) -> list[HpcRun]:
+        async with self.async_sessionmaker() as session:
+            stmt = select(ORMHpcRun).where(
+                ORMHpcRun.status.in_([JobStatusDB.PENDING, JobStatusDB.RUNNING]),
+                ORMHpcRun.wave_index.is_not(None),
+            )
             result: Result[tuple[ORMHpcRun]] = await session.execute(stmt)
             orm_hpcruns = result.scalars().all()
             return [orm_hpcrun.to_hpc_run() for orm_hpcrun in orm_hpcruns]

--- a/viva_api/simulation/database_service.py
+++ b/viva_api/simulation/database_service.py
@@ -130,18 +130,18 @@ class DatabaseService(ABC):
         job_type: JobType,
         ref_id: int,
         correlation_id: str,
-        wave_index: int | None = None,
-        wave_seed_indices: list[int] | None = None,
+        chain_n_generations: int | None = None,
+        chain_final_job_ids: list[str] | None = None,
     ) -> HpcRun:
         """
         :param job_id: Backend-tagged job identifier.
         :param job_type: (`JobType`) job type to be run. Choose one of the following:
             `JobType.SIMULATION`(/vecoli/run), `JobType.PARCA`(/vecoli/parca), `JobType.BUILD_IMAGE`(/simulator/new)
         :param ref_id: primary key of the object this HPC run is associated with (sim, parca, etc.).
-        :param wave_index: 0-based generation this row's Array job ran (wave-dispatch campaigns only,
-            backlog item 33). Omit for every non-wave HpcRun.
-        :param wave_seed_indices: the real seed dispatched at each local array position (position i ->
-            seed wave_seed_indices[i]). Omit for every non-wave HpcRun.
+        :param chain_n_generations: total generation count G for a chain-dispatch campaign (backlog item
+            33). Omit for every non-campaign HpcRun.
+        :param chain_final_job_ids: the AWS Batch job id of each seed's own last successfully-submitted
+            generation job, for a chain-dispatch campaign. Omit for every non-campaign HpcRun.
         """
         pass
 
@@ -225,10 +225,10 @@ class DatabaseService(ABC):
         pass
 
     @abstractmethod
-    async def list_active_wave_hpcruns(self) -> list[HpcRun]:
-        """Return active (PENDING/RUNNING) HpcRun rows belonging to a wave-dispatch
-        campaign (``wave_index is not None``) -- backlog item 33. The set
-        ``JobScheduler.update_wave_jobs`` polls each interval."""
+    async def list_active_chain_campaigns(self) -> list[HpcRun]:
+        """Return active (PENDING/RUNNING) HpcRun rows tracking a chain-dispatch
+        campaign (``chain_n_generations is not None``) -- backlog item 33. The set
+        ``JobScheduler.update_chain_campaigns`` polls each interval."""
         pass
 
     @abstractmethod
@@ -521,8 +521,8 @@ class DatabaseServiceSQL(DatabaseService):
         job_type: JobType,
         ref_id: int,
         correlation_id: str,
-        wave_index: int | None = None,
-        wave_seed_indices: list[int] | None = None,
+        chain_n_generations: int | None = None,
+        chain_final_job_ids: list[str] | None = None,
     ) -> HpcRun:
         jobref_simulation_id = ref_id if job_type == JobType.SIMULATION else None
         jobref_parca_dataset_id = ref_id if job_type == JobType.PARCA else None
@@ -539,8 +539,8 @@ class DatabaseServiceSQL(DatabaseService):
                 jobref_parca_dataset_id=jobref_parca_dataset_id,
                 start_time=datetime.datetime.now(),
                 correlation_id=correlation_id,
-                wave_index=wave_index,
-                wave_seed_indices=list(wave_seed_indices) if wave_seed_indices is not None else None,
+                chain_n_generations=chain_n_generations,
+                chain_final_job_ids=list(chain_final_job_ids) if chain_final_job_ids is not None else None,
             )
             session.add(orm_hpc_run)
             await session.flush()
@@ -911,11 +911,11 @@ class DatabaseServiceSQL(DatabaseService):
             return [orm_hpcrun.to_hpc_run() for orm_hpcrun in orm_hpcruns]
 
     @override
-    async def list_active_wave_hpcruns(self) -> list[HpcRun]:
+    async def list_active_chain_campaigns(self) -> list[HpcRun]:
         async with self.async_sessionmaker() as session:
             stmt = select(ORMHpcRun).where(
                 ORMHpcRun.status.in_([JobStatusDB.PENDING, JobStatusDB.RUNNING]),
-                ORMHpcRun.wave_index.is_not(None),
+                ORMHpcRun.chain_n_generations.is_not(None),
             )
             result: Result[tuple[ORMHpcRun]] = await session.execute(stmt)
             orm_hpcruns = result.scalars().all()

--- a/viva_api/simulation/db_reconcile.py
+++ b/viva_api/simulation/db_reconcile.py
@@ -108,6 +108,10 @@ async def _marker_compose_hpcrun_job_id_ext(conn: AsyncConnection) -> bool:
     return await _column_exists(conn, "compose_hpcrun", "job_id_ext")
 
 
+async def _marker_hpcrun_chain_dispatch(conn: AsyncConnection) -> bool:
+    return await _column_exists(conn, "hpcrun", "chain_final_job_ids")
+
+
 # (revision, human-readable marker description, async predicate)
 # One marker per revision reachable by a legacy create_all database. New entries
 # are needed ONLY while create_all still bootstraps prod DBs (see module docstring):
@@ -120,6 +124,7 @@ LEGACY_FINGERPRINTS: list[tuple[str, str]] = [
     ("c1a2b3d4e5f6", "simulation.tags column exists"),
     ("d3f9a1c72b84", "analysis.n_tp column exists"),
     ("e5a7c9d10f21", "compose_hpcrun.job_id_ext column exists"),
+    ("f2b8e4a6c9d1", "hpcrun.chain_final_job_ids column exists"),
 ]
 _LEGACY_PREDICATES = [
     _marker_baseline,
@@ -128,6 +133,7 @@ _LEGACY_PREDICATES = [
     _marker_simulation_tags,
     _marker_analysis_query_columns,
     _marker_compose_hpcrun_job_id_ext,
+    _marker_hpcrun_chain_dispatch,
 ]
 
 

--- a/viva_api/simulation/job_scheduler.py
+++ b/viva_api/simulation/job_scheduler.py
@@ -157,23 +157,27 @@ class JobScheduler:
         """
         if self.simulation_service_ray is None:
             return
+        # Narrow simulation_service_ray to non-None ONCE here (rather than a
+        # runtime `assert` inside `_advance_wave`, which -O would silently
+        # strip) and thread it through explicitly.
+        simulation_service_ray = self.simulation_service_ray
+
         active_waves = await self.database_service.list_active_wave_hpcruns()
         if not active_waves:
             logger.debug("No active wave-dispatch jobs found for polling.")
             return
         for wave in active_waves:
             try:
-                await self._advance_wave(wave)
+                await self._advance_wave(wave, simulation_service_ray)
             except Exception:
                 logger.exception("Error advancing wave HpcRun %s", wave.database_id)
 
-    async def _advance_wave(self, wave: HpcRun) -> None:
+    async def _advance_wave(self, wave: HpcRun, simulation_service_ray: SimulationServiceRay) -> None:
         """Handle one active wave HpcRun: no-op if still running; otherwise mark
         it terminal and, if survivors remain and generations remain, submit the
         next wave (see ``update_wave_jobs`` for what happens on the final wave).
         """
-        assert self.simulation_service_ray is not None  # guarded by update_wave_jobs's caller
-        result = self.simulation_service_ray.get_wave_result(wave.job_id.value)
+        result = simulation_service_ray.get_wave_result(wave.job_id.value)
         if not result.terminal:
             return
 
@@ -214,11 +218,13 @@ class JobScheduler:
 
         simulator = await self.database_service.get_simulator(simulator_id=simulation.simulator_id)
         if simulator is None:
-            logger.error("Wave dispatch: Simulator %s not found for simulation %s", simulation.simulator_id, wave.ref_id)
+            logger.error(
+                "Wave dispatch: Simulator %s not found for simulation %s", simulation.simulator_id, wave.ref_id
+            )
             return
         total_n_seeds = int(simulation.num_seeds or len(seed_indices))
 
-        next_job_id = await self.simulation_service_ray.submit_next_wave(
+        next_job_id = await simulation_service_ray.submit_next_wave(
             simulation=simulation,
             database_service=self.database_service,
             commit=simulator.git_commit_hash,

--- a/viva_api/simulation/job_scheduler.py
+++ b/viva_api/simulation/job_scheduler.py
@@ -1,4 +1,5 @@
 import asyncio
+import datetime
 import logging
 
 from async_lru import alru_cache
@@ -10,7 +11,8 @@ from viva_api.common.models import JobBackend, JobStatus, SSHTarget
 from viva_api.config import get_settings
 from viva_api.dependencies import get_ssh_session_service
 from viva_api.simulation.database_service import DatabaseService
-from viva_api.simulation.models import WorkerEvent, WorkerEventMessagePayload
+from viva_api.simulation.models import HpcRun, WorkerEvent, WorkerEventMessagePayload
+from viva_api.simulation.simulation_service_ray import SimulationServiceRay
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +20,7 @@ logger = logging.getLogger(__name__)
 class JobScheduler:
     database_service: DatabaseService
     slurm_service: SlurmService | None
+    simulation_service_ray: SimulationServiceRay | None
     messaging_service: MessagingService
     _polling_task: asyncio.Task[None] | None = None
     _stop_event: asyncio.Event
@@ -27,10 +30,12 @@ class JobScheduler:
         messaging_service: MessagingService,
         database_service: DatabaseService,
         slurm_service: SlurmService | None = None,
+        simulation_service_ray: SimulationServiceRay | None = None,
     ):
         self.messaging_service = messaging_service
         self.database_service = database_service
         self.slurm_service = slurm_service
+        self.simulation_service_ray = simulation_service_ray
         self._stop_event = asyncio.Event()
 
     @alru_cache
@@ -86,6 +91,10 @@ class JobScheduler:
                 await self.update_running_jobs()
             except Exception:
                 logger.exception("Error during job polling")
+            try:
+                await self.update_wave_jobs()
+            except Exception:
+                logger.exception("Error during wave job polling")
             await asyncio.sleep(interval_seconds)
 
     async def update_running_jobs(self) -> None:
@@ -136,6 +145,96 @@ class JobScheduler:
             )
             await self.database_service.update_hpcrun_status(hpcrun_id=hpc_run.database_id, update=update)
             logger.info(f"Updated HpcRun {hpc_run.database_id} status to {new_status}")
+
+    async def update_wave_jobs(self) -> None:
+        """Poll every active wave-dispatch HpcRun to terminal, then either
+        submit the next generation's wave (remapping survivors, backlog item
+        33) or leave it be — the analysis DAG node for a campaign's FINAL wave
+        is submitted alongside that wave itself (see ``SimulationServiceRay.
+        _submit_wave_and_maybe_analysis``), not from here. No-op when no wave
+        campaign is active, or on a deployment with no Ray/Batch backend wired
+        (SLURM-only deployments pass ``simulation_service_ray=None``).
+        """
+        if self.simulation_service_ray is None:
+            return
+        active_waves = await self.database_service.list_active_wave_hpcruns()
+        if not active_waves:
+            logger.debug("No active wave-dispatch jobs found for polling.")
+            return
+        for wave in active_waves:
+            try:
+                await self._advance_wave(wave)
+            except Exception:
+                logger.exception("Error advancing wave HpcRun %s", wave.database_id)
+
+    async def _advance_wave(self, wave: HpcRun) -> None:
+        """Handle one active wave HpcRun: no-op if still running; otherwise mark
+        it terminal and, if survivors remain and generations remain, submit the
+        next wave (see ``update_wave_jobs`` for what happens on the final wave).
+        """
+        assert self.simulation_service_ray is not None  # guarded by update_wave_jobs's caller
+        result = self.simulation_service_ray.get_wave_result(wave.job_id.value)
+        if not result.terminal:
+            return
+
+        seed_indices = wave.wave_seed_indices or []
+        survivors = [seed_indices[i] for i in result.succeeded_local_indices if i < len(seed_indices)]
+
+        # Terminal is either every child SUCCEEDED, or the array parent went
+        # FAILED-due-to-partial-loss -- both are "wave finished", not an
+        # orchestrator error (Spot/OOM attrition is expected economics). Only a
+        # wave with ZERO survivors is a genuine campaign-ending failure.
+        await self.database_service.update_hpcrun_status(
+            hpcrun_id=wave.database_id,
+            update=JobStatusUpdate(
+                job_id=wave.job_id,
+                status=JobStatus.COMPLETED if survivors else JobStatus.FAILED,
+                end_time=datetime.datetime.now().isoformat(),
+                error_message=None if survivors else "wave dispatch: zero seeds survived this generation",
+            ),
+        )
+        if not survivors:
+            logger.warning(
+                "Wave dispatch: HpcRun %s (generation %s) had zero survivors; campaign ends here.",
+                wave.database_id,
+                wave.wave_index,
+            )
+            return
+
+        simulation = await self.database_service.get_simulation(simulation_id=wave.ref_id)
+        if simulation is None:
+            logger.error("Wave dispatch: Simulation %s not found for HpcRun %s", wave.ref_id, wave.database_id)
+            return
+        n_generations = int(simulation.config.generations or 1)
+        next_generation = int(wave.wave_index or 0) + 1
+        if next_generation >= n_generations:
+            # This WAS already the campaign's final wave -- its analysis node was
+            # submitted alongside it at submission time, not here.
+            return
+
+        simulator = await self.database_service.get_simulator(simulator_id=simulation.simulator_id)
+        if simulator is None:
+            logger.error("Wave dispatch: Simulator %s not found for simulation %s", simulation.simulator_id, wave.ref_id)
+            return
+        total_n_seeds = int(simulation.num_seeds or len(seed_indices))
+
+        next_job_id = await self.simulation_service_ray.submit_next_wave(
+            simulation=simulation,
+            database_service=self.database_service,
+            commit=simulator.git_commit_hash,
+            generation_index=next_generation,
+            seed_indices=survivors,
+            total_n_seeds=total_n_seeds,
+            n_generations=n_generations,
+        )
+        logger.info(
+            "Wave dispatch %s: generation %d (%d survivors) -> generation %d job %s",
+            simulation.config.experiment_id,
+            wave.wave_index,
+            len(survivors),
+            next_generation,
+            next_job_id,
+        )
 
     async def close(self) -> None:
         await self.stop_polling()

--- a/viva_api/simulation/job_scheduler.py
+++ b/viva_api/simulation/job_scheduler.py
@@ -92,9 +92,9 @@ class JobScheduler:
             except Exception:
                 logger.exception("Error during job polling")
             try:
-                await self.update_wave_jobs()
+                await self.update_chain_campaigns()
             except Exception:
-                logger.exception("Error during wave job polling")
+                logger.exception("Error during chain-dispatch campaign polling")
             await asyncio.sleep(interval_seconds)
 
     async def update_running_jobs(self) -> None:
@@ -146,100 +146,106 @@ class JobScheduler:
             await self.database_service.update_hpcrun_status(hpcrun_id=hpc_run.database_id, update=update)
             logger.info(f"Updated HpcRun {hpc_run.database_id} status to {new_status}")
 
-    async def update_wave_jobs(self) -> None:
-        """Poll every active wave-dispatch HpcRun to terminal, then either
-        submit the next generation's wave (remapping survivors, backlog item
-        33) or leave it be — the analysis DAG node for a campaign's FINAL wave
-        is submitted alongside that wave itself (see ``SimulationServiceRay.
-        _submit_wave_and_maybe_analysis``), not from here. No-op when no wave
-        campaign is active, or on a deployment with no Ray/Batch backend wired
-        (SLURM-only deployments pass ``simulation_service_ray=None``).
+    async def update_chain_campaigns(self) -> None:
+        """Poll every active chain-dispatch campaign's tracked final-generation
+        job ids to terminal, then submit the analysis DAG node exactly once per
+        campaign (backlog item 33 rework — individual per-seed job chains,
+        replacing the per-generation-array "wave" design's own per-generation
+        poll-then-advance loop). Unlike that design, there is no "advance to
+        the next generation" step left to do here: AWS Batch's own dependsOn
+        already resolves each seed's chain natively (see
+        ``SimulationServiceRay.submit_chain_dispatch_job``); the only thing
+        left to poll for is "has every seed's chain reached a terminal state,"
+        answered by ``SimulationServiceRay.get_chain_campaign_result``. No-op
+        when no chain campaign is active, or on a deployment with no Ray/Batch
+        backend wired (SLURM-only deployments pass
+        ``simulation_service_ray=None``).
         """
         if self.simulation_service_ray is None:
             return
         # Narrow simulation_service_ray to non-None ONCE here (rather than a
-        # runtime `assert` inside `_advance_wave`, which -O would silently
-        # strip) and thread it through explicitly.
+        # runtime `assert` inside `_advance_chain_campaign`, which -O would
+        # silently strip) and thread it through explicitly.
         simulation_service_ray = self.simulation_service_ray
 
-        active_waves = await self.database_service.list_active_wave_hpcruns()
-        if not active_waves:
-            logger.debug("No active wave-dispatch jobs found for polling.")
+        active_campaigns = await self.database_service.list_active_chain_campaigns()
+        if not active_campaigns:
+            logger.debug("No active chain-dispatch campaigns found for polling.")
             return
-        for wave in active_waves:
+        for campaign in active_campaigns:
             try:
-                await self._advance_wave(wave, simulation_service_ray)
+                await self._advance_chain_campaign(campaign, simulation_service_ray)
             except Exception:
-                logger.exception("Error advancing wave HpcRun %s", wave.database_id)
+                logger.exception("Error advancing chain-dispatch campaign HpcRun %s", campaign.database_id)
 
-    async def _advance_wave(self, wave: HpcRun, simulation_service_ray: SimulationServiceRay) -> None:
-        """Handle one active wave HpcRun: no-op if still running; otherwise mark
-        it terminal and, if survivors remain and generations remain, submit the
-        next wave (see ``update_wave_jobs`` for what happens on the final wave).
+    async def _advance_chain_campaign(self, campaign: HpcRun, simulation_service_ray: SimulationServiceRay) -> None:
+        """Handle one active chain-dispatch campaign HpcRun: no-op while any
+        tracked seed chain is still unresolved; once every tracked chain has
+        reached a terminal state, mark the campaign row terminal and, if at
+        least one seed chain succeeded, submit the analysis DAG node (see
+        ``update_chain_campaigns`` for the zero-succeeded case).
+
+        This method never marks an INDIVIDUAL chain job failed — a
+        permanently-failed seed's job already shows up as FAILED in
+        ``result.failed_job_ids`` via Batch's own dependency-failure
+        propagation (a later generation's job that depended on a failed one
+        auto-transitions to FAILED with no orchestrator action). The only
+        status write here is to the campaign's own tracking row.
         """
-        result = simulation_service_ray.get_wave_result(wave.job_id.value)
+        job_ids = campaign.chain_final_job_ids or []
+        result = simulation_service_ray.get_chain_campaign_result(job_ids)
         if not result.terminal:
             return
 
-        seed_indices = wave.wave_seed_indices or []
-        survivors = [seed_indices[i] for i in result.succeeded_local_indices if i < len(seed_indices)]
-
-        # Terminal is either every child SUCCEEDED, or the array parent went
-        # FAILED-due-to-partial-loss -- both are "wave finished", not an
-        # orchestrator error (Spot/OOM attrition is expected economics). Only a
-        # wave with ZERO survivors is a genuine campaign-ending failure.
+        succeeded = result.succeeded_job_ids
         await self.database_service.update_hpcrun_status(
-            hpcrun_id=wave.database_id,
+            hpcrun_id=campaign.database_id,
             update=JobStatusUpdate(
-                job_id=wave.job_id,
-                status=JobStatus.COMPLETED if survivors else JobStatus.FAILED,
+                job_id=campaign.job_id,
+                status=JobStatus.COMPLETED if succeeded else JobStatus.FAILED,
                 end_time=datetime.datetime.now().isoformat(),
-                error_message=None if survivors else "wave dispatch: zero seeds survived this generation",
+                error_message=None if succeeded else "chain dispatch: zero seed chains succeeded",
             ),
         )
-        if not survivors:
+        if not succeeded:
             logger.warning(
-                "Wave dispatch: HpcRun %s (generation %s) had zero survivors; campaign ends here.",
-                wave.database_id,
-                wave.wave_index,
+                "Chain dispatch: HpcRun %s had zero succeeded seed chains "
+                "(%d tracked, %d failed); campaign ends here, no analysis submitted.",
+                campaign.database_id,
+                len(job_ids),
+                len(result.failed_job_ids),
             )
             return
 
-        simulation = await self.database_service.get_simulation(simulation_id=wave.ref_id)
+        simulation = await self.database_service.get_simulation(simulation_id=campaign.ref_id)
         if simulation is None:
-            logger.error("Wave dispatch: Simulation %s not found for HpcRun %s", wave.ref_id, wave.database_id)
+            logger.error("Chain dispatch: Simulation %s not found for HpcRun %s", campaign.ref_id, campaign.database_id)
             return
-        n_generations = int(simulation.config.generations or 1)
-        next_generation = int(wave.wave_index or 0) + 1
-        if next_generation >= n_generations:
-            # This WAS already the campaign's final wave -- its analysis node was
-            # submitted alongside it at submission time, not here.
-            return
-
         simulator = await self.database_service.get_simulator(simulator_id=simulation.simulator_id)
         if simulator is None:
             logger.error(
-                "Wave dispatch: Simulator %s not found for simulation %s", simulation.simulator_id, wave.ref_id
+                "Chain dispatch: Simulator %s not found for simulation %s",
+                simulation.simulator_id,
+                campaign.ref_id,
             )
             return
-        total_n_seeds = int(simulation.num_seeds or len(seed_indices))
+        n_generations = int(campaign.chain_n_generations or simulation.config.generations or 1)
+        total_n_seeds = int(simulation.num_seeds or len(job_ids))
 
-        next_job_id = await simulation_service_ray.submit_next_wave(
+        analysis_job_id = await simulation_service_ray.submit_campaign_analysis(
             simulation=simulation,
             database_service=self.database_service,
             commit=simulator.git_commit_hash,
-            generation_index=next_generation,
-            seed_indices=survivors,
             total_n_seeds=total_n_seeds,
             n_generations=n_generations,
         )
         logger.info(
-            "Wave dispatch %s: generation %d (%d survivors) -> generation %d job %s",
+            "Chain dispatch %s: campaign HpcRun %s all-terminal (%d/%d chains succeeded) -> analysis job %s",
             simulation.config.experiment_id,
-            wave.wave_index,
-            len(survivors),
-            next_generation,
-            next_job_id,
+            campaign.database_id,
+            len(succeeded),
+            len(job_ids),
+            analysis_job_id,
         )
 
     async def close(self) -> None:

--- a/viva_api/simulation/models.py
+++ b/viva_api/simulation/models.py
@@ -44,6 +44,9 @@ class HpcRun(BaseModel):
     start_time: str | None = None  # ISO format datetime string
     end_time: str | None = None  # ISO format datetime string or None if still running
     error_message: str | None = None  # Error message if the simulation failed
+    # Wave-dispatch campaign fields (backlog item 33), None for every non-wave run.
+    wave_index: int | None = None  # 0-based generation this row's Array job ran
+    wave_seed_indices: list[int] | None = None  # real seed at each local array position
 
     @model_validator(mode="before")
     @classmethod

--- a/viva_api/simulation/models.py
+++ b/viva_api/simulation/models.py
@@ -44,9 +44,13 @@ class HpcRun(BaseModel):
     start_time: str | None = None  # ISO format datetime string
     end_time: str | None = None  # ISO format datetime string or None if still running
     error_message: str | None = None  # Error message if the simulation failed
-    # Wave-dispatch campaign fields (backlog item 33), None for every non-wave run.
-    wave_index: int | None = None  # 0-based generation this row's Array job ran
-    wave_seed_indices: list[int] | None = None  # real seed at each local array position
+    # Chain-dispatch campaign fields (backlog item 33): None for every HpcRun that
+    # isn't a chain-campaign tracker row. chain_n_generations is the campaign's
+    # total generation count G; chain_final_job_ids is the AWS Batch job id of
+    # each seed's own last successfully-submitted generation job -- what the
+    # analysis-fan-in poller (JobScheduler.update_chain_campaigns) watches.
+    chain_n_generations: int | None = None
+    chain_final_job_ids: list[str] | None = None
 
     @model_validator(mode="before")
     @classmethod

--- a/viva_api/simulation/simulation_service_ray.py
+++ b/viva_api/simulation/simulation_service_ray.py
@@ -700,6 +700,30 @@ class SimulationServiceRay(SimulationService):
         it via an offset (unlike ``_array_sim_command``'s BASE_SEED arithmetic,
         which only ever needs a contiguous range).
 
+        CROSS-REPO CONTRACT GAP, confirmed against primary sources this
+        session, NOT yet closed as of sms-ecoli PR #39 (``feat/per-generation-
+        wave-dispatch``): the overrides below set ``initial_generation_index``
+        (and the caller sets ``initial_carry_state_path``/``daughter_state_out
+        _path`` via the merge script) as TOP-LEVEL ``--overrides`` keys, which
+        ``run_pbg.py`` forwards to ``process_bigraph.composite_spec.
+        CompositeSpec.to_document(overrides=...)`` -> ``_merged_params``. That
+        method (verified directly, ``process_bigraph/composite_spec.py``)
+        raises ``KeyError: "unknown override(s): [...]"`` for ANY key not in
+        the composite's OWN declared ``@composite_generator(parameters={...})``
+        dict — it is a strict allowlist, not a passthrough. PR #39 threaded
+        the 3 new keys through ``BatchBaselineRunner.config_schema`` and
+        ``meta_composite.py``'s ``_lineage_node`` (a DIFFERENT, multi-branch
+        composite path), but NOT through ``v2ecoli/composites/batch_baseline.
+        py``'s own ``parameters={...}`` dict / ``batch_baseline()`` signature /
+        ``runner_config`` dict — which is the composite THIS command actually
+        dispatches through (``V2ECOLI_BATCH_BASELINE_COMPOSITE_ID``). Until
+        sms-ecoli adds the same 3 keys there (mirroring the exact pattern
+        already applied to ``BatchBaselineRunner``/``meta_composite.py``), a
+        real wave dispatch will fail fast with that KeyError at container
+        start. This command's shape is correct against the INTENDED full
+        contract; it is blocked on that small companion fix, not on anything
+        wrong here.
+
         ``seed_indices`` is embedded as a bare JSON int array (at most 1000
         ints for the canonical dispatch shape — comfortably under Batch's
         8192-byte containerOverrides.command cap; see

--- a/viva_api/simulation/simulation_service_ray.py
+++ b/viva_api/simulation/simulation_service_ray.py
@@ -751,7 +751,7 @@ class SimulationServiceRay(SimulationService):
         env = f"PBG_RESULTS_DIR={SIM_OUT_DIR} PBG_CORE_BUILDER={V2ECOLI_CORE_BUILDER}"
         return (
             f"OVERRIDES=$(python3 -c '{merge_py}'"
-            f" {static_overrides_json} {seed_indices_json} \"$AWS_BATCH_JOB_ARRAY_INDEX\" {bucket} {state_prefix})"
+            f' {static_overrides_json} {seed_indices_json} "$AWS_BATCH_JOB_ARRAY_INDEX" {bucket} {state_prefix})'
             f" && cd {V2ECOLI_DIR}"
             f" && aws s3 cp {runner_s3_uri} /tmp/run_pbg.py"
             f" && {env} python /tmp/run_pbg.py"
@@ -1323,9 +1323,7 @@ bash docker/build-and-push-ecr.sh -i {commit} -r {settings.ray_ecr_repository} -
                 "(use submit_ecoli_simulation_job for single-generation runs)"
             )
         if n_seeds < 2:
-            raise ValueError(
-                "submit_wave_dispatch_job requires n_seeds > 1 (AWS Batch array jobs require size >= 2)"
-            )
+            raise ValueError("submit_wave_dispatch_job requires n_seeds > 1 (AWS Batch array jobs require size >= 2)")
 
         job_def_mnp = self._ensure_mnp_job_def(self._image_uri(commit), commit)
         cache_s3 = self._cache_s3_uri(commit)

--- a/viva_api/simulation/simulation_service_ray.py
+++ b/viva_api/simulation/simulation_service_ray.py
@@ -28,6 +28,7 @@ image per submission, we derive a per-commit MNP job-def revision from the sms-c
 base (cloning its node properties, swapping the image to ``v2ecoli:<commit>``).
 """
 
+import asyncio
 import copy
 import importlib.resources as _res
 import json
@@ -36,11 +37,13 @@ import random
 import shlex
 import string
 import tempfile
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, override
 
 import boto3
+from botocore.config import Config
 from pydantic import BaseModel
 
 from viva_api.common.hpc.job_service import JobStatusInfo
@@ -130,9 +133,68 @@ ANALYSIS_SCALES = ("single", "multidaughter", "multigeneration", "multiseed", "m
 # than carrying a second, drift-prone copy of the list.
 APPLICABLE_ANALYSES = "applicable"
 
+# ── Chain-dispatch campaign submission (backlog item 33) ────────────────────
+#
+# AWS Batch's SubmitJob is capped at 50 TPS per account, fixed -- not
+# adjustable via a quota increase (AWS Batch service quotas, verified this
+# session). A canonical 1000-seed x 10-generation campaign submits N*G=10,000
+# individual per-seed-per-generation jobs upfront (see
+# ``submit_chain_dispatch_job``), so that loop must stay safely under the cap.
+_SUBMIT_JOB_SAFE_RATE = 40.0  # jobs/sec; headroom below the 50 TPS account cap
+#                               for other concurrent Batch traffic in the same
+#                               account (ParCa/analysis jobs, other campaigns).
+_SUBMIT_JOB_MAX_ATTEMPTS = 5  # botocore "standard" retry attempts per submit_job
+#                               call, for whatever transient/throttling errors
+#                               proactive pacing alone doesn't fully prevent.
+# Per-generation-job retry, matching the (Spot-tolerant) Array job definition's
+# own already-tuned ``arrayRetryAttempts`` default (sms-cdk/lib/ray-batch-
+# stack.ts) -- restores the "checkpoint/resume via the job's own retry" property
+# the per-seed chain design assumes, on the MNP job definition that per-seed
+# jobs actually submit through (see ``_seed_generation_command``'s module-level
+# docstring note for why MNP, not Array, and the cost tradeoff that leaves open).
+_CHAIN_JOB_RETRY_STRATEGY = {"attempts": 2}
+# AWS Batch DescribeJobs accepts at most 100 job ids per call (verified against
+# the real API model this session) -- the analysis-fan-in poller must chunk a
+# campaign's up-to-1000 tracked job ids into batches this size.
+_DESCRIBE_JOBS_MAX_BATCH = 100
+
 
 def _rand_suffix() -> str:
     return "".join(random.choices(string.ascii_lowercase + string.digits, k=6))
+
+
+class _SubmitJobPacer:
+    """Proactive client-side pacer for AWS Batch SubmitJob.
+
+    Caps outbound ``submit_job`` calls to ``max_per_second``, computed from
+    REAL elapsed wall-clock time since the previous call (not a fixed
+    per-call sleep, which either over-throttles once call latency is added on
+    top, or under-throttles if the guessed interval is even slightly off).
+    Deliberately proactive rather than reactive: botocore's own "adaptive"
+    retry mode only starts throttling client-side AFTER it has already
+    observed a real throttling response, so pacing every call up front is
+    what keeps a fresh several-thousand-call burst from front-loading
+    avoidable 429s in the first place. This pacer and the "standard" retry
+    mode configured on the submitting client (see
+    ``submit_chain_dispatch_job``) are complementary, not redundant: this
+    caps the steady-state rate; retry-on-throttle is the backstop for
+    whatever pacing alone doesn't prevent (concurrent campaigns, other Batch
+    traffic in the same account -- the 50 TPS cap is account-wide, not
+    per-campaign).
+    """
+
+    def __init__(self, max_per_second: float = _SUBMIT_JOB_SAFE_RATE) -> None:
+        self._min_interval = 1.0 / max_per_second
+        self._last_call_at: float | None = None
+
+    async def wait(self) -> None:
+        now = time.monotonic()
+        if self._last_call_at is not None:
+            deficit = self._min_interval - (now - self._last_call_at)
+            if deficit > 0:
+                await asyncio.sleep(deficit)
+                now = time.monotonic()
+        self._last_call_at = now
 
 
 def analysis_modules_for(config: Any) -> dict[str, dict[str, Any]] | str:
@@ -171,23 +233,27 @@ def _is_upstream_vecoli(composite: CompositeEngine | None) -> bool:
 
 
 @dataclass
-class WavePollResult:
-    """One wave's (array job's) poll outcome — backlog item 33.
+class ChainCampaignPollResult:
+    """A chain-dispatch campaign's analysis-fan-in poll outcome — backlog item 33.
 
-    ``terminal`` means every child has reached a Batch-terminal state
-    (SUCCEEDED or FAILED, per ``arrayProperties.statusSummary``); a wave with
-    children still RUNNABLE/STARTING/RUNNING is NOT terminal and must be
-    polled again next interval. Once terminal, ``succeeded_local_indices`` /
-    ``failed_local_indices`` are the wave's own LOCAL array positions
-    (0..array_size-1) — the caller (JobScheduler) remaps these to real seed
-    numbers via the HpcRun row's ``wave_seed_indices``, since a wave's array
-    positions are dense (0..len(seed_indices)-1) even though the seeds they
-    represent may be sparse after a prior generation's attrition.
+    ``terminal`` means every one of the campaign's tracked final-generation job
+    ids (``HpcRun.chain_final_job_ids`` — one per seed, each seed's own LAST
+    successfully-submitted generation job) has reached a Batch-terminal state
+    (SUCCEEDED or FAILED); a campaign with any tracked job still
+    SUBMITTED/PENDING/RUNNABLE/STARTING/RUNNING is NOT terminal and must be
+    polled again next interval. A job id that hasn't shown up in ``describe_jobs``
+    yet (e.g. brief eventual-consistency lag right after submission) is treated
+    as not-yet-terminal, not an error — the caller just polls again.
+
+    Unlike the per-generation-array design this superseded, there is no local
+    array position to remap: each tracked id is already a real, independent AWS
+    Batch job id (one seed's final chain link), so ``succeeded_job_ids`` /
+    ``failed_job_ids`` are real job ids directly, usable as-is.
     """
 
     terminal: bool
-    succeeded_local_indices: list[int] = field(default_factory=list)
-    failed_local_indices: list[int] = field(default_factory=list)
+    succeeded_job_ids: list[str] = field(default_factory=list)
+    failed_job_ids: list[str] = field(default_factory=list)
 
 
 class SimulationServiceRay(SimulationService):
@@ -330,6 +396,8 @@ class SimulationServiceRay(SimulationService):
         depends_on: list[str] | None = None,
         depends_type: str | None = "SEQUENTIAL",
         tags: dict[str, str] | None = None,
+        retry_strategy: dict[str, Any] | None = None,
+        batch_client: Any = None,
     ) -> str:
         """Submit a Ray MNP job via boto3, mirroring sms-cdk scripts/ray_batch_submit.sh.
 
@@ -346,6 +414,19 @@ class SimulationServiceRay(SimulationService):
         wait — required when the DEPENDENCY is an Array job, whose parent id AWS
         Batch will not accept under a SEQUENTIAL type (real API rejection, hit live
         2026-08-06; see ``_submit_array``).
+
+        ``retry_strategy``, passed through verbatim as ``SubmitJob.retryStrategy``,
+        overrides whatever the job definition itself declares (per the real AWS
+        Batch API — confirmed this session) — used by the per-seed chain-dispatch
+        path (backlog item 33) to restore per-job retry on the MNP job definition,
+        which (unlike the Array job definition) declares none of its own; omitted
+        (``None``) everywhere else, unchanged from existing behavior.
+
+        ``batch_client``, when given, is used INSTEAD of ``self._batch()`` for this
+        one call — lets a caller submitting many jobs in a tight loop (chain
+        dispatch) supply its own retry-configured client without changing what
+        every other existing call site in this class gets from the shared
+        ``self._batch()`` factory.
         """
         settings = get_settings()
         # Per-node knobs every node acts on (stage cache in, sync results out, ship logs).
@@ -396,8 +477,11 @@ class SimulationServiceRay(SimulationService):
             # payer account's Cost Explorer can attribute compute per run/engine.
             kwargs["tags"] = tags
             kwargs["propagateTags"] = True
+        if retry_strategy:
+            kwargs["retryStrategy"] = retry_strategy
 
-        response = self._batch().submit_job(**kwargs)
+        batch = batch_client if batch_client is not None else self._batch()
+        response = batch.submit_job(**kwargs)
         batch_job_id = str(response["jobId"])
         logger.info(
             "Submitted Ray MNP job %s (id=%s, nodes=%d) to %s",
@@ -681,66 +765,51 @@ class SimulationServiceRay(SimulationService):
             f' --overrides "$OVERRIDES" -n 1'
         )
 
-    def _wave_sim_command(
+    def _seed_generation_command(
         self,
+        *,
+        seed: int,
         generation_index: int,
         experiment_id: str,
         runner_s3_uri: str,
-        seed_indices: list[int],
     ) -> str:
-        """Build one wave's Array child command: ONE seed's ONE generation
-        (backlog item 33 — per-generation task decomposition, mirroring
-        vEcoli-private's own Nextflow task granularity, ``runscripts/nextflow/
-        sim.nf``). Sibling of ``_array_sim_command``, same inline-shell-plus-
-        python3 per-child resolution pattern, extended for a SPARSE seed set:
-        after a prior wave's attrition (Spot loss, OOM), a later wave's array
-        positions are still dense (0..len(seed_indices)-1) but the REAL seeds
-        they represent are not — so each child must look its real seed up in a
-        lookup table (``seed_indices[AWS_BATCH_JOB_ARRAY_INDEX]``), not compute
-        it via an offset (unlike ``_array_sim_command``'s BASE_SEED arithmetic,
-        which only ever needs a contiguous range).
+        """Build ONE seed's ONE generation's command (backlog item 33 rework —
+        per-seed independent job chains, mirroring vEcoli-private's own
+        Nextflow task granularity, ``runscripts/nextflow/sim.nf``, where task
+        retry at generation granularity IS checkpoint/resume).
 
-        CROSS-REPO CONTRACT GAP, confirmed against primary sources this
-        session, NOT yet closed as of sms-ecoli PR #39 (``feat/per-generation-
-        wave-dispatch``): the overrides below set ``initial_generation_index``
-        (and the caller sets ``initial_carry_state_path``/``daughter_state_out
-        _path`` via the merge script) as TOP-LEVEL ``--overrides`` keys, which
-        ``run_pbg.py`` forwards to ``process_bigraph.composite_spec.
-        CompositeSpec.to_document(overrides=...)`` -> ``_merged_params``. That
-        method (verified directly, ``process_bigraph/composite_spec.py``)
-        raises ``KeyError: "unknown override(s): [...]"`` for ANY key not in
-        the composite's OWN declared ``@composite_generator(parameters={...})``
-        dict — it is a strict allowlist, not a passthrough. PR #39 threaded
-        the 3 new keys through ``BatchBaselineRunner.config_schema`` and
-        ``meta_composite.py``'s ``_lineage_node`` (a DIFFERENT, multi-branch
-        composite path), but NOT through ``v2ecoli/composites/batch_baseline.
-        py``'s own ``parameters={...}`` dict / ``batch_baseline()`` signature /
-        ``runner_config`` dict — which is the composite THIS command actually
-        dispatches through (``V2ECOLI_BATCH_BASELINE_COMPOSITE_ID``). Until
-        sms-ecoli adds the same 3 keys there (mirroring the exact pattern
-        already applied to ``BatchBaselineRunner``/``meta_composite.py``), a
-        real wave dispatch will fail fast with that KeyError at container
-        start. This command's shape is correct against the INTENDED full
-        contract; it is blocked on that small companion fix, not on anything
-        wrong here.
+        SIMPLER than the per-generation-array design this superseded (formerly
+        ``_wave_sim_command``): this job is submitted as its own standalone
+        Batch job (see ``submit_chain_dispatch_job``), not one array child
+        sharing a command across many indices, so BOTH ``seed`` and
+        ``generation_index`` are already known Python-side at SUBMISSION time
+        — no ``AWS_BATCH_JOB_ARRAY_INDEX``, no lookup table, no container-start
+        shell/python3 merge step at all. The full ``--overrides`` payload is
+        computed once, here, and embedded as a single static JSON blob.
 
-        ``seed_indices`` is embedded as a bare JSON int array (at most 1000
-        ints for the canonical dispatch shape — comfortably under Batch's
-        8192-byte containerOverrides.command cap; see
-        ``TestWaveSimCommand.test_stays_under_the_batch_command_size_cap`` for
-        the actual byte count at n=1000). The per-seed checkpoint S3 URIs are
-        NOT embedded (1000 full URIs would blow that cap) — the merge script
-        reconstructs them itself using ``RayLayout.wave_state_uri``'s own
-        format, mirrored here since the v2ecoli container has no import path
-        back to this module.
+        ``initial_carry_state_path``/``daughter_state_out_path`` are exactly
+        ``RayLayout.daughter_state_uri``'s own deterministic per-seed,
+        per-generation S3 path — generation 0 has no prior generation, so
+        ``initial_carry_state_path`` is "" (``LineageProcess`` defaults it to
+        "", matching a fresh cell — the validated, non-error case). Every
+        generation writes its own daughter state out, including the final
+        one — a harmless no-op read by nobody if the chain ends there, cheaper
+        than a special case to skip it.
 
-        Generation 0 has no prior wave, so no ``initial_carry_state_path`` is
-        set (LineageProcess defaults it to "", matching a fresh cell —
-        ``initial_generation_index=0`` with no carry state is the validated,
-        non-error case). Every generation writes its own daughter state out,
-        including the final one — a harmless no-op read by nobody if the
-        campaign ends there, cheaper than a special case to skip it.
+        CROSS-REPO CONTRACT: overrides threading these 3 keys through to
+        ``v2ecoli/composites/batch_baseline.py``'s own ``parameters={...}``
+        declaration (the composite this command dispatches through, via
+        ``V2ECOLI_BATCH_BASELINE_COMPOSITE_ID``) is sms-ecoli PR #39's
+        responsibility, already applied there — see that repo's own history;
+        nothing about that contract is affected by this per-seed rework, only
+        WHICH viva-api command builder emits the same 3 keys.
         """
+        daughter_state_out_path = data_layout.RayLayout.daughter_state_uri(experiment_id, seed, generation_index)
+        initial_carry_state_path = (
+            data_layout.RayLayout.daughter_state_uri(experiment_id, seed, generation_index - 1)
+            if generation_index > 0
+            else ""
+        )
         overrides = {
             "n_seeds": 1,
             "n_generations": 1,
@@ -749,38 +818,18 @@ class SimulationServiceRay(SimulationService):
             "experiment_id": experiment_id,
             "analyses": "none",
             "parallel": "",
+            "base_seed": int(seed),
             "initial_generation_index": int(generation_index),
+            "initial_carry_state_path": initial_carry_state_path,
+            "daughter_state_out_path": daughter_state_out_path,
         }
-        static_overrides_json = shlex.quote(json.dumps(overrides))
-        seed_indices_json = shlex.quote(json.dumps([int(s) for s in seed_indices]))
-        state_prefix = shlex.quote(data_layout.RayLayout.wave_state_prefix(experiment_id))
-        bucket = shlex.quote(get_settings().s3_work_bucket)
-        # NOTE: every Python string literal inside this snippet MUST use double
-        # quotes, never single — the whole snippet is embedded inside a
-        # single-quoted shell argument (python3 -c '{merge_py}' below), so a
-        # single quote in here would prematurely close the shell string.
-        merge_py = (
-            "import json,sys;"
-            "d=json.loads(sys.argv[1]);"
-            "seeds=json.loads(sys.argv[2]);"
-            "seed=seeds[int(sys.argv[3])];"
-            "bucket=sys.argv[4];"
-            "prefix=sys.argv[5];"
-            'gen=d["initial_generation_index"];'
-            'd["base_seed"]=seed;'
-            'd["daughter_state_out_path"]=f"s3://{bucket}/{prefix}/seed{seed}/gen{gen}.pkl";'
-            'd["initial_carry_state_path"]=f"s3://{bucket}/{prefix}/seed{seed}/gen{gen - 1}.pkl" if gen>0 else "";'
-            "print(json.dumps(d))"
-        )
         env = f"PBG_RESULTS_DIR={SIM_OUT_DIR} PBG_CORE_BUILDER={V2ECOLI_CORE_BUILDER}"
         return (
-            f"OVERRIDES=$(python3 -c '{merge_py}'"
-            f' {static_overrides_json} {seed_indices_json} "$AWS_BATCH_JOB_ARRAY_INDEX" {bucket} {state_prefix})'
-            f" && cd {V2ECOLI_DIR}"
+            f"cd {V2ECOLI_DIR}"
             f" && aws s3 cp {runner_s3_uri} /tmp/run_pbg.py"
             f" && {env} python /tmp/run_pbg.py"
             f" --composite-id {V2ECOLI_BATCH_BASELINE_COMPOSITE_ID}"
-            f' --overrides "$OVERRIDES" -n 1'
+            f" --overrides {shlex.quote(json.dumps(overrides))} -n 1"
         )
 
     def _analysis_command(
@@ -852,7 +901,7 @@ class SimulationServiceRay(SimulationService):
         database_service: DatabaseService,
         job_definition: str,
         commit: str,
-        sim_job_id: str,
+        sim_job_id: str | None,
         n_seeds: int,
         n_generations: int,
         depends_type: str | None,
@@ -866,11 +915,21 @@ class SimulationServiceRay(SimulationService):
         auto-triggered analysis must be exactly as discoverable as a hand-triggered
         one, not an invisible side effect.
 
-        Best-effort by design, but never SILENT: the simulation job is already
-        submitted and running by the time this is reached, so raising would orphan a
-        real, expensive job. A submission failure is logged AND written to the
-        analyses table as a FAILED row, so "the analysis never ran" is a visible state
-        rather than an absence.
+        Best-effort by design, but never SILENT: the simulation job(s) this depends
+        on are already submitted and running by the time this is reached, so
+        raising would orphan real, expensive jobs. A submission failure is logged
+        AND written to the analyses table as a FAILED row, so "the analysis never
+        ran" is a visible state rather than an absence.
+
+        ``sim_job_id`` is the single Batch job this analysis should natively
+        ``dependsOn`` (item 24's original single-DAG-edge shape, still used by the
+        single-shot dispatch paths). Pass ``None`` for the chain-dispatch campaign
+        path (backlog item 33 rework), where by construction everything this
+        analysis depends on has ALREADY finished by the time it's submitted — the
+        analysis-fan-in poller's own "all tracked jobs terminal" check (see
+        ``JobScheduler.update_chain_campaigns``) provides the "wait for all"
+        semantics a native ``dependsOn`` can't express at 1000-seed scale (Batch
+        caps a job at 20 dependencies), so no ``dependsOn`` is needed at all here.
         """
         experiment_id = simulation.config.experiment_id
         analysis_name = f"analysis-{experiment_id[:20]}-{_rand_suffix()}"
@@ -907,7 +966,7 @@ class SimulationServiceRay(SimulationService):
                 ),
                 out_s3=self._results_s3_uri(experiment_id),
                 out_dir=ANALYSIS_OUT_DIR,
-                depends_on=[sim_job_id],
+                depends_on=[sim_job_id] if sim_job_id else None,
                 depends_type=depends_type,
                 tags=tags,
             )
@@ -1207,10 +1266,11 @@ bash docker/build-and-push-ecr.sh -i {commit} -r {settings.ray_ecr_repository} -
             )
         return JobId.ray(sim_job_id)
 
-    def _wave_base_tags(self, *, simulation: Simulation, commit: str) -> dict[str, str]:
-        """Cost-allocation tag base shared by every wave + the ParCa job that
-        precedes them, mirroring ``submit_ecoli_simulation_job``'s ``base_tags``
-        (composite/condition don't apply — wave dispatch is v2ecoli-only)."""
+    def _chain_base_tags(self, *, simulation: Simulation, commit: str) -> dict[str, str]:
+        """Cost-allocation tag base shared by every per-seed chain job + the
+        ParCa job that precedes them, mirroring ``submit_ecoli_simulation_job``'s
+        ``base_tags`` (composite/condition don't apply — chain dispatch is
+        v2ecoli-only)."""
         settings = get_settings()
         return {
             "Project": "v2ecoli-comparison",
@@ -1220,115 +1280,87 @@ bash docker/build-and-push-ecr.sh -i {commit} -r {settings.ray_ecr_repository} -
             "Team": getattr(settings, "cost_team_tag", None) or "covertlab",
         }
 
-    async def _submit_wave_and_maybe_analysis(
-        self,
-        *,
-        simulation: Simulation,
-        database_service: DatabaseService,
-        commit: str,
-        generation_index: int,
-        seed_indices: list[int],
-        total_n_seeds: int,
-        n_generations: int,
-        depends_on_parca: str | None,
-        base_tags: dict[str, str],
-    ) -> str:
-        """Submit ONE wave (one generation's Array job) over ``seed_indices``,
-        record it, and — if this is the FINAL generation — submit the analysis
-        DAG node right behind it, depending on THIS wave's own array job id via
-        the existing plain ``{"jobId": ...}`` shape (no ``"type"``; an array
-        parent id is rejected by real AWS Batch under a SEQUENTIAL type, see
-        ``_submit_array``). This piggybacks Batch's own ``dependsOn`` instead of
-        polling to detect "did the last wave finish" — the analysis job simply
-        waits on the wave that was JUST submitted, exactly like the existing
-        single-shot Array path's sim -> analysis edge (item 24), just moved to
-        fire at "final wave submitted" time instead of "the only wave
-        submitted" time. Returns the wave's AWS Batch array job id.
-        """
-        experiment_id = simulation.config.experiment_id
-        array_job_def = self._ensure_array_job_def(self._image_uri(commit), commit)
-        runner_s3_uri = await self._stage_runner(experiment_id)
-        cache_s3 = self._cache_s3_uri(commit)
-        is_final_wave = generation_index >= n_generations - 1
+    async def submit_chain_dispatch_job(self, ecoli_simulation: Simulation, database_service: DatabaseService) -> JobId:
+        """Kick off a per-seed chain-dispatch campaign (backlog item 33 rework
+        — individual per-seed job chains, replacing the per-generation-array
+        "wave" design): submit ParCa (1 node), then EVERY seed's full
+        G-generation ``dependsOn`` chain, all N*G jobs submitted upfront,
+        TPS-paced. A true v2 analogy of vEcoli-private's own fully-asynchronous
+        per-seed Nextflow execution (Alex's explicit decision, 2026-08-08) —
+        seed 5 can be on generation 8 while seed 800 is still on generation 1,
+        throttled only by available compute, never by a cross-seed barrier.
 
-        wave_job_id = self._submit_array(
-            job_name=f"wave{generation_index}-sim-{experiment_id}-{_rand_suffix()}"[:128],
-            job_definition=array_job_def,
-            array_size=len(seed_indices),
-            array_job_cmd=self._wave_sim_command(generation_index, experiment_id, runner_s3_uri, seed_indices),
-            out_s3=self._results_s3_uri(experiment_id),
-            out_dir=SIM_OUT_DIR,
-            stage_s3=cache_s3,
-            stage_dir=PARCA_CACHE_DIR,
-            depends_on=[depends_on_parca] if depends_on_parca else None,
-            tags={**base_tags, "Phase": "sim", "Wave": str(generation_index)},
-        )
-        await database_service.insert_hpcrun(
-            job_id=JobId.ray(wave_job_id),
-            job_type=JobType.SIMULATION,
-            ref_id=simulation.database_id,
-            correlation_id=f"wave-{generation_index}-{experiment_id}-{_rand_suffix()}",
-            wave_index=generation_index,
-            wave_seed_indices=list(seed_indices),
-        )
-        logger.info(
-            "Wave dispatch %s: generation %d submitted as array job %s (%d seeds)",
-            experiment_id,
-            generation_index,
-            wave_job_id,
-            len(seed_indices),
-        )
-        if is_final_wave:
-            mnp_job_def = self._ensure_mnp_job_def(self._image_uri(commit), commit)
-            analysis_job_id = await self._submit_analysis_job(
-                simulation=simulation,
-                database_service=database_service,
-                job_definition=mnp_job_def,
-                commit=commit,
-                sim_job_id=wave_job_id,
-                n_seeds=total_n_seeds,
-                n_generations=n_generations,
-                depends_type=None,
-                tags={**base_tags, "Phase": "analysis"},
-            )
-            logger.info(
-                "Wave dispatch %s: final wave %s -> analysis job %s",
-                experiment_id,
-                wave_job_id,
-                analysis_job_id,
-            )
-        return wave_job_id
+        For each seed independently: generation 0 ``dependsOn`` ParCa
+        (SEQUENTIAL, matching the long-standing ParCa→sim edge shape exactly —
+        both ends are MNP jobs here); generation g>0 ``dependsOn`` generation
+        g-1's own job id (same SEQUENTIAL shape). All jobs for every seed are
+        submitted immediately, back to back, without waiting for any to
+        actually run — AWS Batch holds a job in ``PENDING`` (no compute, no
+        cost) until its dependency reaches ``SUCCEEDED``; a dependency that
+        permanently FAILS auto-propagates failure to what depends on it, no
+        orchestrator action needed (see ``_SubmitJobPacer``/``_submit_mnp``'s
+        ``retry_strategy`` for the two things this DOES still need to handle
+        itself: staying under the account-wide SubmitJob rate limit, and
+        restoring per-job retry — see below).
 
-    async def submit_wave_dispatch_job(self, ecoli_simulation: Simulation, database_service: DatabaseService) -> JobId:
-        """Kick off a wave-dispatch campaign (backlog item 33): submit ParCa (1
-        node) + generation 0's Array wave over every requested seed.
+        WHY MNP (``_submit_mnp``, ``num_nodes=1``), not a "singleton array job":
+        this session confirmed directly against the real, shipped mechanism
+        (sms-cdk's ``batch-array-entrypoint.sh`` and AWS's own
+        ``job_env_vars.html``) that NEITHER of viva-api's two entrypoint
+        scripts supports a genuinely standalone job with its own independent
+        job id. ``batch-array-entrypoint.sh`` hard-requires
+        ``AWS_BATCH_JOB_ARRAY_INDEX``, which AWS Batch only sets for children
+        of a REAL array job (and ``arrayProperties.size`` has a hard floor of
+        2 — no size-1 "singleton array" exists). A true per-seed dependsOn
+        chain structurally needs each generation to be its OWN job with its
+        OWN id anyway (array children can't dependsOn each other individually
+        — dependsOn operates at the array PARENT level only), so array jobs
+        were never a fit for this design regardless. MNP with ``num_nodes=1``
+        is the one mechanism already proven to submit a genuinely standalone
+        job (ParCa and the analysis job already run this way) — reused as-is,
+        no new job type, no sms-cdk change.
 
-        Sibling entrypoint to ``submit_ecoli_simulation_job``, same return
-        contract (the tracked ``JobId`` is the just-submitted job — here,
-        generation 0's array job) MINUS ``correlation_id``: unlike a single-shot
-        dispatch (one job, one caller-supplied correlation_id, the caller's own
-        follow-up ``insert_hpcrun`` call records it), a wave campaign spans
-        MANY jobs over its lifetime that no single outer caller is present for
-        (generations 1..N-1 are submitted later, from ``JobScheduler``'s poll
-        loop) — so every wave, including generation 0, records its OWN HpcRun
-        with its own freshly-generated correlation_id internally (see
-        ``_submit_wave_and_maybe_analysis``), rather than splitting that
-        bookkeeping between an external caller and this method.
+        KNOWN, FLAGGED COST TRADEOFF (not silently absorbed): the MNP queue's
+        compute environment (``RayBatchOnDemandCE``, confirmed directly against
+        ``sms-cdk/lib/ray-batch-stack.ts``) is ON-DEMAND ONLY — unlike the Array
+        job definition's queue, which is Spot-tolerant and already carries its
+        own ``retryStrategy`` (``arrayRetryAttempts``, default 2) for exactly
+        the "a Spot reclaim IS the job's own retry" property item 34 assumes.
+        The MNP job definition declares NO ``retryStrategy`` of its own, so
+        every per-seed-per-generation submission below passes an explicit
+        ``retry_strategy`` override (``_CHAIN_JOB_RETRY_STRATEGY``, matching
+        the Array job definition's own already-tuned value) to restore that
+        property — real, working, per-job retry, achieved from viva-api alone.
+        What can NOT be restored from viva-api alone is Spot PRICING itself
+        (a property of the compute environment bound to the queue, not
+        anything a submission-time parameter can change) — a real cost-shape
+        difference from the superseded array-child design, left open for a
+        companion sms-cdk change (e.g. a Spot-capable container-type job
+        definition with a relaxed entrypoint), not this PR's scope.
 
-        Subsequent generations are NOT submitted here: ``JobScheduler.
-        update_wave_jobs`` polls generation 0 to terminal, computes survivors,
-        and submits generation 1 itself (``submit_next_wave``) — repeating
-        until the final generation, at which point the analysis DAG node rides
-        along (see ``_submit_wave_and_maybe_analysis``). This mirrors AWS
-        Batch's own confirmed limitation: an array job's ``dependsOn`` can't
-        express "wait for all-terminal, not all-succeeded", so chaining
-        generations natively would let one permanently-failed seed cascade-fail
-        every later generation for the whole campaign.
+        Unlike the superseded per-generation-array design, ``n_seeds >= 2`` is
+        NOT required: that floor was AWS Batch's own array-size minimum, which
+        doesn't apply here (each seed's chain is independent standalone jobs,
+        no array involved at all). ``n_generations >= 2`` is still required —
+        a single-generation request has nothing to chain; use
+        ``submit_ecoli_simulation_job``.
 
-        Only valid for the shape wave dispatch actually fixes: multiple seeds
-        (AWS Batch array jobs require size>=2) across multiple generations. A
-        single-generation or single-seed request has no attrition-across-
-        generations problem to solve — use ``submit_ecoli_simulation_job``.
+        A submission failure partway through one seed's chain (even after
+        real retry-on-throttle is exhausted) truncates JUST that seed's chain
+        — its already-submitted generations still run normally on Batch, but
+        nothing later is submitted for it, and its last successfully-submitted
+        job id (not necessarily generation G-1) is what gets tracked for the
+        analysis-fan-in poll. OTHER seeds are unaffected. This mirrors how a
+        RUNTIME failure is handled (Batch's own dependency propagation, no
+        orchestrator involvement) as closely as a SUBMISSION-time failure can.
+
+        Returns the ParCa job's ``JobId`` — the one well-defined "campaign
+        kickoff" marker (no single job represents N*G independent chains as a
+        whole). The real per-seed tracking lives in the campaign's own
+        ``HpcRun`` row (``chain_final_job_ids``), inserted once at the end of
+        this method — analogous to how the superseded design's every wave
+        recorded its own row, just collapsed to ONE row per campaign now that
+        Batch's own dependsOn (not orchestrator polling) advances each chain.
         """
         parca_dataset = await database_service.get_parca_dataset(parca_dataset_id=ecoli_simulation.parca_dataset_id)
         if parca_dataset is None:
@@ -1343,16 +1375,27 @@ bash docker/build-and-push-ecr.sh -i {commit} -r {settings.ray_ecr_repository} -
         n_generations = int(config.generations or 1)
         if n_generations < 2:
             raise ValueError(
-                "submit_wave_dispatch_job requires generations > 1 "
+                "submit_chain_dispatch_job requires generations > 1 "
                 "(use submit_ecoli_simulation_job for single-generation runs)"
             )
-        if n_seeds < 2:
-            raise ValueError("submit_wave_dispatch_job requires n_seeds > 1 (AWS Batch array jobs require size >= 2)")
 
+        experiment_id = str(ecoli_simulation.config.experiment_id)
         job_def_mnp = self._ensure_mnp_job_def(self._image_uri(commit), commit)
         cache_s3 = self._cache_s3_uri(commit)
-        base_tags = self._wave_base_tags(simulation=ecoli_simulation, commit=commit)
+        base_tags = self._chain_base_tags(simulation=ecoli_simulation, commit=commit)
+        runner_s3_uri = await self._stage_runner(experiment_id)
 
+        pacer = _SubmitJobPacer()
+        # A dedicated, retry-configured client for this bulk-submission loop only
+        # -- keeps every OTHER existing call site's behavior (which uses the
+        # shared self._batch() factory, unconfigured) completely unchanged.
+        submit_client = boto3.client(
+            "batch",
+            region_name=get_settings().batch_region,
+            config=Config(retries={"mode": "standard", "max_attempts": _SUBMIT_JOB_MAX_ATTEMPTS}),
+        )
+
+        await pacer.wait()
         parca_job_id = self._submit_mnp(
             job_name=f"ray-parca-{commit}-{_rand_suffix()}",
             job_definition=job_def_mnp,
@@ -1361,58 +1404,112 @@ bash docker/build-and-push-ecr.sh -i {commit} -r {settings.ray_ecr_repository} -
             out_s3=cache_s3,
             out_dir=PARCA_CACHE_DIR,
             tags={**base_tags, "Phase": "parca"},
+            batch_client=submit_client,
         )
-        wave0_job_id = await self._submit_wave_and_maybe_analysis(
-            simulation=ecoli_simulation,
-            database_service=database_service,
-            commit=commit,
-            generation_index=0,
-            seed_indices=list(range(n_seeds)),
-            total_n_seeds=n_seeds,
-            n_generations=n_generations,
-            depends_on_parca=parca_job_id,
-            base_tags=base_tags,
+
+        final_job_ids: list[str] = []
+        for seed in range(n_seeds):
+            prev_job_id = parca_job_id
+            seed_final_job_id: str | None = None
+            for generation_index in range(n_generations):
+                await pacer.wait()
+                try:
+                    job_id = self._submit_mnp(
+                        job_name=f"chain-seed{seed}-gen{generation_index}-{experiment_id}-{_rand_suffix()}"[:128],
+                        job_definition=job_def_mnp,
+                        num_nodes=1,
+                        ray_job_cmd=self._seed_generation_command(
+                            seed=seed,
+                            generation_index=generation_index,
+                            experiment_id=experiment_id,
+                            runner_s3_uri=runner_s3_uri,
+                        ),
+                        out_s3=self._results_s3_uri(experiment_id),
+                        out_dir=SIM_OUT_DIR,
+                        stage_s3=cache_s3,
+                        stage_dir=PARCA_CACHE_DIR,
+                        depends_on=[prev_job_id],
+                        depends_type="SEQUENTIAL",
+                        tags={**base_tags, "Phase": "sim", "Seed": str(seed), "Generation": str(generation_index)},
+                        retry_strategy=_CHAIN_JOB_RETRY_STRATEGY,
+                        batch_client=submit_client,
+                    )
+                except Exception:
+                    logger.exception(
+                        "Chain dispatch %s: seed %d generation %d submission failed "
+                        "(even after retry-on-throttle) -- truncating this seed's chain here; "
+                        "other seeds are unaffected",
+                        experiment_id,
+                        seed,
+                        generation_index,
+                    )
+                    break
+                seed_final_job_id = job_id
+                prev_job_id = job_id
+            if seed_final_job_id is not None:
+                final_job_ids.append(seed_final_job_id)
+            else:
+                logger.error(
+                    "Chain dispatch %s: seed %d contributed NO jobs to the campaign (generation 0 submission failed)",
+                    experiment_id,
+                    seed,
+                )
+
+        await database_service.insert_hpcrun(
+            job_id=JobId.ray(parca_job_id),
+            job_type=JobType.SIMULATION,
+            ref_id=ecoli_simulation.database_id,
+            correlation_id=f"chain-campaign-{experiment_id}-{_rand_suffix()}",
+            chain_n_generations=n_generations,
+            chain_final_job_ids=final_job_ids,
         )
         logger.info(
-            "Wave dispatch %s: parca job %s -> wave 0 job %s (%d seeds, %d generations)",
-            ecoli_simulation.config.experiment_id,
+            "Chain dispatch %s: parca job %s -> %d/%d seed chains submitted (%d generations each)",
+            experiment_id,
             parca_job_id,
-            wave0_job_id,
+            len(final_job_ids),
             n_seeds,
             n_generations,
         )
-        return JobId.ray(wave0_job_id)
+        return JobId.ray(parca_job_id)
 
-    async def submit_next_wave(
+    async def submit_campaign_analysis(
         self,
         *,
         simulation: Simulation,
         database_service: DatabaseService,
         commit: str,
-        generation_index: int,
-        seed_indices: list[int],
         total_n_seeds: int,
         n_generations: int,
-    ) -> str:
-        """Submit wave ``generation_index`` for the given SURVIVOR
-        ``seed_indices`` (backlog item 33). No ParCa dependency — the cache is
-        already in S3 from ``submit_wave_dispatch_job``'s generation-0 run, and
-        ParCa already SUCCEEDED long before this call, so there is no ordering
-        left to enforce. Called exclusively by ``JobScheduler.update_wave_jobs``
-        once the PREVIOUS generation's wave reaches a terminal state. Returns
-        the new wave's AWS Batch array job id.
+    ) -> str | None:
+        """Submit the analysis DAG node for a chain-dispatch campaign that the
+        analysis-fan-in poller (``JobScheduler._advance_chain_campaign``) has
+        just confirmed all-terminal — called exactly once per campaign, after
+        every tracked seed chain (whether it fully succeeded or was permanently
+        failed/truncated) has resolved. By construction everything this
+        analysis depends on has ALREADY finished by the time this runs, so it
+        reuses item 24's existing analysis-job submission code
+        (``_submit_analysis_job``) completely as-is, just with ``sim_job_id=
+        None`` — no native ``dependsOn`` needed; the poller's own "all tracked
+        jobs terminal" check already provided the "wait for all" semantics.
+
+        ``total_n_seeds`` is the campaign's ORIGINALLY REQUESTED seed count
+        (not however many chains actually succeeded) — matches the superseded
+        design's own resolved semantics: the analysis resolves "applicable"
+        modules against the campaign's INTENDED shape.
         """
-        base_tags = self._wave_base_tags(simulation=simulation, commit=commit)
-        return await self._submit_wave_and_maybe_analysis(
+        base_tags = self._chain_base_tags(simulation=simulation, commit=commit)
+        mnp_job_def = self._ensure_mnp_job_def(self._image_uri(commit), commit)
+        return await self._submit_analysis_job(
             simulation=simulation,
             database_service=database_service,
+            job_definition=mnp_job_def,
             commit=commit,
-            generation_index=generation_index,
-            seed_indices=seed_indices,
-            total_n_seeds=total_n_seeds,
+            sim_job_id=None,
+            n_seeds=total_n_seeds,
             n_generations=n_generations,
-            depends_on_parca=None,
-            base_tags=base_tags,
+            depends_type=None,
+            tags={**base_tags, "Phase": "analysis"},
         )
 
     @override
@@ -1454,62 +1551,63 @@ bash docker/build-and-push-ecr.sh -i {commit} -r {settings.ray_ecr_repository} -
             error_message=job.get("statusReason") if status == JobStatus.FAILED else None,
         )
 
-    def _list_array_child_indices(self, array_job_id: str, status: str) -> list[int]:
-        """Every child array position currently in ``status`` (paginated).
+    def get_chain_campaign_result(self, job_ids: list[str]) -> ChainCampaignPollResult:
+        """Poll a chain-dispatch campaign's tracked final-generation job ids —
+        one per seed, each seed's own last successfully-submitted generation
+        job (``HpcRun.chain_final_job_ids``) — for the analysis-fan-in
+        condition (backlog item 33 rework, replacing the per-generation-array
+        "wave" design's own single-array-job ``get_wave_result``).
 
-        Live AWS semantics verified against a real job history (sim139's parent
-        array job, 2026-08-08): ``list_jobs(arrayJobId=..., jobStatus=
-        "SUCCEEDED")`` returned exactly the real surviving indices,
-        ``jobStatus="FAILED"`` returned exactly the rest, both cross-checked
-        against ``describe_jobs``'s own ``arrayProperties.statusSummary``
-        counts, union = the full contiguous index range with zero gaps or
-        duplicates. Confirmed a second time on an all-failed job (a
-        zero-match status returns a clean empty list, not an error).
+        "Terminal" means EVERY tracked job has reached a Batch-terminal state
+        (SUCCEEDED or FAILED, via the same ``JobStatus.from_batch_state``
+        mapping ``get_job_status`` already uses) — a seed's chain ending in
+        FAILED (that job's own retries exhausted, or an earlier generation in
+        its chain having failed and auto-propagated via Batch's own dependsOn)
+        is expected economics, not an orchestrator error; the caller
+        (``JobScheduler._advance_chain_campaign``) decides whether the
+        campaign as a whole produced anything worth analyzing. A tracked id
+        that hasn't appeared in a ``describe_jobs`` response yet (brief
+        eventual-consistency lag right after submission) is treated as
+        not-yet-terminal, not a hard failure — this poller runs on an
+        interval, it just checks again next time.
+
+        ``describe_jobs`` accepts at most 100 job ids per call (verified
+        against the real API model this session) — a campaign's up to 1000
+        tracked ids are chunked accordingly, unlike the array-job design this
+        superseded (which polled ONE array parent's own
+        ``arrayProperties.statusSummary`` plus paginated ``list_jobs`` calls).
         """
+        if not job_ids:
+            # Nothing tracked at all -- every seed failed even generation 0's
+            # submission. Trivially "terminal" (nothing left to wait for); the
+            # caller's own zero-succeeded handling covers marking the campaign
+            # FAILED without submitting an analysis over an empty sweep.
+            return ChainCampaignPollResult(terminal=True)
+
         batch = self._batch()
-        indices: list[int] = []
-        kwargs: dict[str, Any] = {"arrayJobId": array_job_id, "jobStatus": status}
-        while True:
-            response = batch.list_jobs(**kwargs)
-            for job in response.get("jobSummaryList", []):
-                index = job.get("arrayProperties", {}).get("index")
-                if index is not None:
-                    indices.append(int(index))
-            next_token = response.get("nextToken")
-            if not next_token:
-                break
-            kwargs["nextToken"] = next_token
-        return sorted(indices)
+        statuses: dict[str, str] = {}
+        for i in range(0, len(job_ids), _DESCRIBE_JOBS_MAX_BATCH):
+            chunk = job_ids[i : i + _DESCRIBE_JOBS_MAX_BATCH]
+            response = batch.describe_jobs(jobs=chunk)
+            for job in response.get("jobs", []):
+                job_id = job.get("jobId")
+                if job_id is not None:
+                    statuses[str(job_id)] = str(job.get("status", ""))
 
-    def get_wave_result(self, array_job_id: str) -> WavePollResult:
-        """Poll ONE wave's array job: terminal-ness + which local array
-        positions SUCCEEDED vs FAILED (backlog item 33).
+        succeeded: list[str] = []
+        failed: list[str] = []
+        for jid in job_ids:
+            mapped = JobStatus.from_batch_state(statuses.get(jid, ""))
+            if mapped == JobStatus.COMPLETED:
+                succeeded.append(jid)
+            elif mapped == JobStatus.FAILED:
+                failed.append(jid)
+            # else: still queued/running, or missing from the response
+            # entirely (not yet visible) -- either way, not yet terminal.
 
-        "Terminal" means every child has reached a Batch-terminal state — the
-        array PARENT itself may report SUCCEEDED (every child succeeded) or
-        FAILED (at least one child permanently exhausted retries — AWS Batch
-        flips the parent to FAILED the instant that happens, per
-        ``job_states.html``/``array_jobs.html``), but BOTH are "wave finished"
-        from this orchestrator's perspective, not an error: some seeds dying to
-        Spot reclamation or a transient OOM is expected economics, not a bug.
-        The caller (``JobScheduler._advance_wave``) is what decides whether
-        surviving seeds exist to carry forward.
-        """
-        response = self._batch().describe_jobs(jobs=[array_job_id])
-        jobs = response.get("jobs", [])
-        if not jobs:
-            raise RuntimeError(f"Batch array job {array_job_id} not found")
-        array_properties = jobs[0].get("arrayProperties", {})
-        size = int(array_properties.get("size") or 0)
-        status_summary: dict[str, int] = array_properties.get("statusSummary") or {}
-        terminal_count = int(status_summary.get("SUCCEEDED", 0)) + int(status_summary.get("FAILED", 0))
-        if size <= 0 or terminal_count < size:
-            return WavePollResult(terminal=False)
-        return WavePollResult(
-            terminal=True,
-            succeeded_local_indices=self._list_array_child_indices(array_job_id, "SUCCEEDED"),
-            failed_local_indices=self._list_array_child_indices(array_job_id, "FAILED"),
-        )
+        if len(succeeded) + len(failed) < len(job_ids):
+            return ChainCampaignPollResult(terminal=False)
+        return ChainCampaignPollResult(terminal=True, succeeded_job_ids=succeeded, failed_job_ids=failed)
 
     @override
     async def cancel_job(self, job_id: JobId) -> None:

--- a/viva_api/simulation/simulation_service_ray.py
+++ b/viva_api/simulation/simulation_service_ray.py
@@ -36,6 +36,7 @@ import random
 import shlex
 import string
 import tempfile
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, override
 
@@ -58,6 +59,7 @@ from viva_api.simulation.github_repo import (
 )
 from viva_api.simulation.models import (
     CompositeEngine,
+    JobType,
     ParcaDataset,
     RepoDiscovery,
     Simulation,
@@ -166,6 +168,26 @@ def _is_upstream_vecoli(composite: CompositeEngine | None) -> bool:
     the ``--vecoli-source`` arg in ``_sim_command``.
     """
     return composite == "vecoli"
+
+
+@dataclass
+class WavePollResult:
+    """One wave's (array job's) poll outcome — backlog item 33.
+
+    ``terminal`` means every child has reached a Batch-terminal state
+    (SUCCEEDED or FAILED, per ``arrayProperties.statusSummary``); a wave with
+    children still RUNNABLE/STARTING/RUNNING is NOT terminal and must be
+    polled again next interval. Once terminal, ``succeeded_local_indices`` /
+    ``failed_local_indices`` are the wave's own LOCAL array positions
+    (0..array_size-1) — the caller (JobScheduler) remaps these to real seed
+    numbers via the HpcRun row's ``wave_seed_indices``, since a wave's array
+    positions are dense (0..len(seed_indices)-1) even though the seeds they
+    represent may be sparse after a prior generation's attrition.
+    """
+
+    terminal: bool
+    succeeded_local_indices: list[int] = field(default_factory=list)
+    failed_local_indices: list[int] = field(default_factory=list)
 
 
 class SimulationServiceRay(SimulationService):
@@ -659,6 +681,84 @@ class SimulationServiceRay(SimulationService):
             f' --overrides "$OVERRIDES" -n 1'
         )
 
+    def _wave_sim_command(
+        self,
+        generation_index: int,
+        experiment_id: str,
+        runner_s3_uri: str,
+        seed_indices: list[int],
+    ) -> str:
+        """Build one wave's Array child command: ONE seed's ONE generation
+        (backlog item 33 — per-generation task decomposition, mirroring
+        vEcoli-private's own Nextflow task granularity, ``runscripts/nextflow/
+        sim.nf``). Sibling of ``_array_sim_command``, same inline-shell-plus-
+        python3 per-child resolution pattern, extended for a SPARSE seed set:
+        after a prior wave's attrition (Spot loss, OOM), a later wave's array
+        positions are still dense (0..len(seed_indices)-1) but the REAL seeds
+        they represent are not — so each child must look its real seed up in a
+        lookup table (``seed_indices[AWS_BATCH_JOB_ARRAY_INDEX]``), not compute
+        it via an offset (unlike ``_array_sim_command``'s BASE_SEED arithmetic,
+        which only ever needs a contiguous range).
+
+        ``seed_indices`` is embedded as a bare JSON int array (at most 1000
+        ints for the canonical dispatch shape — comfortably under Batch's
+        8192-byte containerOverrides.command cap; see
+        ``TestWaveSimCommand.test_stays_under_the_batch_command_size_cap`` for
+        the actual byte count at n=1000). The per-seed checkpoint S3 URIs are
+        NOT embedded (1000 full URIs would blow that cap) — the merge script
+        reconstructs them itself using ``RayLayout.wave_state_uri``'s own
+        format, mirrored here since the v2ecoli container has no import path
+        back to this module.
+
+        Generation 0 has no prior wave, so no ``initial_carry_state_path`` is
+        set (LineageProcess defaults it to "", matching a fresh cell —
+        ``initial_generation_index=0`` with no carry state is the validated,
+        non-error case). Every generation writes its own daughter state out,
+        including the final one — a harmless no-op read by nobody if the
+        campaign ends there, cheaper than a special case to skip it.
+        """
+        overrides = {
+            "n_seeds": 1,
+            "n_generations": 1,
+            "cache_dir": PARCA_CACHE_DIR,
+            "out_dir": SIM_OUT_DIR,
+            "experiment_id": experiment_id,
+            "analyses": "none",
+            "parallel": "",
+            "initial_generation_index": int(generation_index),
+        }
+        static_overrides_json = shlex.quote(json.dumps(overrides))
+        seed_indices_json = shlex.quote(json.dumps([int(s) for s in seed_indices]))
+        state_prefix = shlex.quote(data_layout.RayLayout.wave_state_prefix(experiment_id))
+        bucket = shlex.quote(get_settings().s3_work_bucket)
+        # NOTE: every Python string literal inside this snippet MUST use double
+        # quotes, never single — the whole snippet is embedded inside a
+        # single-quoted shell argument (python3 -c '{merge_py}' below), so a
+        # single quote in here would prematurely close the shell string.
+        merge_py = (
+            "import json,sys;"
+            "d=json.loads(sys.argv[1]);"
+            "seeds=json.loads(sys.argv[2]);"
+            "seed=seeds[int(sys.argv[3])];"
+            "bucket=sys.argv[4];"
+            "prefix=sys.argv[5];"
+            'gen=d["initial_generation_index"];'
+            'd["base_seed"]=seed;'
+            'd["daughter_state_out_path"]=f"s3://{bucket}/{prefix}/seed{seed}/gen{gen}.pkl";'
+            'd["initial_carry_state_path"]=f"s3://{bucket}/{prefix}/seed{seed}/gen{gen - 1}.pkl" if gen>0 else "";'
+            "print(json.dumps(d))"
+        )
+        env = f"PBG_RESULTS_DIR={SIM_OUT_DIR} PBG_CORE_BUILDER={V2ECOLI_CORE_BUILDER}"
+        return (
+            f"OVERRIDES=$(python3 -c '{merge_py}'"
+            f" {static_overrides_json} {seed_indices_json} \"$AWS_BATCH_JOB_ARRAY_INDEX\" {bucket} {state_prefix})"
+            f" && cd {V2ECOLI_DIR}"
+            f" && aws s3 cp {runner_s3_uri} /tmp/run_pbg.py"
+            f" && {env} python /tmp/run_pbg.py"
+            f" --composite-id {V2ECOLI_BATCH_BASELINE_COMPOSITE_ID}"
+            f' --overrides "$OVERRIDES" -n 1'
+        )
+
     def _analysis_command(
         self,
         *,
@@ -1083,6 +1183,216 @@ bash docker/build-and-push-ecr.sh -i {commit} -r {settings.ray_ecr_repository} -
             )
         return JobId.ray(sim_job_id)
 
+    def _wave_base_tags(self, *, simulation: Simulation, commit: str) -> dict[str, str]:
+        """Cost-allocation tag base shared by every wave + the ParCa job that
+        precedes them, mirroring ``submit_ecoli_simulation_job``'s ``base_tags``
+        (composite/condition don't apply — wave dispatch is v2ecoli-only)."""
+        settings = get_settings()
+        return {
+            "Project": "v2ecoli-comparison",
+            "ExperimentId": str(simulation.config.experiment_id)[:255],
+            "Engine": "v2ecoli",
+            "Commit": str(commit)[:12],
+            "Team": getattr(settings, "cost_team_tag", None) or "covertlab",
+        }
+
+    async def _submit_wave_and_maybe_analysis(
+        self,
+        *,
+        simulation: Simulation,
+        database_service: DatabaseService,
+        commit: str,
+        generation_index: int,
+        seed_indices: list[int],
+        total_n_seeds: int,
+        n_generations: int,
+        depends_on_parca: str | None,
+        base_tags: dict[str, str],
+    ) -> str:
+        """Submit ONE wave (one generation's Array job) over ``seed_indices``,
+        record it, and — if this is the FINAL generation — submit the analysis
+        DAG node right behind it, depending on THIS wave's own array job id via
+        the existing plain ``{"jobId": ...}`` shape (no ``"type"``; an array
+        parent id is rejected by real AWS Batch under a SEQUENTIAL type, see
+        ``_submit_array``). This piggybacks Batch's own ``dependsOn`` instead of
+        polling to detect "did the last wave finish" — the analysis job simply
+        waits on the wave that was JUST submitted, exactly like the existing
+        single-shot Array path's sim -> analysis edge (item 24), just moved to
+        fire at "final wave submitted" time instead of "the only wave
+        submitted" time. Returns the wave's AWS Batch array job id.
+        """
+        experiment_id = simulation.config.experiment_id
+        array_job_def = self._ensure_array_job_def(self._image_uri(commit), commit)
+        runner_s3_uri = await self._stage_runner(experiment_id)
+        cache_s3 = self._cache_s3_uri(commit)
+        is_final_wave = generation_index >= n_generations - 1
+
+        wave_job_id = self._submit_array(
+            job_name=f"wave{generation_index}-sim-{experiment_id}-{_rand_suffix()}"[:128],
+            job_definition=array_job_def,
+            array_size=len(seed_indices),
+            array_job_cmd=self._wave_sim_command(generation_index, experiment_id, runner_s3_uri, seed_indices),
+            out_s3=self._results_s3_uri(experiment_id),
+            out_dir=SIM_OUT_DIR,
+            stage_s3=cache_s3,
+            stage_dir=PARCA_CACHE_DIR,
+            depends_on=[depends_on_parca] if depends_on_parca else None,
+            tags={**base_tags, "Phase": "sim", "Wave": str(generation_index)},
+        )
+        await database_service.insert_hpcrun(
+            job_id=JobId.ray(wave_job_id),
+            job_type=JobType.SIMULATION,
+            ref_id=simulation.database_id,
+            correlation_id=f"wave-{generation_index}-{experiment_id}-{_rand_suffix()}",
+            wave_index=generation_index,
+            wave_seed_indices=list(seed_indices),
+        )
+        logger.info(
+            "Wave dispatch %s: generation %d submitted as array job %s (%d seeds)",
+            experiment_id,
+            generation_index,
+            wave_job_id,
+            len(seed_indices),
+        )
+        if is_final_wave:
+            mnp_job_def = self._ensure_mnp_job_def(self._image_uri(commit), commit)
+            analysis_job_id = await self._submit_analysis_job(
+                simulation=simulation,
+                database_service=database_service,
+                job_definition=mnp_job_def,
+                commit=commit,
+                sim_job_id=wave_job_id,
+                n_seeds=total_n_seeds,
+                n_generations=n_generations,
+                depends_type=None,
+                tags={**base_tags, "Phase": "analysis"},
+            )
+            logger.info(
+                "Wave dispatch %s: final wave %s -> analysis job %s",
+                experiment_id,
+                wave_job_id,
+                analysis_job_id,
+            )
+        return wave_job_id
+
+    async def submit_wave_dispatch_job(self, ecoli_simulation: Simulation, database_service: DatabaseService) -> JobId:
+        """Kick off a wave-dispatch campaign (backlog item 33): submit ParCa (1
+        node) + generation 0's Array wave over every requested seed.
+
+        Sibling entrypoint to ``submit_ecoli_simulation_job``, same return
+        contract (the tracked ``JobId`` is the just-submitted job — here,
+        generation 0's array job) MINUS ``correlation_id``: unlike a single-shot
+        dispatch (one job, one caller-supplied correlation_id, the caller's own
+        follow-up ``insert_hpcrun`` call records it), a wave campaign spans
+        MANY jobs over its lifetime that no single outer caller is present for
+        (generations 1..N-1 are submitted later, from ``JobScheduler``'s poll
+        loop) — so every wave, including generation 0, records its OWN HpcRun
+        with its own freshly-generated correlation_id internally (see
+        ``_submit_wave_and_maybe_analysis``), rather than splitting that
+        bookkeeping between an external caller and this method.
+
+        Subsequent generations are NOT submitted here: ``JobScheduler.
+        update_wave_jobs`` polls generation 0 to terminal, computes survivors,
+        and submits generation 1 itself (``submit_next_wave``) — repeating
+        until the final generation, at which point the analysis DAG node rides
+        along (see ``_submit_wave_and_maybe_analysis``). This mirrors AWS
+        Batch's own confirmed limitation: an array job's ``dependsOn`` can't
+        express "wait for all-terminal, not all-succeeded", so chaining
+        generations natively would let one permanently-failed seed cascade-fail
+        every later generation for the whole campaign.
+
+        Only valid for the shape wave dispatch actually fixes: multiple seeds
+        (AWS Batch array jobs require size>=2) across multiple generations. A
+        single-generation or single-seed request has no attrition-across-
+        generations problem to solve — use ``submit_ecoli_simulation_job``.
+        """
+        parca_dataset = await database_service.get_parca_dataset(parca_dataset_id=ecoli_simulation.parca_dataset_id)
+        if parca_dataset is None:
+            raise ValueError(f"ParcaDataset with ID {ecoli_simulation.parca_dataset_id} not found.")
+        simulator = await database_service.get_simulator(simulator_id=ecoli_simulation.simulator_id)
+        if simulator is None:
+            raise ValueError(f"Simulator {ecoli_simulation.simulator_id} not found")
+
+        commit = simulator.git_commit_hash
+        config = ecoli_simulation.config
+        n_seeds = int(ecoli_simulation.num_seeds or getattr(config, "n_init_sims", None) or 1)
+        n_generations = int(config.generations or 1)
+        if n_generations < 2:
+            raise ValueError(
+                "submit_wave_dispatch_job requires generations > 1 "
+                "(use submit_ecoli_simulation_job for single-generation runs)"
+            )
+        if n_seeds < 2:
+            raise ValueError(
+                "submit_wave_dispatch_job requires n_seeds > 1 (AWS Batch array jobs require size >= 2)"
+            )
+
+        job_def_mnp = self._ensure_mnp_job_def(self._image_uri(commit), commit)
+        cache_s3 = self._cache_s3_uri(commit)
+        base_tags = self._wave_base_tags(simulation=ecoli_simulation, commit=commit)
+
+        parca_job_id = self._submit_mnp(
+            job_name=f"ray-parca-{commit}-{_rand_suffix()}",
+            job_definition=job_def_mnp,
+            num_nodes=1,
+            ray_job_cmd=self._parca_command(),
+            out_s3=cache_s3,
+            out_dir=PARCA_CACHE_DIR,
+            tags={**base_tags, "Phase": "parca"},
+        )
+        wave0_job_id = await self._submit_wave_and_maybe_analysis(
+            simulation=ecoli_simulation,
+            database_service=database_service,
+            commit=commit,
+            generation_index=0,
+            seed_indices=list(range(n_seeds)),
+            total_n_seeds=n_seeds,
+            n_generations=n_generations,
+            depends_on_parca=parca_job_id,
+            base_tags=base_tags,
+        )
+        logger.info(
+            "Wave dispatch %s: parca job %s -> wave 0 job %s (%d seeds, %d generations)",
+            ecoli_simulation.config.experiment_id,
+            parca_job_id,
+            wave0_job_id,
+            n_seeds,
+            n_generations,
+        )
+        return JobId.ray(wave0_job_id)
+
+    async def submit_next_wave(
+        self,
+        *,
+        simulation: Simulation,
+        database_service: DatabaseService,
+        commit: str,
+        generation_index: int,
+        seed_indices: list[int],
+        total_n_seeds: int,
+        n_generations: int,
+    ) -> str:
+        """Submit wave ``generation_index`` for the given SURVIVOR
+        ``seed_indices`` (backlog item 33). No ParCa dependency — the cache is
+        already in S3 from ``submit_wave_dispatch_job``'s generation-0 run, and
+        ParCa already SUCCEEDED long before this call, so there is no ordering
+        left to enforce. Called exclusively by ``JobScheduler.update_wave_jobs``
+        once the PREVIOUS generation's wave reaches a terminal state. Returns
+        the new wave's AWS Batch array job id.
+        """
+        base_tags = self._wave_base_tags(simulation=simulation, commit=commit)
+        return await self._submit_wave_and_maybe_analysis(
+            simulation=simulation,
+            database_service=database_service,
+            commit=commit,
+            generation_index=generation_index,
+            seed_indices=seed_indices,
+            total_n_seeds=total_n_seeds,
+            n_generations=n_generations,
+            depends_on_parca=None,
+            base_tags=base_tags,
+        )
+
     @override
     async def read_config_template(
         self,
@@ -1120,6 +1430,63 @@ bash docker/build-and-push-ecr.sh -i {commit} -r {settings.ray_ecr_repository} -
             end_time=str(stopped) if stopped else None,
             exit_code=None,
             error_message=job.get("statusReason") if status == JobStatus.FAILED else None,
+        )
+
+    def _list_array_child_indices(self, array_job_id: str, status: str) -> list[int]:
+        """Every child array position currently in ``status`` (paginated).
+
+        Live AWS semantics verified against a real job history (sim139's parent
+        array job, 2026-08-08): ``list_jobs(arrayJobId=..., jobStatus=
+        "SUCCEEDED")`` returned exactly the real surviving indices,
+        ``jobStatus="FAILED"`` returned exactly the rest, both cross-checked
+        against ``describe_jobs``'s own ``arrayProperties.statusSummary``
+        counts, union = the full contiguous index range with zero gaps or
+        duplicates. Confirmed a second time on an all-failed job (a
+        zero-match status returns a clean empty list, not an error).
+        """
+        batch = self._batch()
+        indices: list[int] = []
+        kwargs: dict[str, Any] = {"arrayJobId": array_job_id, "jobStatus": status}
+        while True:
+            response = batch.list_jobs(**kwargs)
+            for job in response.get("jobSummaryList", []):
+                index = job.get("arrayProperties", {}).get("index")
+                if index is not None:
+                    indices.append(int(index))
+            next_token = response.get("nextToken")
+            if not next_token:
+                break
+            kwargs["nextToken"] = next_token
+        return sorted(indices)
+
+    def get_wave_result(self, array_job_id: str) -> WavePollResult:
+        """Poll ONE wave's array job: terminal-ness + which local array
+        positions SUCCEEDED vs FAILED (backlog item 33).
+
+        "Terminal" means every child has reached a Batch-terminal state — the
+        array PARENT itself may report SUCCEEDED (every child succeeded) or
+        FAILED (at least one child permanently exhausted retries — AWS Batch
+        flips the parent to FAILED the instant that happens, per
+        ``job_states.html``/``array_jobs.html``), but BOTH are "wave finished"
+        from this orchestrator's perspective, not an error: some seeds dying to
+        Spot reclamation or a transient OOM is expected economics, not a bug.
+        The caller (``JobScheduler._advance_wave``) is what decides whether
+        surviving seeds exist to carry forward.
+        """
+        response = self._batch().describe_jobs(jobs=[array_job_id])
+        jobs = response.get("jobs", [])
+        if not jobs:
+            raise RuntimeError(f"Batch array job {array_job_id} not found")
+        array_properties = jobs[0].get("arrayProperties", {})
+        size = int(array_properties.get("size") or 0)
+        status_summary: dict[str, int] = array_properties.get("statusSummary") or {}
+        terminal_count = int(status_summary.get("SUCCEEDED", 0)) + int(status_summary.get("FAILED", 0))
+        if size <= 0 or terminal_count < size:
+            return WavePollResult(terminal=False)
+        return WavePollResult(
+            terminal=True,
+            succeeded_local_indices=self._list_array_child_indices(array_job_id, "SUCCEEDED"),
+            failed_local_indices=self._list_array_child_indices(array_job_id, "FAILED"),
         )
 
     @override

--- a/viva_api/simulation/simulation_service_ray.py
+++ b/viva_api/simulation/simulation_service_ray.py
@@ -636,6 +636,18 @@ class SimulationServiceRay(SimulationService):
         responsibility, already applied there — see that repo's own history;
         nothing about that contract is affected by this per-seed rework, only
         WHICH viva-api command builder emits the same 3 keys.
+
+        ``out_dir`` is ``RayLayout.seed_results_uri`` (an ``s3://`` URI), not a
+        local path: every generation's job for this seed shares it, so the
+        composite's own parquet sweep / zarr store / summary.json (sms-ecoli's
+        ``v2ecoli/cache.py``, ``workflow/lineage.py``, ``workflow/run.py`` —
+        all made S3-URI-aware alongside this) accumulate under one seed-scoped
+        S3 prefix instead of colliding on the flat, ensemble-wide
+        ``experiment_prefix`` every seed's every generation would otherwise
+        share (the real bug item 35's pilot found — every job's ``summary.json``
+        clobbering the last one's). ``daughter_state_out_path``/
+        ``initial_carry_state_path`` already lived under a per-seed prefix
+        (``daughter_state_uri``), unaffected by this.
         """
         daughter_state_out_path = data_layout.RayLayout.daughter_state_uri(experiment_id, seed, generation_index)
         initial_carry_state_path = (
@@ -643,11 +655,12 @@ class SimulationServiceRay(SimulationService):
             if generation_index > 0
             else ""
         )
+        seed_out_dir = data_layout.RayLayout.seed_results_uri(experiment_id, seed).rstrip("/")
         overrides = {
             "n_seeds": 1,
             "n_generations": 1,
             "cache_dir": PARCA_CACHE_DIR,
-            "out_dir": SIM_OUT_DIR,
+            "out_dir": seed_out_dir,
             "experiment_id": experiment_id,
             "analyses": "none",
             "parallel": "",
@@ -1249,7 +1262,16 @@ bash docker/build-and-push-ecr.sh -i {commit} -r {settings.ray_ecr_repository} -
                             experiment_id=experiment_id,
                             runner_s3_uri=runner_s3_uri,
                         ),
-                        out_s3=self._results_s3_uri(experiment_id),
+                        # Per-seed prefix, not the flat ensemble one: matches the
+                        # composite's own out_dir override in
+                        # _seed_generation_command (see there for why) — RAY_OUT_S3
+                        # is now mostly a safety-net catch-all (the emitters/
+                        # summary.json/daughter-state all write directly to S3
+                        # under this same prefix), not the primary mechanism, but
+                        # it must still point at the SAME prefix so anything that
+                        # DOES still land in the local RAY_OUT_DIR scratch dir
+                        # syncs to the right place rather than the old flat one.
+                        out_s3=data_layout.RayLayout.seed_results_uri(experiment_id, seed),
                         out_dir=SIM_OUT_DIR,
                         stage_s3=cache_s3,
                         stage_dir=PARCA_CACHE_DIR,

--- a/viva_api/simulation/simulation_service_ray.py
+++ b/viva_api/simulation/simulation_service_ray.py
@@ -334,54 +334,6 @@ class SimulationServiceRay(SimulationService):
         logger.info("Registered Ray MNP job def %s:%s for image %s", name, response["revision"], image)
         return f"{name}:{response['revision']}"
 
-    def _ensure_array_job_def(self, image: str, commit: str) -> str:
-        """Return an Array job definition (name:revision) whose image is the commit's image.
-
-        Verified directly against the real AWS Batch API (``aws batch submit-job
-        help``): a plain container job's ``--container-overrides`` has no ``image``
-        field (only EKS jobs' ``eksPropertiesOverride`` does) -- container jobs
-        can't override the image per-submission either, same limitation as MNP,
-        just for a different reason. So, symmetric with ``_ensure_mnp_job_def``,
-        derive a per-commit job-def revision: describe the CDK base job def
-        (``ray_array_job_definition``: roles, resources, retry strategy, log
-        config), swap ONLY the container image to ``image``, and register it as
-        ``<base>-<commit>``. An existing active revision already pointing at this
-        image is reused, so resubmits don't churn revisions.
-        """
-        settings = get_settings()
-        batch = self._batch()
-        name = f"{settings.ray_array_job_definition}-{commit}"
-
-        existing = batch.describe_job_definitions(jobDefinitionName=name, status="ACTIVE")
-        for jd in existing.get("jobDefinitions", []):
-            if jd.get("containerProperties", {}).get("image") == image:
-                return f"{name}:{jd['revision']}"
-
-        base = batch.describe_job_definitions(jobDefinitionName=settings.ray_array_job_definition, status="ACTIVE")
-        base_defs = base.get("jobDefinitions", [])
-        if not base_defs:
-            raise RuntimeError(f"Base Array job definition {settings.ray_array_job_definition!r} not found")
-        base_def = max(base_defs, key=lambda d: d["revision"])
-        container_properties = copy.deepcopy(base_def["containerProperties"])
-        container_properties["image"] = image
-
-        register_kwargs: dict[str, Any] = {
-            "jobDefinitionName": name,
-            "type": "container",
-            "containerProperties": container_properties,
-        }
-        # Carry forward everything else the CDK base job def sets (retryStrategy,
-        # platformCapabilities) -- register_job_definition does NOT inherit these
-        # from an existing revision, it only creates exactly what's passed in.
-        if base_def.get("retryStrategy"):
-            register_kwargs["retryStrategy"] = base_def["retryStrategy"]
-        if base_def.get("platformCapabilities"):
-            register_kwargs["platformCapabilities"] = base_def["platformCapabilities"]
-
-        response = batch.register_job_definition(**register_kwargs)
-        logger.info("Registered Array job def %s:%s for image %s", name, response["revision"], image)
-        return f"{name}:{response['revision']}"
-
     def _submit_mnp(
         self,
         *,
@@ -489,72 +441,6 @@ class SimulationServiceRay(SimulationService):
             batch_job_id,
             num_nodes,
             settings.ray_mnp_queue,
-        )
-        return batch_job_id
-
-    def _submit_array(
-        self,
-        *,
-        job_name: str,
-        job_definition: str,
-        array_size: int,
-        array_job_cmd: str,
-        out_s3: str,
-        out_dir: str,
-        stage_s3: str | None = None,
-        stage_dir: str | None = None,
-        depends_on: list[str] | None = None,
-        tags: dict[str, str] | None = None,
-    ) -> str:
-        """Submit an AWS Batch ARRAY job: N independent single-seed children, no
-        Ray cluster (see scripts/batch-array-entrypoint.sh, sms-cdk). Every child
-        gets the SAME containerOverrides -- Batch injects only
-        AWS_BATCH_JOB_ARRAY_INDEX differently per child, which ``array_job_cmd``
-        resolves at container-start time (see ``_array_sim_command``). Env names
-        are ``ARRAY_*`` (not ``RAY_*``) so the two dispatch paths' env vars can
-        never be cross-wired if a caller mixes them up. Returns the AWS Batch job
-        id (the array parent id; child status is queried per-index if needed).
-        """
-        settings = get_settings()
-        env: list[dict[str, str]] = [
-            {"name": "ARRAY_JOB_CMD", "value": array_job_cmd},
-            {"name": "ARRAY_OUT_DIR", "value": out_dir},
-            {"name": "ARRAY_OUT_S3", "value": out_s3},
-            {"name": "ARRAY_REPORT_PATH", "value": REPORT_PATH},
-        ]
-        if stage_s3 and stage_dir:
-            env.append({"name": "ARRAY_STAGE_S3", "value": stage_s3})
-            env.append({"name": "ARRAY_STAGE_DIR", "value": stage_dir})
-        if settings.ray_log_s3_prefix:
-            env.append({"name": "ARRAY_LOG_S3_PREFIX", "value": settings.ray_log_s3_prefix})
-
-        kwargs: dict[str, Any] = {
-            "jobName": job_name,
-            "jobQueue": settings.ray_array_queue,
-            "jobDefinition": job_definition,
-            "arrayProperties": {"size": array_size},
-            "containerOverrides": {"environment": env},
-        }
-        if depends_on:
-            # Plain job dependency (no "type") -- NOT "SEQUENTIAL", unlike _submit_mnp above.
-            # AWS Batch rejects {"jobId": ..., "type": "SEQUENTIAL"} for a job that also sets
-            # arrayProperties: real error, hit live 2026-08-06, "Job Id cannot be set when
-            # dependency type is SEQUENTIAL". SEQUENTIAL is for an array job depending on
-            # itself/other array-shaped dependents, not a targeted jobId wait -- it doesn't
-            # apply here, we just need "don't start any array child until ParCa succeeds".
-            kwargs["dependsOn"] = [{"jobId": jid} for jid in depends_on]
-        if tags:
-            kwargs["tags"] = tags
-            kwargs["propagateTags"] = True
-
-        response = self._batch().submit_job(**kwargs)
-        batch_job_id = str(response["jobId"])
-        logger.info(
-            "Submitted Batch Array job %s (id=%s, size=%d) to %s",
-            job_name,
-            batch_job_id,
-            array_size,
-            settings.ray_array_queue,
         )
         return batch_job_id
 
@@ -710,59 +596,6 @@ class SimulationServiceRay(SimulationService):
         return (
             f"cd {V2ECOLI_DIR} && python scripts/run_phase0_xarray_ensemble.py"
             f" --n-seeds {n_seeds} --n-steps {n_steps} --chunk {chunk} --parallel ray"
-        )
-
-    def _array_sim_command(
-        self,
-        n_generations: int,
-        experiment_id: str,
-        runner_s3_uri: str,
-        base_seed_offset: int = 0,
-    ) -> str:
-        """Build one Array child's run_pbg.py command (the batch_baseline path).
-
-        Every child runs exactly ONE seed (n_seeds=1), which v2ecoli's
-        ``_resolve_parallel()`` deterministically routes to the sequential
-        no-Ray code path (``len(branches) > 1`` is False for a 1-seed,
-        no-variants request, regardless of the ``parallel`` setting) -- so an
-        array child never needs a Ray cluster at all, verified directly
-        against v2ecoli/workflow/run.py at the deployed commit.
-
-        Each child's real seed is ``base_seed_offset + AWS_BATCH_JOB_ARRAY_INDEX``
-        -- only known once the container starts (AWS Batch injects an identical
-        containerOverrides.environment into every child; only
-        AWS_BATCH_JOB_ARRAY_INDEX itself differs per child), so it can't be
-        computed at submission time. The merge happens via a small ``python3 -c``
-        invocation at container-start: BASE_SEED is arithmetic-only (digits, no
-        quoting concerns); the static overrides are shlex-quoted (safe
-        regardless of what ``experiment_id`` contains -- it is a caller-supplied,
-        unconstrained string) and passed as argv, never string-spliced into the
-        JSON -- json.loads/json.dumps do the merge exactly once, so there is no
-        hand-rolled escaping to get wrong.
-        """
-        overrides = {
-            "n_seeds": 1,
-            "n_generations": int(n_generations),
-            "cache_dir": PARCA_CACHE_DIR,
-            "out_dir": SIM_OUT_DIR,
-            "experiment_id": experiment_id,
-            # A child sees only ITS OWN seed, so an inline flush here would run the
-            # cross-seed scales against one seed, N times over. The whole-sweep
-            # analysis is the DAG's third node instead -- see _analysis_command.
-            "analyses": "none",
-            "parallel": "",
-        }
-        static_overrides_json = shlex.quote(json.dumps(overrides))
-        merge_py = 'import json,sys; d=json.loads(sys.argv[1]); d["base_seed"]=int(sys.argv[2]); print(json.dumps(d))'
-        env = f"PBG_RESULTS_DIR={SIM_OUT_DIR} PBG_CORE_BUILDER={V2ECOLI_CORE_BUILDER}"
-        return (
-            f"BASE_SEED=$(({int(base_seed_offset)} + AWS_BATCH_JOB_ARRAY_INDEX))"
-            f" && OVERRIDES=$(python3 -c '{merge_py}' {static_overrides_json} \"$BASE_SEED\")"
-            f" && cd {V2ECOLI_DIR}"
-            f" && aws s3 cp {runner_s3_uri} /tmp/run_pbg.py"
-            f" && {env} python /tmp/run_pbg.py"
-            f" --composite-id {V2ECOLI_BATCH_BASELINE_COMPOSITE_ID}"
-            f' --overrides "$OVERRIDES" -n 1'
         )
 
     def _seed_generation_command(
@@ -1093,9 +926,36 @@ bash docker/build-and-push-ecr.sh -i {commit} -r {settings.ray_ecr_repository} -
 
         The tracked job id is the *simulation* job. Batch will not start it until
         the ParCa job SUCCEEDED, so the cache is in S3 before the sim stages it.
+
+        ROUTING (backlog item 33 rework): the canonical batch_baseline sweep
+        (``composite`` is None, more than one generation) is delegated ENTIRELY
+        to ``submit_chain_dispatch_job`` — individual per-seed AWS Batch job
+        chains, a true v2 analogy of vEcoli-private's own fully-asynchronous
+        per-seed Nextflow execution (Alex's explicit decision). This check runs
+        BEFORE any of the MNP/single-shot setup below, so a canonical request
+        never touches that setup, and never needs Array-job machinery at all —
+        ``_submit_array``/``_array_sim_command``/``_ensure_array_job_def`` were
+        REMOVED as part of this rework once this routing landed made them dead
+        code (their only caller was the array branch this replaced; confirmed
+        via a fresh repo-wide grep before deleting them, not assumed).
+
+        Every OTHER shape still reaches the MNP path below exactly as before:
+        the composite-driven two-engine comparison ensemble (genuinely fans out
+        via Ray actors, at ANY generation count — chain-dispatch is v2ecoli-only
+        and does not apply), and the single-generation phase0 ensemble.
         """
         if database_service is None:
             raise RuntimeError("DatabaseService is not available. Cannot submit Ray simulation job.")
+
+        config = ecoli_simulation.config
+        composite = getattr(config, "composite", None)
+        # config.generations is a real (non-"extra") SimulationConfig field, unlike
+        # the comparison knobs read further below -- read directly, not via getattr.
+        n_generations = int(config.generations or 1)
+        if composite is None and n_generations > 1:
+            return await self.submit_chain_dispatch_job(
+                ecoli_simulation, database_service, correlation_id=correlation_id
+            )
 
         parca_dataset = await database_service.get_parca_dataset(parca_dataset_id=ecoli_simulation.parca_dataset_id)
         if parca_dataset is None:
@@ -1112,24 +972,17 @@ bash docker/build-and-push-ecr.sh -i {commit} -r {settings.ray_ecr_repository} -
         # v2ecoli:<commit> (both ParCa and the sim run the same image).
         job_def = self._ensure_mnp_job_def(self._image_uri(commit), commit)
 
-        config = ecoli_simulation.config
         # SimulationConfig is a vEcoli passthrough (extra="allow"); the comparison
         # knobs are validated at the API boundary (Literal Query params) and ride
         # in as extra keys, so they're read here via getattr (present only when the
-        # caller set them). ``composite``/``vecoli_source`` values are already
-        # constrained by the endpoint's CompositeEngine/VecoliSource types.
+        # caller set them). ``vecoli_source`` is already constrained by the
+        # endpoint's VecoliSource type; ``composite`` was already read above.
         n_seeds = ecoli_simulation.num_seeds or getattr(config, "n_init_sims", None) or 1
         n_steps = getattr(config, "ray_n_steps", None) or settings.ray_n_steps
         chunk = getattr(config, "ray_chunk", None) or settings.ray_chunk
-        # Optional two-engine comparison knobs (default phase0 ensemble when unset).
-        composite = getattr(config, "composite", None)
         condition = getattr(config, "condition", None)
         max_generations = getattr(config, "max_generations", None)
         vecoli_source = getattr(config, "vecoli_source", None)
-        # config.generations is a real (non-"extra") SimulationConfig field, unlike
-        # the comparison knobs above -- read directly, not via getattr. Only the
-        # non-composite path branches on it (see _sim_command).
-        n_generations = int(config.generations or 1)
 
         # Engine-specific ParCa source: the pristine upstream wrapper (--composite
         # vecoli) stages an UPSTREAM-built simData (separate cache + build cmd);
@@ -1139,9 +992,11 @@ bash docker/build-and-push-ecr.sh -i {commit} -r {settings.ray_ecr_repository} -
         cache_s3 = self._upstream_cache_s3_uri(commit) if is_upstream else self._cache_s3_uri(commit)
         parca_command = self._upstream_parca_command() if is_upstream else self._parca_command()
 
-        # The multi-generation batch path dispatches through the generic run_pbg.py
-        # runner (see _sim_command) instead of a hardcoded CLI script, so it alone
-        # needs the runner staged to S3 first. Every other path is unaffected.
+        # Only the composite-driven comparison-ensemble path can still reach here
+        # with n_generations > 1 (the non-composite canonical shape is routed to
+        # chain-dispatch above, before this line); its own _sim_command branch
+        # never reads runner_s3_uri, but staging it costs nothing and this stays
+        # unconditional on generations alone, matching pre-existing behavior.
         runner_s3_uri = await self._stage_runner(experiment_id) if n_generations > 1 else None
 
         # Cost-allocation tags (propagate to ECS tasks → payer-account Cost
@@ -1167,103 +1022,52 @@ bash docker/build-and-push-ecr.sh -i {commit} -r {settings.ray_ecr_repository} -
             tags={**base_tags, "Phase": "parca"},
         )
 
-        # 2. Simulation ensemble, gated on ParCa, staging the cache.
-        #
-        # The canonical batch_baseline sweep (n_seeds independent seeds, only
-        # the within-seed generation chain is sequential -- verified via
-        # v2ecoli.workflow.run._resolve_parallel and run_seeds_parallel's pure
-        # ray.remote() fan-out, zero actors/shared state) is Array-jobs-shaped:
-        # dispatch it as N independent single-seed children instead of an MNP
-        # Ray cluster. Everything else (phase0 ensemble, comparison-ensemble)
-        # keeps using MNP -- those DO fan out via Ray actors internally. A
-        # single-seed batch_baseline request (n_seeds<=1) also stays on MNP:
-        # AWS Batch array jobs require size>=2, and there's no parallelism to
-        # gain from Array-izing a single seed anyway. See the ray-vs-batch-
-        # array-jobs-investigation decision: Array jobs for canonical, Ray-MNP
-        # stays for colonies/anything needing real Ray coordination.
-        is_array_eligible = composite is None and n_generations > 1 and int(n_seeds) > 1
-
-        if is_array_eligible:
-            if not runner_s3_uri:
-                raise RuntimeError("runner_s3_uri is required for batch_baseline array dispatch")
-            array_job_def = self._ensure_array_job_def(self._image_uri(commit), commit)
-            sim_job_id = self._submit_array(
-                job_name=f"array-sim-{experiment_id}-{_rand_suffix()}"[:128],
-                job_definition=array_job_def,
-                array_size=int(n_seeds),
-                array_job_cmd=self._array_sim_command(n_generations, str(experiment_id), runner_s3_uri),
-                out_s3=self._results_s3_uri(experiment_id),
-                out_dir=SIM_OUT_DIR,
-                stage_s3=cache_s3,
-                stage_dir=PARCA_CACHE_DIR,
-                depends_on=[parca_job_id],
-                tags={**base_tags, "Phase": "sim"},
-            )
-            logger.info(
-                "Array simulation %s: parca job %s -> sim job %s (%d array children)",
-                experiment_id,
-                parca_job_id,
-                sim_job_id,
+        # 2. Simulation ensemble (N-node Ray cluster), gated on ParCa, staging the
+        # cache. Always MNP now: the ONE shape that used to need Array jobs here
+        # (canonical batch_baseline, composite is None + multi-generation) is
+        # routed to submit_chain_dispatch_job before this method does ANY of the
+        # setup above (see the routing check at the top) -- every request that
+        # still reaches this point either sets composite (the comparison
+        # ensemble, which genuinely fans out via Ray actors) or requests a
+        # single generation (the phase0 ensemble).
+        sim_job_id = self._submit_mnp(
+            job_name=f"ray-sim-{experiment_id}-{_rand_suffix()}"[:128],
+            job_definition=job_def,
+            num_nodes=settings.ray_num_nodes,
+            ray_job_cmd=self._sim_command(
                 int(n_seeds),
-            )
-        else:
-            sim_job_id = self._submit_mnp(
-                job_name=f"ray-sim-{experiment_id}-{_rand_suffix()}"[:128],
-                job_definition=job_def,
-                num_nodes=settings.ray_num_nodes,
-                ray_job_cmd=self._sim_command(
-                    int(n_seeds),
-                    int(n_steps),
-                    int(chunk),
-                    composite=composite,
-                    condition=condition,
-                    max_generations=max_generations,
-                    vecoli_source=vecoli_source,
-                    n_generations=n_generations,
-                    experiment_id=str(experiment_id),
-                    runner_s3_uri=runner_s3_uri,
-                ),
-                out_s3=self._results_s3_uri(experiment_id),
-                out_dir=SIM_OUT_DIR,
-                stage_s3=cache_s3,
-                stage_dir=PARCA_CACHE_DIR,
-                depends_on=[parca_job_id],
-                tags={**base_tags, "Phase": "sim"},
-            )
-            logger.info(
-                "Ray simulation %s: parca job %s -> sim job %s (%d nodes)",
-                experiment_id,
-                parca_job_id,
-                sim_job_id,
-                settings.ray_num_nodes,
-            )
-
-        # 3. Analysis, gated on the simulation. The multi-generation batch_baseline
-        #    sweep is the shape that emits the hive-parquet the ported cd1_*/ptools_*
-        #    analyses read, so it is the shape that gets the third DAG node. The
-        #    comparison-ensemble and phase0 paths write no such sweep and are
-        #    deliberately untouched.
-        #
-        #    An Array sim job's parent id cannot be waited on under a SEQUENTIAL
-        #    dependency type (real AWS Batch rejection) -- plain {"jobId": …} there.
-        if composite is None and n_generations > 1:
-            analysis_job_id = await self._submit_analysis_job(
-                simulation=ecoli_simulation,
-                database_service=database_service,
-                job_definition=job_def,
-                commit=commit,
-                sim_job_id=sim_job_id,
-                n_seeds=int(n_seeds),
+                int(n_steps),
+                int(chunk),
+                composite=composite,
+                condition=condition,
+                max_generations=max_generations,
+                vecoli_source=vecoli_source,
                 n_generations=n_generations,
-                depends_type=None if is_array_eligible else "SEQUENTIAL",
-                tags={**base_tags, "Phase": "analysis"},
-            )
-            logger.info(
-                "Ray simulation %s: sim job %s -> analysis job %s",
-                experiment_id,
-                sim_job_id,
-                analysis_job_id,
-            )
+                experiment_id=str(experiment_id),
+                runner_s3_uri=runner_s3_uri,
+            ),
+            out_s3=self._results_s3_uri(experiment_id),
+            out_dir=SIM_OUT_DIR,
+            stage_s3=cache_s3,
+            stage_dir=PARCA_CACHE_DIR,
+            depends_on=[parca_job_id],
+            tags={**base_tags, "Phase": "sim"},
+        )
+        logger.info(
+            "Ray simulation %s: parca job %s -> sim job %s (%d nodes)",
+            experiment_id,
+            parca_job_id,
+            sim_job_id,
+            settings.ray_num_nodes,
+        )
+
+        # No inline analysis submission: the ONE shape that used to need it here
+        # (canonical batch_baseline) is entirely handled by chain-dispatch's own
+        # poller-triggered submit_campaign_analysis now (see
+        # JobScheduler.update_chain_campaigns / _advance_chain_campaign). The
+        # comparison-ensemble and phase0 paths that still reach this point write
+        # no cd1_*/ptools_*-ready sweep and never got inline analysis either --
+        # unaffected by this rework.
         return JobId.ray(sim_job_id)
 
     def _chain_base_tags(self, *, simulation: Simulation, commit: str) -> dict[str, str]:
@@ -1280,7 +1084,12 @@ bash docker/build-and-push-ecr.sh -i {commit} -r {settings.ray_ecr_repository} -
             "Team": getattr(settings, "cost_team_tag", None) or "covertlab",
         }
 
-    async def submit_chain_dispatch_job(self, ecoli_simulation: Simulation, database_service: DatabaseService) -> JobId:
+    async def submit_chain_dispatch_job(
+        self,
+        ecoli_simulation: Simulation,
+        database_service: DatabaseService,
+        correlation_id: str | None = None,
+    ) -> JobId:
         """Kick off a per-seed chain-dispatch campaign (backlog item 33 rework
         — individual per-seed job chains, replacing the per-generation-array
         "wave" design): submit ParCa (1 node), then EVERY seed's full
@@ -1289,6 +1098,22 @@ bash docker/build-and-push-ecr.sh -i {commit} -r {settings.ray_ecr_repository} -
         per-seed Nextflow execution (Alex's explicit decision, 2026-08-08) —
         seed 5 can be on generation 8 while seed 800 is still on generation 1,
         throttled only by available compute, never by a cross-seed barrier.
+
+        ``correlation_id``: this method (unlike a single-shot dispatch) always
+        records its OWN ``HpcRun`` row internally — see the ``insert_hpcrun``
+        call at the end — because the campaign-tracking row needs
+        ``chain_n_generations``/``chain_final_job_ids``, fields a generic
+        caller has no way to populate. When called directly (e.g. by tests, or
+        a future dedicated campaign-kickoff route) with no ``correlation_id``,
+        one is generated fresh here, exactly as before. When called FROM
+        ``submit_ecoli_simulation_job`` (the real dispatch entrypoint), that
+        method's own caller-supplied ``correlation_id`` is threaded through
+        instead, so the ONE row this method inserts uses the SAME
+        correlation_id the router/handler already generated for the request —
+        the row a status lookup by that id resolves to is the real campaign
+        row, not a second, generic one a caller might otherwise insert after
+        the fact (see ``viva_api.common.handlers.simulations``'s own
+        idempotent-insert guard, added alongside this parameter).
 
         For each seed independently: generation 0 ``dependsOn`` ParCa
         (SEQUENTIAL, matching the long-standing ParCa→sim edge shape exactly —
@@ -1459,7 +1284,7 @@ bash docker/build-and-push-ecr.sh -i {commit} -r {settings.ray_ecr_repository} -
             job_id=JobId.ray(parca_job_id),
             job_type=JobType.SIMULATION,
             ref_id=ecoli_simulation.database_id,
-            correlation_id=f"chain-campaign-{experiment_id}-{_rand_suffix()}",
+            correlation_id=correlation_id or f"chain-campaign-{experiment_id}-{_rand_suffix()}",
             chain_n_generations=n_generations,
             chain_final_job_ids=final_job_ids,
         )

--- a/viva_api/simulation/tables_orm.py
+++ b/viva_api/simulation/tables_orm.py
@@ -119,16 +119,23 @@ class ORMHpcRun(Base):
         ForeignKey("parca_dataset.id"), nullable=True, index=True
     )
     jobref_simulator_id: Mapped[int | None] = mapped_column(ForeignKey("simulator.id"), nullable=True, index=True)
-    # Wave-dispatch campaign fields (backlog item 33: per-generation task
-    # decomposition). NULL for every non-wave HpcRun (SLURM, K8s, MNP, single-shot
-    # Array) -- additive and backward-compatible, no new table: this model already
-    # supports multiple HpcRun rows per simulation (one row per wave/generation).
-    # ``wave_index`` is the 0-based generation this row's Array job ran;
-    # ``wave_seed_indices`` is the REAL seed number dispatched at each local array
-    # position (position i -> seed wave_seed_indices[i]), needed to remap a sparse
-    # survivor set back to real seeds after attrition.
-    wave_index: Mapped[int | None] = mapped_column(nullable=True)
-    wave_seed_indices: Mapped[list[int] | None] = mapped_column(JSONB, nullable=True)
+    # Chain-dispatch campaign fields (backlog item 33: per-generation task
+    # decomposition via individual per-seed AWS Batch job chains, each generation
+    # its own job chained natively via dependsOn). NULL for every non-campaign
+    # HpcRun (SLURM, K8s, MNP, single-shot Array) -- additive and backward-
+    # compatible, no new table. Unlike the per-generation-array design this
+    # superseded (one HpcRun row per generation), ONE row now tracks the WHOLE
+    # campaign: AWS Batch's own dependsOn resolves each seed's chain natively, so
+    # the only thing left to poll for is "has every seed's chain reached a
+    # terminal state" (JobScheduler.update_chain_campaigns). ``chain_n_generations``
+    # is the campaign's total generation count G (also the "is this row a
+    # chain-campaign tracker" discriminator, via IS NOT NULL); ``chain_final_job_ids``
+    # is the AWS Batch job id of each seed's own LAST successfully-submitted
+    # generation job (normally generation G-1, but truncated early for a seed
+    # whose chain hit a submission failure partway through) -- the exact set the
+    # analysis-fan-in poller watches for all-terminal.
+    chain_n_generations: Mapped[int | None] = mapped_column(nullable=True)
+    chain_final_job_ids: Mapped[list[str] | None] = mapped_column(JSONB, nullable=True)
 
     def _build_job_id(self) -> JobId:
         """Construct a JobId from the ORM columns."""
@@ -150,8 +157,8 @@ class ORMHpcRun(Base):
             error_message=self.error_message,
             start_time=str(self.start_time) if self.start_time else None,
             end_time=str(self.end_time) if self.end_time else None,
-            wave_index=self.wave_index,
-            wave_seed_indices=list(self.wave_seed_indices) if self.wave_seed_indices is not None else None,
+            chain_n_generations=self.chain_n_generations,
+            chain_final_job_ids=list(self.chain_final_job_ids) if self.chain_final_job_ids is not None else None,
         )
 
 

--- a/viva_api/simulation/tables_orm.py
+++ b/viva_api/simulation/tables_orm.py
@@ -119,6 +119,16 @@ class ORMHpcRun(Base):
         ForeignKey("parca_dataset.id"), nullable=True, index=True
     )
     jobref_simulator_id: Mapped[int | None] = mapped_column(ForeignKey("simulator.id"), nullable=True, index=True)
+    # Wave-dispatch campaign fields (backlog item 33: per-generation task
+    # decomposition). NULL for every non-wave HpcRun (SLURM, K8s, MNP, single-shot
+    # Array) -- additive and backward-compatible, no new table: this model already
+    # supports multiple HpcRun rows per simulation (one row per wave/generation).
+    # ``wave_index`` is the 0-based generation this row's Array job ran;
+    # ``wave_seed_indices`` is the REAL seed number dispatched at each local array
+    # position (position i -> seed wave_seed_indices[i]), needed to remap a sparse
+    # survivor set back to real seeds after attrition.
+    wave_index: Mapped[int | None] = mapped_column(nullable=True)
+    wave_seed_indices: Mapped[list[int] | None] = mapped_column(JSONB, nullable=True)
 
     def _build_job_id(self) -> JobId:
         """Construct a JobId from the ORM columns."""
@@ -140,6 +150,8 @@ class ORMHpcRun(Base):
             error_message=self.error_message,
             start_time=str(self.start_time) if self.start_time else None,
             end_time=str(self.end_time) if self.end_time else None,
+            wave_index=self.wave_index,
+            wave_seed_indices=list(self.wave_seed_indices) if self.wave_seed_indices is not None else None,
         )
 
 

--- a/viva_api/version.py
+++ b/viva_api/version.py
@@ -266,4 +266,60 @@
 #          _submit_mnp gains an optional depends_type: the analysis node waits on
 #          an ARRAY parent id, which AWS Batch rejects under SEQUENTIAL; the
 #          ParCa -> sim edge keeps its live-verified SEQUENTIAL shape untouched.
-__version__ = "0.9.41"
+# 0.9.42 — backlog item 33 REWORKED from per-generation-array "wave" dispatch to
+#          individual per-seed AWS Batch job chains, matching vEcoli-private's own
+#          fully-asynchronous per-seed Nextflow execution (Alex's explicit decision:
+#          "it must be a true v2 analogy of vEcoli-private"). The wave design made
+#          every seed wait at every generation boundary; this doesn't -- seed 5 can
+#          be on generation 8 while seed 800 is on generation 1, throttled only by
+#          available compute.
+#          submit_chain_dispatch_job (new, replaces submit_wave_dispatch_job/
+#          submit_next_wave) submits ParCa + EVERY seed's full G-generation
+#          dependsOn chain upfront -- N*G individual MNP (num_nodes=1) jobs,
+#          TPS-paced below the account-wide 50 TPS SubmitJob cap (_SubmitJobPacer,
+#          proactive + real elapsed-time-based, not a fixed sleep guess) with real
+#          retry-on-throttle (botocore "standard" retry mode on a dedicated client
+#          for this loop only). _seed_generation_command (replaces _wave_sim_command)
+#          is simpler than the design it replaces: seed + generation are both known
+#          at SUBMISSION time, so the whole --overrides payload is static -- no
+#          AWS_BATCH_JOB_ARRAY_INDEX, no lookup table, no container-start shell/
+#          python3 merge step at all.
+#          WHY MNP, not a "singleton array job": confirmed directly against
+#          sms-cdk's batch-array-entrypoint.sh and AWS's own job_env_vars.html that
+#          NEITHER shipped entrypoint supports a genuinely standalone job --
+#          batch-array-entrypoint.sh hard-requires AWS_BATCH_JOB_ARRAY_INDEX (only
+#          set for array children, and arrayProperties.size has a hard floor of 2 --
+#          no size-1 array exists), and a true per-seed dependsOn chain needs each
+#          generation to be its own job with its own id anyway (array children can't
+#          dependsOn each other). MNP num_nodes=1 is the one already-proven
+#          standalone-job mechanism (ParCa/analysis already use it) -- reused as-is,
+#          no sms-cdk change. _submit_mnp gains an optional retry_strategy override
+#          (restores per-job retry on the MNP job definition, which -- unlike the
+#          Array job definition -- declares none of its own; matches the Array job
+#          def's own already-tuned attempts=2) and an optional batch_client override
+#          (lets the bulk submission loop use its own retry-configured client
+#          without changing any other existing call site's behavior).
+#          FLAGGED, NOT SILENTLY ABSORBED: the MNP queue's compute environment
+#          (RayBatchOnDemandCE, confirmed against sms-cdk/lib/ray-batch-stack.ts) is
+#          ON-DEMAND ONLY, unlike the Array job definition's Spot-tolerant queue --
+#          a real cost-shape difference from the superseded design that the
+#          retry_strategy override can't fix (Spot pricing is a compute-environment
+#          property, not a submission-time parameter). Left open for a companion
+#          sms-cdk change, documented prominently in submit_chain_dispatch_job's own
+#          docstring rather than silently ignored.
+#          JobScheduler.update_wave_jobs/_advance_wave -> update_chain_campaigns/
+#          _advance_chain_campaign: no "advance to next generation" step needed at
+#          all now (Batch's own dependsOn already does that) -- just "has every
+#          seed's chain reached a terminal state," then submit_campaign_analysis
+#          (new, thin wrapper over the unchanged _submit_analysis_job) with NO
+#          native dependsOn, since by construction everything it depends on already
+#          finished by the time the poller fires.
+#          ORMHpcRun.wave_index/wave_seed_indices -> chain_n_generations/
+#          chain_final_job_ids (migration f2b8e4a6c9d1 amended in place -- still
+#          unmerged, nothing deployed against the old names); ONE HpcRun row now
+#          tracks a whole campaign (each seed's own last successfully-submitted job
+#          id), not one row per generation. n_seeds >= 2 is no longer required
+#          (that floor was AWS Batch's own array-size minimum, moot once nothing is
+#          an array job). RayLayout.wave_state_uri/wave_state_prefix ->
+#          daughter_state_uri/daughter_state_prefix (pure rename, same S3 layout).
+__version__ = "0.9.42"


### PR DESCRIPTION
## Summary

**PIVOTED 2026-08-08** from the per-generation-array "wave" design (this PR's original scope) to **individual per-seed AWS Batch job chains** — a true v2 analogy of vEcoli-private's own fully-asynchronous per-seed Nextflow execution. Alex (project owner) reviewed the discrepancy directly and gave an explicit decision: *"it must be a true v2 analogy of vEcoli-private... yes proceed with the individual per-seed chaining work."*

**Why the pivot.** The wave design (this PR's original commits, still in the history below) made every seed wait at every generation boundary — no seed could start generation N+1 until *every* other seed finished generation N. Real vEcoli-private does not do this: seed 5 can be on generation 8 while seed 800 is still on generation 1, throttled only by available compute, never by an artificial cross-seed barrier. A whole modeling team's throughput depends on the real execution behavior matching v1's, not just resembling it.

**The new design, in one line:** for each seed independently, submit all G generations' jobs upfront, each `dependsOn` the previous one's own job id — AWS Batch's native dependency resolution (not orchestrator polling) advances every chain. The ONE thing still needing orchestrator-side polling is knowing when to fire the analysis: it must run once, after all N seeds' chains have reached *some* terminal state (success or permanent failure). Since N can be 1000 and a job caps at 20 dependencies, that can't be a native `dependsOn` — `JobScheduler` polls each campaign's N tracked final-job ids and fires the analysis once every one is terminal.

**UPDATE (same day):** a review pass found the mechanism above, while fully built and tested in isolation, was never actually **reachable** — see "The wiring gap" section below. That's now closed on this same branch/PR.

## What's here now (post-pivot)

- **`SimulationServiceRay.submit_chain_dispatch_job`** (replaces `submit_wave_dispatch_job`/`submit_next_wave`): submits ParCa, then **every seed's full G-generation `dependsOn` chain**, all N×G jobs upfront — TPS-paced below AWS Batch's fixed 50 TPS account-wide `SubmitJob` cap (`_SubmitJobPacer`, proactive, real elapsed-time-based, not a fixed sleep guess) with real retry-on-throttle (botocore `"standard"` retry mode on a dedicated client for this loop only, so no other existing call site's behavior changes). A submission failure partway through one seed's chain truncates *just* that seed's chain — its already-submitted jobs keep running normally, nothing later is submitted for it, and its last successfully-submitted job id is what gets tracked. Other seeds are unaffected.
- **`_seed_generation_command`** (replaces `_wave_sim_command`): builds one seed's one generation's command. Genuinely simpler than the design it replaces — since an individual job already knows its own fixed seed *and* generation at submission time, the whole `--overrides` payload is static. No `AWS_BATCH_JOB_ARRAY_INDEX`, no lookup table, no container-start shell/python3 merge step at all.
- **Why MNP (`_submit_mnp`, `num_nodes=1`), not a "singleton array job".** Confirmed directly against the real, shipped mechanism this session (sms-cdk's `batch-array-entrypoint.sh` + AWS's own `job_env_vars.html` docs): neither of viva-api's two entrypoint scripts supports a genuinely standalone job with its own independent job id. `batch-array-entrypoint.sh` hard-requires `AWS_BATCH_JOB_ARRAY_INDEX`, which AWS Batch only sets for children of a real array job — and `arrayProperties.size` has a hard floor of 2 (no size-1 array exists). A true per-seed `dependsOn` chain needs each generation to be its own job with its own id anyway (array children can't `dependsOn` each other individually), so array jobs were never a fit for this design regardless. MNP with `num_nodes=1` is the one mechanism already proven to submit a genuinely standalone job — ParCa and the analysis job already run this way — reused as-is, no new job type, no sms-cdk change. `_submit_mnp` gains two purely-additive optional parameters: `retry_strategy` (restores per-job retry on the MNP job definition, which — unlike the Array job definition — declares none of its own; matches the Array job def's own already-tuned `attempts=2`) and `batch_client` (lets the bulk submission loop use its own retry-configured client without touching any other existing call site).
- **Known, flagged cost tradeoff — not silently absorbed.** The MNP queue's compute environment (`RayBatchOnDemandCE`, confirmed directly against `sms-cdk/lib/ray-batch-stack.ts`) is **on-demand only**, unlike the Array job definition's Spot-tolerant queue. The `retry_strategy` override restores per-job *retry*; it cannot restore Spot *pricing* (a compute-environment property, not a submission-time parameter). This is a real cost-shape difference from the superseded array-child design, documented prominently in `submit_chain_dispatch_job`'s own docstring, left open for a companion sms-cdk change (e.g. a Spot-capable container-type job definition with a relaxed entrypoint) — not this PR's scope, and not something viva-api alone can close.
- **`JobScheduler.update_chain_campaigns`/`_advance_chain_campaign`** (replaces `update_wave_jobs`/`_advance_wave`): the `_polling_loop` structure is unchanged. Unlike the wave design, there is no "advance to the next generation" step left to do at all — Batch's own `dependsOn` already does that. The only thing left to poll for is "has every seed's chain reached a terminal state," answered by the new `SimulationServiceRay.get_chain_campaign_result` (batched `describe_jobs`, chunked at AWS's real 100-id-per-call cap, replacing the wave design's single-array-job `get_wave_result`/`list_jobs` pagination). Terminal-with-at-least-one-success submits the analysis (`submit_campaign_analysis`, a thin wrapper reusing item 24's existing `_submit_analysis_job` completely as-is, with `sim_job_id=None` — no native `dependsOn`, since by construction everything it depends on already finished by the time the poller fires); terminal-with-zero-successes marks the campaign `FAILED` with no analysis submitted.
- **`ORMHpcRun.wave_index`/`wave_seed_indices` → `chain_n_generations`/`chain_final_job_ids`** (migration `f2b8e4a6c9d1` amended in place — still unmerged, nothing deployed against the old names, so no second migration needed). Unlike the wave design (one `HpcRun` row per generation), **one row now tracks a whole campaign**: `chain_n_generations` is the campaign's total generation count G; `chain_final_job_ids` is each seed's own last successfully-submitted job id — exactly the set the analysis-fan-in poller watches.
- **`n_seeds >= 2` is no longer required** (dropped from the wave design's own validation): that floor was AWS Batch's own array-size minimum, moot once nothing dispatched here is an array job at all.
- **`RayLayout.wave_state_uri`/`wave_state_prefix` → `daughter_state_uri`/`daughter_state_prefix`** — pure rename (same deterministic S3 layout, same `seed{seed}/gen{generation}.pkl` scheme), reused as-is per-seed instead of per-wave.
- **`db_reconcile.py`**: added the missing `LEGACY_FINGERPRINTS` marker for this migration (a pre-existing gap on this branch — the original wave-dispatch commits added the migration but never added its fingerprint marker, per this repo's own documented "add a new fingerprint marker whenever you add a migration" contract while `create_all` still bootstraps prod DBs).
- **Version bump 0.9.41 → 0.9.42** with a full changelog entry in `version.py`.

## The wiring gap (found in review, closed on this same branch)

A review pass independently confirmed a real gap before this was reachable for a pilot: `submit_chain_dispatch_job` had **zero callers outside its own tests** (`grep -rn "submit_chain_dispatch_job"` — every non-test hit was a docstring/comment cross-reference), and `git diff main...HEAD -- viva_api/api/` was empty — no router had ever changed. `submit_ecoli_simulation_job`, the actual entrypoint every real request goes through, still had its original `is_array_eligible` branch routing the canonical batch_baseline shape unconditionally to the old array-job path. **A real request would have silently kept exercising the old array/wave-style path forever.**

Closed in the follow-up commit:

- **`submit_ecoli_simulation_job`** now checks `composite is None and n_generations > 1` **before any MNP/array setup runs** and delegates the whole request to `submit_chain_dispatch_job`. `n_seeds >= 1` is sufficient now (matches the `n_seeds >= 2` relaxation above).
- **Removed `_submit_array`/`_array_sim_command`/`_ensure_array_job_def` entirely**, plus `submit_ecoli_simulation_job`'s now-dead `is_array_eligible` branch and its now-dead inline analysis-submission block — both were guarded by exactly the condition the new routing check now intercepts first, so neither could execute again (confirmed via grep before deleting, not assumed). This was the existing single-shot dispatch path (items 24/26/27); it's now fully absorbed into chain-dispatch for the one shape it served, and gone.
- **`submit_chain_dispatch_job` gained an optional `correlation_id` parameter**, threaded from `submit_ecoli_simulation_job`'s own caller-supplied one. Without this, the campaign's own internal `insert_hpcrun` (recording `chain_n_generations`/`chain_final_job_ids` — fields no generic caller can populate) and the handler's separate `insert_hpcrun` call in `viva_api/common/handlers/simulations.py` would race to record **two rows** for one simulation under different correlation_ids — and since `get_hpcrun_by_ref` (every real status endpoint's lookup) resolves to the **most recently inserted** row, the handler's own later, generic insert would permanently shadow the real campaign row with a stale one nobody ever updates. Fixed at both ends: `submit_chain_dispatch_job` reuses the caller's correlation_id when given one, and both handler call sites gained an idempotent guard (`get_hpcrun_id_by_correlation_id` before insert — an existing DB method, zero new query logic) that's a no-op for every other dispatch shape.
- **New real regression coverage — the test that would have caught this:**
  - `TestSimulationServiceRaySubmit` (`test_ray_backend.py`) now calls `submit_ecoli_simulation_job` directly (multiseed AND single-seed canonical requests) asserting real per-seed-chain jobs get submitted — never the array path — plus a guard test proving a composite-driven comparison-ensemble request with `generations>1` correctly stays on MNP (chain-dispatch is v2ecoli-only).
  - `tests/integration/test_k8s_workflow_mock.py` gained an end-to-end test through the **real request path** (`run_simulation_workflow` → repo-based backend resolution via the same `global_simulation_services` registry a real deployment uses, keyed by the real sms-ecoli repo URL) with a multiseed × multigeneration request, mocked AWS Batch. Verifies real dependsOn chains AND, via a raw SQL row count (not just `get_hpcrun_by_ref`'s most-recent-wins lookup, which a shadowing duplicate could hide behind), that **exactly one** `HpcRun` row exists.
  - `tests/integration/test_aws_batch_e2e.py`'s placeholder is now a real, genuine multiseed × multigeneration chain-dispatch test against real AWS Batch on smsvpctest (real ParCa + per-seed chains, real dependsOn polling, real analysis DAG submission, real cd1_*/ptools_* artifact verification in S3), idempotent like `test_hpc_workflow.py`, gated behind `AWS_BATCH_INTEGRATION=1`. Written and verified to collect/skip cleanly and pass `make check` — **deliberately not executed against real AWS this session** (real dispatch, real cost, needs an explicit go-ahead first).
- **v1-analogy re-confirmed at the routing level, not just re-asserted**: the new routing check is a single synchronous decision (no `await` before it), evaluated once per request, entirely before any per-seed/per-generation logic runs. A diff against the pre-fix commit shows `submit_chain_dispatch_job`'s own submission loop, TPS pacing, and dependsOn-chaining logic are **byte-for-byte unchanged** by this wiring — the only touched line is which `correlation_id` its own single `insert_hpcrun` call uses. Submission order (paced, front-loaded) was already decoupled from execution order (AWS Batch's own dependency-driven scheduling) in the already-verified isolated version; routing a request to that same, untouched mechanism earlier cannot introduce a barrier that wasn't already absent.

## What's unchanged from before

- `_analysis_command` / `_submit_analysis_job`'s actual analysis-job logic (only its `sim_job_id` parameter became optional, purely additively).
- `_ensure_mnp_job_def`, `_parca_command`, `_stage_runner`, `analysis_modules_for` — all reused as-is.

## Test plan

- [x] `TestSubmitJobPacer`: TPS-pacing math against a fake monotonic clock.
- [x] `TestSeedGenerationCommand`: fully static `--overrides` payload parsed via `shlex.split` (no container-start merge step left to execute).
- [x] `TestChainDispatchSubmission`: representative-seed dependency chain, single-seed multi-generation, rate-limiter pacing, seed-submission-failure truncation (tracks the real last-successful job id, not a nonexistent later one), generation-0 failure excludes a seed entirely.
- [x] `TestGetChainCampaignResult`: empty-campaign trivial-terminal, not-terminal while pending, all-succeeded, mixed success/failure (still terminal), all-failed (still terminal), a missing job id treated as not-yet-terminal, `describe_jobs` chunked at the real 100-id cap.
- [x] `TestSubmitCampaignAnalysis`: no native `dependsOn`, original requested seed count used, `analysis_options` propagation, failed-submission recorded not swallowed.
- [x] `TestAdvanceChainCampaign` (real Postgres): no-op without Ray, not-terminal untouched, success submits analysis, zero-success marks `FAILED`, a permanently-failed seed's job is never individually re-marked (exactly one `update_hpcrun_status` call per advance), two concurrent campaigns end-to-end.
- [x] **`TestSimulationServiceRaySubmit`** (new): canonical multiseed/single-seed requests through the real `submit_ecoli_simulation_job` entrypoint reach chain-dispatch; composite comparison-ensemble requests correctly don't.
- [x] **`test_k8s_workflow_mock.py`** (new): full real-request-path routing + exactly-one-HpcRun-row proof, mocked AWS.
- [x] **`test_aws_batch_e2e.py`** (filled in): real multiseed × multigeneration chain-dispatch against real AWS Batch — written, `make check`-clean, collects/skips cleanly, **not yet executed** (needs explicit go-ahead).
- [x] `make check` clean: `uv lock --locked`, `ruff check`/`ruff format --check`, `mypy` (193 source files), `deptry` — zero findings.
- [x] Scoped suite (`tests/simulation/`, `tests/common/`, `tests/app/`, `tests/clients/`, `tests/data/`, `tests/compose/`, `tests/api/`, `tests/integration/`), pre-existing environment-credential issues neutralized via env (documented SSH-key issue plus a newly-hit expired AWS session token in `test_s3_simulation_data.py`, confirmed zero overlap with anything touched here): **555 passed, 64 skipped, 0 failed** — same result via the real `make test` target.
- [x] Real CI (GitHub Actions) green on every push: `quality`, `tests-and-type-check (3.13)`, `check-docs` all pass.

## A pre-existing, unrelated finding (not fixed in this PR, flagged not silently absorbed)

The checked-in OpenAPI spec (`viva_api/api/spec/openapi_3_1_0_generated.yaml`) is significantly stale relative to source (checked in at `0.9.20` vs. source already past `0.9.41` before this session). Regenerating it via `make spec` pulls in a large amount of unrelated drift; not committed here to keep this PR's diff reviewable — flagged for a separate, dedicated cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
