### PR TITLE
fix(workbench): pin remote runs to sms-ecoli, not v2ecoli

### DIFF
--- a/kustomize/base/workbench/workbench.yaml
+++ b/kustomize/base/workbench/workbench.yaml
@@ -183,10 +183,19 @@ spec:
             # build, many simulation configs — and it sidesteps the pod's
             # unwritable /workspace git remote + protected-main push. Enabled
             # declaratively here; no human GitHub token is embedded.
+            #
+            # repo/branch MUST be CovertLabEcoli/sms-ecoli — the canonical
+            # workflow's own workspace, never vivarium-collective/v2ecoli (a
+            # structurally-diverged sibling repo). This pin originally targeted
+            # v2ecoli (2026-07-13, pre-dates sms-ecoli becoming the canonical
+            # target) and was never updated — caused a real, live workspace-
+            # identity-mismatch dispatch on smscdk (caught 2026-08-11 before
+            # any spend; see the regression test below). Do not revert without
+            # updating tests/test_deploy_config.py too.
             - name: VIVARIUM_WORKBENCH_REMOTE_PINNED
               value: "1"
             - name: VIVARIUM_WORKBENCH_REMOTE_REPO_URL
-              value: "https://github.com/vivarium-collective/v2ecoli"
+              value: "https://github.com/CovertLabEcoli/sms-ecoli"
             - name: VIVARIUM_WORKBENCH_REMOTE_BRANCH
               value: "main"
             # The init container's chown only runs on FIRST seed (it's guarded by

--- a/tests/test_deploy_config.py
+++ b/tests/test_deploy_config.py
@@ -1,0 +1,51 @@
+"""Static sanity checks on kustomize deploy config that has no natural home
+in the application test tree — catches config drift a Python test otherwise
+never would.
+
+See kustomize/base/workbench/workbench.yaml's own comment for the incident
+this guards: the smscdk workbench deployment's pinned remote-run target
+regressed to vivarium-collective/v2ecoli (a structurally-diverged sibling
+repo) instead of the canonical CovertLabEcoli/sms-ecoli, undetected until an
+independent live-session check caught it before any real dispatch.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKBENCH_BASE = REPO_ROOT / "kustomize" / "base" / "workbench" / "workbench.yaml"
+
+CANONICAL_REMOTE_REPO_URL = "https://github.com/CovertLabEcoli/sms-ecoli"
+
+
+def _workbench_container_env() -> list[dict[str, Any]]:
+    docs: list[Any] = list(yaml.safe_load_all(WORKBENCH_BASE.read_text(encoding="utf-8")))
+    deployments = [d for d in docs if d and d.get("kind") == "Deployment"]
+    assert len(deployments) == 1, f"expected exactly one Deployment doc in {WORKBENCH_BASE}"
+    containers = deployments[0]["spec"]["template"]["spec"]["containers"]
+    assert len(containers) == 1, f"expected exactly one container in {WORKBENCH_BASE}"
+    env: list[dict[str, Any]] = containers[0]["env"]
+    return env
+
+
+def _env_value(env: list[dict[str, Any]], name: str) -> str:
+    matches: list[str] = [e["value"] for e in env if e.get("name") == name]
+    assert len(matches) == 1, f"expected exactly one {name} entry, found {len(matches)}"
+    return matches[0]
+
+
+def test_workbench_remote_pinned_repo_is_sms_ecoli() -> None:
+    """The deployed workbench's pinned-remote-run target must be sms-ecoli,
+    never v2ecoli — the canonical workflow's own workspace requirement.
+    Regression test for the 2026-08-11 live mismatch: this base manifest's
+    VIVARIUM_WORKBENCH_REMOTE_REPO_URL silently pointed at
+    vivarium-collective/v2ecoli, so every session on the smscdk deployment
+    that never explicitly called /api/source/switch-build inherited the
+    wrong dispatch target with zero warning until independently checked.
+    """
+    env = _workbench_container_env()
+    assert _env_value(env, "VIVARIUM_WORKBENCH_REMOTE_REPO_URL") == CANONICAL_REMOTE_REPO_URL
+    assert _env_value(env, "VIVARIUM_WORKBENCH_REMOTE_BRANCH") == "main"
+    assert _env_value(env, "VIVARIUM_WORKBENCH_REMOTE_PINNED") == "1"


### PR DESCRIPTION
## Summary

The smscdk workbench deployment's `VIVARIUM_WORKBENCH_REMOTE_REPO_URL` has pointed at `vivarium-collective/v2ecoli` since 2026-07-13 (commit `2ef52c0a7`), predating `sms-ecoli` becoming the canonical workflow's own workspace. No overlay ever overrode it (it's set once in `kustomize/base/workbench/workbench.yaml`, shared by every environment that includes this base), so every session on the deployed workbench that never explicitly called `/api/source/switch-build` silently inherited the wrong dispatch target.

Caught live on 2026-08-11 (same commit hash `bc0c416c92c7` as a prior 2026-08-04 incident already documented in `vivarium-workbench/.todo/_backlog.md` item 20) — before any real AWS spend, via an independent `GET /api/remote-run-config` check made from inside an authenticated browser session, deliberately not trusting the sidebar's own displayed workspace label (which showed `sms-ecoli` correctly, while the actual resolved dispatch target did not).

## Changes

- `kustomize/base/workbench/workbench.yaml`: `VIVARIUM_WORKBENCH_REMOTE_REPO_URL` → `https://github.com/CovertLabEcoli/sms-ecoli`, with a comment explaining why and pointing at the regression test.
- `tests/test_deploy_config.py` (new): static regression test parsing the rendered base manifest and asserting the remote-pinned env vars — repo URL, branch, and pinned flag — so this can't silently drift back without a test failure.

## Test plan

- [x] `uv run pytest tests/test_deploy_config.py -v` — passes
- [x] `uv run mypy tests/test_deploy_config.py` — clean (strict mode)
- [x] `uv run ruff check tests/test_deploy_config.py` — clean
- [x] `kubectl kustomize kustomize/overlays/sms-api-stanford-workbench` — confirmed the rendered manifest shows exactly this one value change, nothing else
- [ ] `kubectl diff` against the live smscdk cluster before apply
- [ ] Post-deploy: re-verify `GET /api/remote-run-config` from a real session resolves to sms-ecoli

No app version bump — this is a deploy-config-only change to the workbench container's env, not `viva_api` code; per this repo's own release-protocol convention it gets a descriptive deploy tag on the merge commit rather than a semver bump/release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)