### PR TITLE
deploy(stanford prod): workbench 0.3.37 -> 0.3.40

### DIFF
--- a/kustomize/overlays/sms-api-stanford-workbench/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-workbench/kustomization.yaml
@@ -154,8 +154,21 @@ images:
   # canonical:-flag semantics instead of last-run-wins; and adds a read-only
   # GET /api/server-version endpoint so a published/readonly bundle can
   # report what it's actually running.
+  # 0.3.40 (workbench #791/#793/#794/#795/#797, item 39; 0.3.38/0.3.39 were
+  # never deployed here) closes out the workbench image's Fix B: the
+  # Dockerfile stopped git-cloning a workspace repo at build time (0.3.38)
+  # but couldn't actually build on Apple Silicon -- polars needs AVX2, which
+  # QEMU/Rosetta cross-arch emulation can't execute, crashing `Illegal
+  # instruction` even at import time. Extended the existing AWS Batch DooD
+  # build mechanism (already used for v2ecoli's own images) for real amd64
+  # compute instead; found+fixed 3 more real bugs live (stale sanity-check
+  # import, Batch job-name dots, 4 missing git-sourced core deps the
+  # workspace image's own build excludes). Also fixes analysis-name
+  # translation for remote dispatch to resolve against the live served
+  # workspace instead of a build-time-baked snapshot (#791). First image
+  # built via this path, independently verified live on ghcr.io.
   - name: ghcr.io/vivarium-collective/vivarium-workbench
-    newTag: 0.3.37
+    newTag: 0.3.40
 
 replicas:
   # Single writer: workbench holds a git working copy + SQLite on an RWO EBS volume.


### PR DESCRIPTION
## Summary
- Bumps the `workbench` image (`ghcr.io/vivarium-collective/vivarium-workbench`) `newTag` from `0.3.37` to `0.3.40` in the `sms-api-stanford-workbench` overlay.
- Closes out backlog item 39: the workbench Dockerfile now pulls sms-ecoli's own published, per-commit ECR image instead of git-cloning a workspace repo at build time, built via a new AWS Batch DooD path (real amd64 compute — local Apple Silicon builds hit an unfixable AVX2/QEMU emulation crash). See [vivarium-workbench v0.3.40 release notes](https://github.com/vivarium-collective/vivarium-workbench/releases/tag/v0.3.40) for the full fix chain (#791/#793/#794/#795).
- `kubectl diff -k` confirmed the change touches only the `workbench` Deployment's two container image tags (`workbench` + `seed-workspace` init container) plus the automatic `generation` bump — nothing else.

## Test plan
- [x] `kubectl diff -k kustomize/overlays/sms-api-stanford-workbench` — scoped diff confirmed before applying.
- [x] `kubectl apply -k kustomize/overlays/sms-api-stanford-workbench` — applied to smscdk prod.
- [ ] `kubectl rollout status deployment/workbench -n sms-api-stanford` — in progress.
- [ ] Live-verify on the running pod that `ANALYSIS_REGISTRY` has 27+ entries (not the old 6-entry stub).

🤖 Generated with [Claude Code](https://claude.com/claude-code)