### PR TITLE
deploy(stanford prod): workbench 0.3.40 -> 0.3.41

### DIFF
--- a/kustomize/overlays/sms-api-stanford-workbench/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-workbench/kustomization.yaml
@@ -167,8 +167,15 @@ images:
   # translation for remote dispatch to resolve against the live served
   # workspace instead of a build-time-baked snapshot (#791). First image
   # built via this path, independently verified live on ghcr.io.
+  # 0.3.41 (workbench #799/#800) closes item 39 for real: 0.3.40's live
+  # ANALYSIS_REGISTRY check found only 6 of 45 real entries even with a
+  # correctly-pinned, non-stub install -- build_analysis_options() never
+  # imported the sibling v2ecoli.workflow.analyses package, the one that
+  # actually registers every cd1_*/ptools_* analysis via import-time
+  # side effects. env_worker.py already knew to do this for the local run
+  # path; the remote dispatch path (this item's own subject) didn't.
   - name: ghcr.io/vivarium-collective/vivarium-workbench
-    newTag: 0.3.40
+    newTag: 0.3.41
 
 replicas:
   # Single writer: workbench holds a git working copy + SQLite on an RWO EBS volume.


### PR DESCRIPTION
## Summary
- Bumps the `workbench` image `newTag` from `0.3.40` to `0.3.41`.
- Closes out backlog item 39 for real: 0.3.40's live `ANALYSIS_REGISTRY` check found only 6 of 45 real entries even with a correctly-pinned, non-stub install — `build_analysis_options()` never imported the sibling `v2ecoli.workflow.analyses` package, the one that actually registers every `cd1_*`/`ptools_*` analysis. Fixed in [vivarium-workbench#799](https://github.com/vivarium-collective/vivarium-workbench/pull/799)/[#800](https://github.com/vivarium-collective/vivarium-workbench/pull/800).
- `kubectl diff -k` confirmed the change touches only the `workbench` Deployment's two container image tags + the automatic `generation` bump.

## Test plan
- [x] `kubectl diff -k` — scoped diff confirmed.
- [x] `kubectl apply -k` — applied to smscdk prod.
- [ ] `kubectl rollout status` — in progress.
- [ ] Live-verify `ANALYSIS_REGISTRY` has 45 entries including cd1_*/ptools_* names on the real pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)