### PR TITLE
deploy(stanford prod): workbench 0.3.40 -> 0.3.42

### DIFF
--- a/kustomize/overlays/sms-api-stanford-workbench/kustomization.yaml
+++ b/kustomize/overlays/sms-api-stanford-workbench/kustomization.yaml
@@ -168,7 +168,7 @@ images:
   # workspace instead of a build-time-baked snapshot (#791). First image
   # built via this path, independently verified live on ghcr.io.
   - name: ghcr.io/vivarium-collective/vivarium-workbench
-    newTag: 0.3.40
+    newTag: 0.3.42
 
 replicas:
   # Single writer: workbench holds a git working copy + SQLite on an RWO EBS volume.


### PR DESCRIPTION
## Summary
- Bumps the `sms-api-stanford-workbench` overlay's `vivarium-workbench` image tag from `0.3.40` to `0.3.42` (both the `workbench` container and the `seed-workspace` init container).
- Ships backlog item 44's fix: the workbench pod has been in `CrashLoopBackOff` in prod — root cause was the multi-stage Dockerfile's `--no-deps` install never enforcing vivarium-workbench's own `process-bigraph>=1.8.2` floor against sms-ecoli's stale locked `1.5.0` (missing the `artifacts` submodule imported at server startup). Fixed via an explicit pinned install of `process-bigraph`/`bigraph-schema` to the exact commits vivarium-workbench's own `uv.lock` resolves (vivarium-workbench PRs #802, #803).
- `0.3.42` is a strict superset of `0.3.41` — this branch was cut directly from `main` (currently at `0.3.40`) rather than stacking on the still-open PR #242 (`0.3.40 -> 0.3.41`), since #242's own content is already fully included. #242 should be closed or merged separately for the historical record; it is not required before this PR.

## Test plan
- [x] `kubectl diff -k kustomize/overlays/sms-api-stanford-workbench` previewed locally — confirmed the only change is both containers' image tag, no other drift.
- [x] New image independently verified via `docker manifest inspect ghcr.io/vivarium-collective/vivarium-workbench:0.3.42` (real manifest returned).
- [ ] `kubectl apply -k` to prod + rollout health check (restart count stable over time, not a single point-in-time read) — pending, done as a separate explicit step after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)