### PR TITLE
chore(ci): gate build-and-push on tests; drop the dead in-image test run

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -7,15 +7,59 @@ on:
         description: "Version to build and push (optional)"
         required: false
         default: ""
+      skip_tests:
+        description: "EMERGENCY ONLY: build without running the test gate"
+        required: false
+        default: false
+        type: boolean
 
+# The `test` job below is the gate. This workflow is dispatched with an
+# arbitrary `--ref` (the documented deploy loop routinely builds straight from
+# an unmerged feature branch), and `main`'s branch protection has NO required
+# status checks — so before this gate existed, nothing whatsoever guaranteed
+# that a pushed image had passing tests. The image build itself never ran them:
+# scripts/build_action.sh is `docker buildx build --push` and nothing else, and
+# Dockerfile-api's in-image `RUN pytest` had been commented out for a long time.
 jobs:
+  test:
+    # Skipped only via the explicit, auditable skip_tests input.
+    if: ${{ !inputs.skip_tests }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Check out
+        uses: actions/checkout@v7
+
+      - name: Set up the environment
+        uses: ./.github/actions/setup-python-env
+        with:
+          python-version: "3.13"
+
+      - name: Run tests
+        run: uv run python -m pytest tests
+
+      - name: Check typing
+        run: uv run mypy
+
   build-and-push:
+    needs: test
+    # `always()` is required so this still evaluates when `test` is SKIPPED via
+    # skip_tests; without it a skipped dependency would skip this job too. The
+    # explicit result check keeps a FAILED test job blocking the build.
+    if: ${{ always() && (needs.test.result == 'success' || inputs.skip_tests) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write # Required for pushing to ghcr.io
 
     steps:
+      - name: Warn when the test gate was bypassed
+        if: ${{ inputs.skip_tests }}
+        run: |
+          echo "::warning title=Test gate bypassed::Building and pushing WITHOUT running tests (skip_tests=true), requested by ${{ github.actor }} on ref ${{ github.ref_name }}."
+
       - name: Checkout code
         uses: actions/checkout@v7
 

--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -70,11 +70,12 @@ COPY --chown=appuser:appgroup viva_api /app/viva_api
 # Back-compat shim so deployed Jobs still invoking `python -m sms_api.*` keep
 # working across the sms_api -> viva_api rename (see sms_api/__init__.py).
 COPY --chown=appuser:appgroup sms_api /app/sms_api
-COPY --chown=appuser:appgroup tests /app/tests
 COPY --chown=appuser:appgroup app /app/app
 COPY --chown=appuser:appgroup alembic /app/alembic
 COPY --chown=appuser:appgroup clients /app/clients
-COPY --chown=appuser:appgroup pytest.ini alembic.ini README.md /app/
+# README.md is required: pyproject's `readme` points at it, so hatchling fails
+# the project install without it. pytest.ini is NOT copied — see the note below.
+COPY --chown=appuser:appgroup alembic.ini README.md /app/
 COPY --chown=appuser:appgroup assets/simulations /app/assets/simulations
 COPY --chown=appuser:appgroup assets/*.json /app/assets/
 COPY --chown=appuser:appgroup assets/app /app/assets/app
@@ -86,8 +87,22 @@ RUN mkdir -p /app/.results_cache && \
 # Sync the project
 RUN uv sync --frozen --no-default-groups
 
-# Test the project (skip Docker-dependent tests since we're inside a container)
-#RUN SKIP_DOCKER_TESTS=1 uv run python -m pytest
+# NOTE: the test suite is deliberately NOT run here, and `tests/`/`pytest.ini`
+# are deliberately not copied into the image.
+#
+# This used to be `RUN SKIP_DOCKER_TESTS=1 uv run python -m pytest`, whose job
+# was to fail the image build when tests failed. That belongs in CI, not in a
+# build layer: the suite needs testcontainers (Postgres/Redis/NATS), so only the
+# non-Docker subset could ever run here — hence SKIP_DOCKER_TESTS — and it
+# re-ran on every layer-invalidating change for a signal CI already produces
+# faster and in parallel. It is also now impossible: UV_NO_DEFAULT_GROUPS
+# above means pytest is not installed in this image at all.
+#
+# The gate that replaced it lives in .github/workflows/build-and-push.yml,
+# which runs the full suite + mypy and will not build or push an image unless
+# they pass. That closes the real gap this line only nominally covered: that
+# workflow takes an arbitrary `--ref` and previously built whatever was there,
+# tested or not.
 
 # Declare the volume for local cache storage
 VOLUME ["/app/scratch"]


### PR DESCRIPTION
> **Stacked on #244** — base is `fix/trim-dev-deps-from-api-image`, not `main`. Part (2) below depends on it. Merge #244 first; this PR's base will retarget to `main` automatically.

Replaces the (long-commented-out) in-image test run with a real CI gate, then removes the artifacts that only existed to serve it.

## (1) `build-and-push` now depends on a `test` job

This closes a genuine gap, not a theoretical one:

- The workflow is dispatched with an **arbitrary `--ref`** — the documented deploy loop routinely builds straight from an unmerged feature branch (`gh workflow run build-and-push.yml --ref atlantis-cli`).
- `main`'s branch protection has **no required status checks**:
  ```
  required_status_checks:        NONE
  required_pull_request_reviews: yes
  enforce_admins:                True
  ```
  So the green PR checks are advisory — a PR can be merged red.
- The build never tested anything itself: `scripts/build_action.sh` is `docker buildx build --push` and nothing else.

Net effect before this PR: **nothing guaranteed a pushed image had passing tests.** The in-image `RUN pytest` was the only thing nominally covering that, and it's been commented out for a long time — so in practice the net hasn't existed at all.

The new `test` job mirrors `main.yml`'s `tests-and-type-check` (same `setup-python-env` action, `pytest` + `mypy`), minus coverage upload.

**Escape hatch:** a `skip_tests` boolean input, for incidents where you must ship without waiting. It's explicit and auditable — using it emits a `::warning` naming the actor and ref. Say the word if you'd rather not have it and I'll drop it.

Two subtleties in the wiring:
- `always()` in the build job's `if` is required so a **skipped** `test` job (via `skip_tests`) doesn't cascade-skip the build.
- The explicit `needs.test.result == 'success'` check keeps a **failed** test job blocking the build — `always()` alone would let it through.

## (2) Drop `tests/`, `pytest.ini`, and the dead `RUN pytest` from the image

Per discussion: that line's job was to fail the build on failing tests, but it's the wrong layer. The suite needs testcontainers (Postgres/Redis/NATS), so only the non-Docker subset could ever run there — hence `SKIP_DOCKER_TESTS=1` — and it re-ran on every layer-invalidating change for a signal CI produces faster and in parallel.

As of #244 it's also **impossible**: `UV_NO_DEFAULT_GROUPS` means `pytest` isn't installed in the image, so uncommenting that line would fail confusingly. A comment explaining the reasoning and pointing at the new gate replaces it.

### Verified, not assumed

`tests` is listed in `[tool.hatch.build.targets.wheel] include`, so the real risk was that the in-image `uv sync` would fail without it. I reproduced the image's install against a tests-less copy of the tree:

- `uv sync --frozen --no-default-groups` — succeeds
- project installs editable (`_editable_impl_viva_api.pth`, `viva_api-0.9.42.dist-info`)
- `viva_api.api.main` imports, `uvicorn` resolves
- `python -m viva_api.simulation.db_reconcile --help` runs

`tests` stays in the hatch include list — correct for `make build_package` / PyPI publish, which run outside Docker where `tests/` exists.

`README.md` **must** stay copied: pyproject's `readme` points at it and hatchling fails the project install without it. (Hit this for real while testing.)

## Heads-up unrelated to this diff

While running lint I hit the repo's recurring ruff-version trap: local `ruff 0.12.12` strips `# noqa: S603` from `tests/api/app/test_cli_e2e.py`, but the pre-commit pin (`v0.11.5`) requires it. That's the same thing commits `921d532d`, `d134fd04`, and `1561af54` each had to undo. I reverted it — **no unrelated file is touched by this PR** — but the drift is still there and will keep biting. Worth pinning `ruff` in `[project] dependencies` to match `.pre-commit-config.yaml`, as a separate change.

## Test plan

- [x] `make check` — lock, pre-commit (pinned ruff), mypy (194 files), deptry all clean
- [x] `uv run pytest tests/test_deploy_config.py` — 2 passed
- [x] Workflow YAML parses; `jobs: ['test', 'build-and-push']`, `needs: test`, `inputs: ['version', 'skip_tests']`
- [x] Image install verified without `tests/`/`pytest.ini` (see above)
- [ ] First real dispatch of `build-and-push` after merge — confirm the `test` job runs and gates
- [ ] Confirm a deliberately-failing test blocks the build (can be checked on a throwaway branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)