### PR TITLE
deploy(stanford prod): api 0.9.41 -> 0.9.42

### DIFF
--- a/kustomize/overlays/sms-api-stanford-db-migration/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-db-migration/kustomization.yaml
@@ -7,7 +7,7 @@ images:
   - name: ghcr.io/vivarium-collective/sms-api
     # Must contain viva_api/simulation/db_reconcile.py (the Job runs it). Keep in
     # sync with the app overlay's sms-api tag; do not lower below 0.9.19.
-    newTag: 0.9.26
+    newTag: 0.9.42
 
 resources:
   - alembic-job.yaml

--- a/kustomize/overlays/sms-api-stanford/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford/kustomization.yaml
@@ -77,8 +77,16 @@ images:
   # entrypoint. Also splits the workbench Deployment out of this overlay into the
   # sibling ../sms-api-stanford-workbench overlay (item 21) and completes the
   # sms_api -> viva_api package rename (main/deploy-trunk reunified, #232/#233).
+  # 0.9.42 (#237): per-seed job chain dispatch replaces AWS Batch array jobs for
+  # simulation dispatch (item 33) -- each seed's generations run as their own
+  # sequentially-dependent chain instead of sharing one array job, removing the
+  # >=2-seed array floor and letting a campaign resume per-seed. get_simulation_status
+  # made chain-campaign-aware (item 14). Real-AWS-verified fix for the analysis-stage
+  # OOM (item 38): AnalysisOptions.memory_gb config knob + the new r7i.4xlarge/128GiB
+  # Ray-MNP compute environment (sms-cdk) together let the pilot-scale analysis
+  # complete without the OOM-kill the original bug had (job f87c7d34, exitCode 137).
   - name: ghcr.io/vivarium-collective/sms-api
-    newTag: 0.9.41
+    newTag: 0.9.42
   # ptools pinned to last-known-good tag — CI only builds sms-api, so there is
   # no newer sms-ptools:0.6.x image on ghcr.io.  0.5.9 is the tag the live Stanford
   # pod has been running successfully; keeping both namespaces pointing here


### PR DESCRIPTION
Bumps the sms-api-stanford (prod) and sms-api-stanford-db-migration overlays to 0.9.42, matching the just-released v0.9.42 (item 33 per-seed chain dispatch + item 38 analysis OOM fix). Image already built+pushed (workflow run 31523668985).