### PR TITLE
fix(image): keep dev/docs dependency groups out of the api runtime image

### DIFF
--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -20,6 +20,19 @@ ENV PYTHONUNBUFFERED=1 \
     MKL_NUM_THREADS=1 \
     OPENBLAS_NUM_THREADS=1
 
+# Keep the dev/docs dependency groups out of the runtime image.
+#
+# This MUST be an ENV, not just a `--no-default-groups` flag on the `uv sync`
+# calls below: every command this image actually runs goes through `uv run`
+# (the CMD, and the alembic-migrate Job's
+# `uv run python -m viva_api.simulation.db_reconcile`), and `uv run` re-syncs
+# the environment against `[tool.uv] default-groups = ["dev", "docs"]` before
+# executing. Build-time flags alone are therefore inert — verified: a
+# `--no-default-groups` build followed by a plain `uv run` reinstalls 37 dev
+# packages at container start, which also makes startup depend on network
+# access to the index. The env var is what the runtime `uv run` honors.
+ENV UV_NO_DEFAULT_GROUPS=true
+
 # Install uv from the GitHub Container Registry
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
@@ -48,8 +61,9 @@ WORKDIR /app
 COPY --chown=appuser:appgroup uv.lock /app/uv.lock
 COPY --chown=appuser:appgroup pyproject.toml /app/pyproject.toml
 
-# Install dependencies
-RUN uv sync --frozen --no-install-project --no-dev
+# Install dependencies (--no-dev is redundant under UV_NO_DEFAULT_GROUPS but kept
+# explicit; note --no-dev alone would still install the separate `docs` group)
+RUN uv sync --frozen --no-install-project --no-default-groups
 
 # Copy the rest of the application code
 COPY --chown=appuser:appgroup viva_api /app/viva_api
@@ -70,7 +84,7 @@ RUN mkdir -p /app/.results_cache && \
     chown appuser:appgroup /app/.results_cache
 
 # Sync the project
-RUN uv sync --frozen
+RUN uv sync --frozen --no-default-groups
 
 # Test the project (skip Docker-dependent tests since we're inside a container)
 #RUN SKIP_DOCKER_TESTS=1 uv run python -m pytest

--- a/tests/test_deploy_config.py
+++ b/tests/test_deploy_config.py
@@ -16,6 +16,7 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKBENCH_BASE = REPO_ROOT / "kustomize" / "base" / "workbench" / "workbench.yaml"
+DOCKERFILE_API = REPO_ROOT / "Dockerfile-api"
 
 CANONICAL_REMOTE_REPO_URL = "https://github.com/CovertLabEcoli/sms-ecoli"
 
@@ -49,3 +50,38 @@ def test_workbench_remote_pinned_repo_is_sms_ecoli() -> None:
     assert _env_value(env, "VIVARIUM_WORKBENCH_REMOTE_REPO_URL") == CANONICAL_REMOTE_REPO_URL
     assert _env_value(env, "VIVARIUM_WORKBENCH_REMOTE_BRANCH") == "main"
     assert _env_value(env, "VIVARIUM_WORKBENCH_REMOTE_PINNED") == "1"
+
+
+def test_api_image_excludes_dev_and_docs_dependency_groups() -> None:
+    """The runtime api image must not ship the dev/docs dependency groups.
+
+    Guards BOTH halves, because either alone is insufficient:
+
+    * ``ENV UV_NO_DEFAULT_GROUPS=true`` — the load-bearing one. Every command
+      the image runs goes through ``uv run`` (the CMD, and the alembic-migrate
+      Job's ``uv run python -m viva_api.simulation.db_reconcile``), and
+      ``uv run`` re-syncs against ``[tool.uv] default-groups = ["dev", "docs"]``
+      before executing. Without this env var a ``--no-default-groups`` build is
+      inert: the dev group is reinstalled at container start (measured: 37
+      packages), which silently restores pytest/debugpy/ipdb in production AND
+      makes startup depend on reaching the package index.
+    * ``--no-default-groups`` on every ``uv sync`` — so the groups are never
+      written into the image layers in the first place.
+
+    Note ``--no-dev`` is NOT sufficient in place of ``--no-default-groups``:
+    it excludes only the ``dev`` group, leaving the separate ``docs`` group
+    (sphinx et al.) installed.
+    """
+    dockerfile = DOCKERFILE_API.read_text(encoding="utf-8")
+
+    assert "ENV UV_NO_DEFAULT_GROUPS=true" in dockerfile, (
+        "Dockerfile-api must set UV_NO_DEFAULT_GROUPS=true; without it `uv run` "
+        "reinstalls the dev group at container start and the build-time flags are inert"
+    )
+
+    sync_lines = [
+        line.strip() for line in dockerfile.splitlines() if "uv sync" in line and not line.lstrip().startswith("#")
+    ]
+    assert sync_lines, "expected at least one `uv sync` line in Dockerfile-api"
+    for line in sync_lines:
+        assert "--no-default-groups" in line, f"`uv sync` line must pass --no-default-groups: {line!r}"


### PR DESCRIPTION
## Summary

The api image ships the full **dev + docs toolchain to production** — `pytest`, `mypy`, `tox`, `testcontainers`, `sphinx`, `debugpy`, `ipdb`, `openapi-python-client`. Confirmed live in **both** running containers:

| Deployment | Image | dev tooling |
|---|---|---|
| prod `sms-api-stanford` | `sms-api:0.9.42` | all present |
| dev `sms-api-stanford-test` | `sms-api:0.9.42-pr237-test` | all present |

**Cause:** `Dockerfile-api` ran `uv sync --frozen --no-install-project --no-dev`, then a bare `uv sync --frozen`, which re-resolves against `[tool.uv] default-groups = ["dev", "docs"]` and pulls everything back in. The first sync's `--no-dev` was effectively cancelled.

## Two non-obvious things, both verified rather than assumed

**1. Build-time flags alone are inert.** Every command this image runs goes through `uv run` — the CMD, and the alembic-migrate Job's `uv run python -m viva_api.simulation.db_reconcile` — and `uv run` **re-syncs against `default-groups` before executing**. A `--no-default-groups` build followed by a plain `uv run` reinstalled **37 dev packages at container start**:

```
$ UV_PROJECT_ENVIRONMENT=$V uv sync --frozen --no-default-groups   # pytest: absent
$ UV_PROJECT_ENVIRONMENT=$V uv run python -c ...
Installed 37 packages in 96ms
pytest after uv run: PRESENT
```

That would also have made container startup depend on reaching the package index. **`ENV UV_NO_DEFAULT_GROUPS=true` is the load-bearing change**; the sync flags just keep the layers clean.

**2. `--no-dev` is not enough.** It excludes only the `dev` group, leaving the separate `docs` group installed — `sphinx` survived a `--no-dev` sync. `--no-default-groups` covers both.

## Measured impact

On the real `pyproject.toml`/`uv.lock` (arm64):

| | size | packages |
|---|---|---|
| current (dev+docs) | 1375 MB | 262 |
| `--no-dev` only | 1194 MB | 224 |
| **`--no-default-groups`** | **1130 MB** | **203** |

**245 MB / 59 packages.** Modest against a 1.6 GB image — the substantive win is not shipping a debugger and a test framework to production, not the bytes.

## Verification

- Runtime entrypoints resolve under the new env: `viva_api.api.main` imports, `uvicorn` resolves, `python -m viva_api.simulation.db_reconcile --help` runs.
- `ruff`, `marimo`, `alembic`, `fastapi` are **main** dependencies and are unaffected (`ruff` in particular is in `[project] dependencies`, not `dev`).
- Nothing in `kustomize/` invokes pytest/mypy/sphinx against this image; `scripts/generate-api-client.sh` uses `openapi-python-client` but runs locally via `make api_client`, not in the container.
- `ruff check` / `ruff format --check` / `mypy` clean; `tests/test_deploy_config.py` 2/2 pass.

**Not verified: a full local `docker build`.** This machine's Docker daemon cannot reach `deb.debian.org`, so the build fails at the `apt-get` layer — which **precedes every line changed here**, i.e. pre-existing and unrelated to this diff. CI / build-and-push will exercise the real build.

## Regression guard

Adds `test_api_image_excludes_dev_and_docs_dependency_groups` to `tests/test_deploy_config.py` asserting **both** halves. Removing the ENV alone silently restores the old behavior with no other visible signal, so it's guarded explicitly. Negative-control checked: deleting the ENV line makes the test fail with the explanatory message; restoring it passes.

## Deliberately out of scope

- **No version bump.** Following the precedent of #227 (item 21 overlay split), which merged without one and was picked up by the subsequent deploy PR. `0.9.43` is already claimed by open #239, so bumping here would collide.
- **`tests/` is still COPYed into the image.** With the dev group gone it's inert (unrunnable), so removing it is a separate, larger call about whether in-image test runs are ever intended — `Dockerfile-api`'s commented-out `RUN ... pytest` suggests they once were.

## Test plan

- [x] `uv run pytest tests/test_deploy_config.py -v` — 2 passed
- [x] Negative control: guard fails when `ENV UV_NO_DEFAULT_GROUPS=true` is removed
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] `uv run mypy tests/test_deploy_config.py` — clean
- [x] Entrypoints verified under `--no-default-groups` + `UV_NO_DEFAULT_GROUPS=true`
- [ ] Real image build via CI / build-and-push (cannot run locally, see above)
- [ ] Post-merge: confirm on a rolled pod that `pytest`/`debugpy` are absent and the app serves

🤖 Generated with [Claude Code](https://claude.com/claude-code)