### PR TITLE
fix: submit a chain-dispatch campaign in the background so POST /simulations returns in seconds (v0.9.43)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "viva_api"
-version = "0.9.42"
+version = "0.9.43"
 description = "This is the api server for Vivarium simulation services."
 authors = [{ name = "Alex Patrie", email = "alexanderpatrie@gmail.com" }, { name = "Jim Schaff", email = "jschaff@gmail.com" }]
 requires-python = ">=3.13,<3.14"

--- a/tests/integration/test_k8s_workflow_mock.py
+++ b/tests/integration/test_k8s_workflow_mock.py
@@ -16,13 +16,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
-from sqlalchemy import func, select
+from sqlalchemy import select
 
 import viva_api.dependencies as deps
 from tests.fixtures.api_fixtures import SimulatorRepoInfo
 from viva_api.common.handlers import simulations as sim_handlers
 from viva_api.common.hpc.job_service import JobStatusInfo
-from viva_api.common.models import JobId, JobStatus
+from viva_api.common.models import JobBackend, JobId, JobStatus
 from viva_api.common.simulator_defaults import RepoUrl
 from viva_api.config import ComputeBackend, get_settings
 from viva_api.simulation.database_service import DatabaseServiceSQL
@@ -533,6 +533,20 @@ async def test_ray_canonical_batch_baseline_routes_through_real_entrypoint_to_ch
                 num_seeds=2,
             )
 
+            # The real entrypoint now returns as soon as the campaign is
+            # SCHEDULED, issuing the N*G submissions on a background task
+            # (SimulationServiceRay._submit_chain_dispatch_background), so
+            # simulation.job_id is the LOCAL task id rather than the ParCa Batch
+            # job id. Await that task -- inside the patch context, since the task
+            # is what actually calls boto3 -- before checking anything it is
+            # responsible for. Awaiting the asyncio.Task directly blocks until it
+            # is done and re-raises whatever it hit. Only the TIMING of the
+            # checks below changes; every invariant is the one this test has
+            # always asserted.
+            assert simulation.job_id is not None
+            assert simulation.job_id in ray_service._local._tasks
+            campaign_job_id = await ray_service._local._tasks[simulation.job_id]
+
         # Reached chain-dispatch, not the array path: N*G real per-seed
         # generation jobs, never a single array-shaped submission.
         assert mock_batch.submit_job.call_count == 7
@@ -548,30 +562,47 @@ async def test_ray_canonical_batch_baseline_routes_through_real_entrypoint_to_ch
         assert s1g1.kwargs["dependsOn"] == [{"jobId": "s1g0", "type": "SEQUENTIAL"}]
         assert s1g2.kwargs["dependsOn"] == [{"jobId": "s1g1", "type": "SEQUENTIAL"}]
 
-        # simulation.job_id reflects chain-dispatch's own return convention (the
-        # ParCa job -- there is no single "sim" job for a chain campaign).
-        assert simulation.job_id == "parca-1"
+        # Chain-dispatch's own return convention (the ParCa job -- there is no
+        # single "sim" job for a chain campaign) is now the BACKGROUND TASK's
+        # result. The API response's own job_id is the LOCAL task id, which is
+        # what GET /simulations/{id}/status resolves while submission is still in
+        # flight.
+        assert campaign_job_id == JobId.ray("parca-1")
 
-        # Exactly ONE HpcRun row exists for this simulation: the real campaign
-        # row (chain_n_generations/chain_final_job_ids populated), never shadowed
-        # by a second, generic row from the handler's own insert_hpcrun call --
-        # the real, end-to-end proof that the idempotent-insert guard in
-        # viva_api.common.handlers.simulations actually works (not just an
-        # isolated unit-level claim about it). A raw row count, not just
-        # get_hpcrun_by_ref's most-recent-wins lookup, so a regression that
-        # reintroduces a shadowing duplicate can't hide behind "the newest row
-        # happens to look right."
+        # TWO HpcRun rows exist for this simulation, and this test now pins what
+        # each one is. Previously there was exactly one; the second is the
+        # synchronous placeholder _submit_chain_dispatch_background commits
+        # before returning, so a status poll arriving during the (minutes-long)
+        # submission has a real row to read. The invariant this raw row count was
+        # written to protect is unchanged and still checked: the handler in
+        # viva_api.common.handlers.simulations must NOT add a generic row of its
+        # own on top -- its idempotent-insert guard sees the placeholder's
+        # correlation_id and skips. A THIRD row here would mean that guard broke.
+        # Counting rows rather than trusting get_hpcrun_by_ref's
+        # most-recent-wins lookup, so such a regression cannot hide behind "the
+        # newest row happens to look right."
         async with database_service.async_sessionmaker() as session:
             result = await session.execute(
-                select(func.count())
-                .select_from(ORMHpcRun)
-                .where(ORMHpcRun.jobref_simulation_id == simulation.database_id)
+                select(ORMHpcRun).where(ORMHpcRun.jobref_simulation_id == simulation.database_id).order_by(ORMHpcRun.id)
             )
-            row_count = result.scalar_one()
-        assert row_count == 1
+            rows = list(result.scalars().all())
+        assert len(rows) == 2
+        placeholder_row, campaign_row = rows
+        # The placeholder: LOCAL backend, both chain fields unset (so the
+        # scheduler's chain_n_generations IS NOT NULL poll set skips it).
+        assert placeholder_row.job_backend == JobBackend.LOCAL
+        assert placeholder_row.job_id_ext == simulation.job_id
+        assert placeholder_row.chain_n_generations is None
+        assert placeholder_row.chain_final_job_ids is None
+        # The real campaign row, inserted last and therefore the one every later
+        # status read resolves to. Same correlation_id as the placeholder, which
+        # is exactly what makes the handler's guard fire.
+        assert campaign_row.correlation_id == placeholder_row.correlation_id
 
         hpc_run = await database_service.get_hpcrun_by_ref(ref_id=simulation.database_id, job_type=JobType.SIMULATION)
         assert hpc_run is not None
+        assert hpc_run.database_id == campaign_row.id
+        assert hpc_run.job_id == JobId.ray("parca-1")
         assert hpc_run.chain_n_generations == 3
         assert hpc_run.chain_final_job_ids == ["s0g2", "s1g2"]
     finally:

--- a/tests/simulation/test_ray_backend.py
+++ b/tests/simulation/test_ray_backend.py
@@ -1,6 +1,7 @@
 """Tests for the Ray-on-Batch backend: JobId.ray, Batch state mapping, ComputeBackend.RAY,
 and SimulationServiceRay submission/status/cancel (boto3 mocked, Postgres via testcontainers)."""
 
+import asyncio
 import json
 import shlex
 from typing import TYPE_CHECKING, Any
@@ -11,6 +12,7 @@ import pytest
 from viva_api.common.hpc.job_service import JobStatusInfo
 from viva_api.common.models import JobBackend, JobId, JobStatus
 from viva_api.config import ComputeBackend
+from viva_api.simulation.models import JobType
 from viva_api.simulation.simulation_service_ray import (
     PARCA_CACHE_DIR,
     SIM_OUT_DIR,
@@ -268,9 +270,22 @@ class TestSimulationServiceRaySubmit:
                 ecoli_simulation=simulation, database_service=database_service, correlation_id="corr-real-entry"
             )
 
+            # The entrypoint now returns a LOCAL task id the instant the campaign
+            # is scheduled and issues the real N*G submissions in the background
+            # (_submit_chain_dispatch_background) -- so every downstream invariant
+            # below is checked AFTER awaiting that task, not synchronously on
+            # return. Awaiting the asyncio.Task directly blocks until it is done
+            # and re-raises anything it hit, which is exactly what a test wants;
+            # it has to happen INSIDE the patch context, since the task is what
+            # actually calls boto3.
+            assert job_id.backend == JobBackend.LOCAL
+            campaign_job_id = await service._local._tasks[job_id.value]
+
         # Chain-dispatch's own return convention: the ParCa job id, never a
-        # single "sim" job id (there isn't one anymore).
-        assert job_id == JobId.ray("parca-1")
+        # single "sim" job id (there isn't one anymore). Same invariant as
+        # before; it is now the background task's RESULT rather than
+        # submit_ecoli_simulation_job's own return value.
+        assert campaign_job_id == JobId.ray("parca-1")
         assert mock_batch.submit_job.call_count == 7
         calls = mock_batch.submit_job.call_args_list
 
@@ -293,14 +308,23 @@ class TestSimulationServiceRaySubmit:
 
         # The campaign row was recorded under the CALLER's OWN correlation_id
         # (threaded through, not a fresh internally-generated one) -- this is
-        # what lets a real status lookup by that id resolve to the actual
-        # campaign row, not a stale duplicate a caller's own generic
-        # insert_hpcrun would otherwise shadow it with (see the idempotent-
-        # insert guard in viva_api.common.handlers.simulations).
-        campaign_hpcrun_id = await database_service.get_hpcrun_id_by_correlation_id(correlation_id="corr-real-entry")
-        assert campaign_hpcrun_id is not None
-        campaign = await database_service.get_hpcrun(campaign_hpcrun_id)
+        # what makes the idempotent-insert guard in
+        # viva_api.common.handlers.simulations fire, so the caller never adds a
+        # generic row of its own on top.
+        #
+        # Resolved via get_hpcrun_by_ref (ORDER BY id DESC) rather than
+        # get_hpcrun_id_by_correlation_id: the background dispatch now leaves TWO
+        # rows under this one correlation_id -- the synchronous placeholder and,
+        # once the task finishes, the real campaign row -- and
+        # get_hpcrun_id_by_correlation_id is a bare LIMIT 1 with no ORDER BY, so
+        # which of the two it returns is not defined. Most-recent-row-wins is the
+        # rule every real status read actually uses, and it is what must resolve
+        # to the campaign row.
+        assert await database_service.get_hpcrun_id_by_correlation_id(correlation_id="corr-real-entry") is not None
+        campaign = await database_service.get_hpcrun_by_ref(ref_id=simulation.database_id, job_type=JobType.SIMULATION)
         assert campaign is not None
+        assert campaign.correlation_id == "corr-real-entry"
+        assert campaign.job_id == JobId.ray("parca-1")
         assert campaign.chain_n_generations == 3
         assert campaign.chain_final_job_ids == ["s0g2", "s1g2"]
 
@@ -335,14 +359,144 @@ class TestSimulationServiceRaySubmit:
             job_id = await service.submit_ecoli_simulation_job(
                 ecoli_simulation=simulation, database_service=database_service, correlation_id="corr-single-real"
             )
+            # Background dispatch (see the multiseed test above for the full
+            # rationale): await the spawned task before checking what it did.
+            assert job_id.backend == JobBackend.LOCAL
+            campaign_job_id = await service._local._tasks[job_id.value]
 
-        assert job_id == JobId.ray("parca-1")
+        assert campaign_job_id == JobId.ray("parca-1")
         assert mock_batch.submit_job.call_count == 4  # parca + 1 seed x 3 generations
         _parca_call, g0, g1, g2 = mock_batch.submit_job.call_args_list
         assert "arrayProperties" not in g0.kwargs
         assert g0.kwargs["dependsOn"] == [{"jobId": "parca-1", "type": "SEQUENTIAL"}]
         assert g1.kwargs["dependsOn"] == [{"jobId": "s0g0", "type": "SEQUENTIAL"}]
         assert g2.kwargs["dependsOn"] == [{"jobId": "s0g1", "type": "SEQUENTIAL"}]
+
+    async def test_canonical_chain_dispatch_returns_before_submitting_anything(
+        self,
+        experiment_request: "SimulationRequest",
+        database_service: "DatabaseServiceSQL",
+    ) -> None:
+        """The entrypoint returns a trackable id BEFORE the campaign submits
+        anything -- the property this whole change exists to create, as opposed
+        to the two tests above, which re-check the (unchanged) downstream
+        submission shape after the background task has run.
+
+        The real bug (vivarium-workbench backlog item 51, found during a live
+        1000x10 production dispatch on 2026-08-14): a canonical chain-dispatch
+        request issued all n_seeds*n_generations AWS Batch SubmitJob calls
+        INLINE, inside the single POST /api/v1/simulations the client was
+        awaiting -- about 15 minutes for the real 10,000-job shape. The client's
+        HTTP timeout fired long first and reported a FAILED dispatch, while
+        viva-api went right on submitting the real, AWS-billed campaign. Retrying
+        (the obvious response to being told it failed) would have started a
+        second, duplicate, paid campaign on top of the first.
+
+        The background task is held at a deterministic chokepoint -- the
+        run_pbg.py staging upload, which submit_chain_dispatch_job awaits after
+        its two DB reads and before the pacer and every submit_job call -- so the
+        "nothing has happened yet" assertions below are guarantees rather than a
+        race this test happens to win.
+        """
+        setattr(experiment_request.config, "n_init_sims", 2)  # noqa: B010
+        experiment_request.config.generations = 3
+        simulation = await database_service.insert_simulation(sim_request=experiment_request)
+
+        submit_ids = ["parca-1", "s0g0", "s0g1", "s0g2", "s1g0", "s1g1", "s1g2"]
+        mock_batch = _fake_batch(submit_ids)
+
+        staging_released = asyncio.Event()
+
+        async def _hold_at_staging(*args: Any, **kwargs: Any) -> None:
+            await staging_released.wait()
+
+        fake_file_service = AsyncMock()
+        fake_file_service.upload_file = AsyncMock(side_effect=_hold_at_staging)
+
+        service = SimulationServiceRay()
+        with (
+            patch("viva_api.simulation.simulation_service_ray.get_settings", _ray_settings),
+            patch("viva_api.common.storage.data_layout.get_settings", _ray_settings),
+            patch("viva_api.simulation.simulation_service_ray.boto3.client", return_value=mock_batch),
+            patch("viva_api.dependencies.get_file_service", return_value=fake_file_service),
+            patch("viva_api.simulation.simulation_service_ray.asyncio.sleep", new=AsyncMock()),
+        ):
+            # The property under test, stated directly: the entrypoint returns
+            # promptly regardless of campaign size. asyncio.wait_for, rather than
+            # a bare await, so that the pre-fix inline behaviour FAILS here in
+            # seconds instead of deadlocking the suite -- submitting inline, it
+            # would park in the submission loop at the staging chokepoint below
+            # and never come back, since only this test body releases it.
+            job_id = await asyncio.wait_for(
+                service.submit_ecoli_simulation_job(
+                    ecoli_simulation=simulation,
+                    database_service=database_service,
+                    correlation_id="corr-fast-return",
+                ),
+                timeout=10,
+            )
+
+            # 1. Returned having submitted NOTHING -- not "fewer calls", zero.
+            assert mock_batch.submit_job.call_count == 0
+            # 2. ...and what came back is a trackable LOCAL task id, which
+            # get_job_status (and cancel_job) already resolve through the shared
+            # LocalTaskService -- the same mechanism submit_build_image_job uses
+            # for the other multi-minute operation this service owns.
+            assert job_id.backend == JobBackend.LOCAL
+            in_flight = await service.get_job_status(job_id)
+            assert in_flight is not None
+            assert in_flight.status == JobStatus.RUNNING
+
+            # 3. A placeholder HpcRun row is already committed, so a status poll
+            # arriving a millisecond later has something real to read -- with
+            # BOTH chain fields left unset.
+            placeholder = await database_service.get_hpcrun_by_ref(
+                ref_id=simulation.database_id, job_type=JobType.SIMULATION
+            )
+            assert placeholder is not None
+            assert placeholder.job_id == job_id
+            assert placeholder.correlation_id == "corr-fast-return"
+            assert placeholder.chain_n_generations is None
+            assert placeholder.chain_final_job_ids is None
+
+            # 4. ...and precisely BECAUSE chain_n_generations is unset, the
+            # scheduler's poll set excludes the placeholder. Were it enrolled,
+            # get_chain_campaign_result([]) would call the campaign trivially
+            # terminal with zero successes and _advance_chain_campaign would mark
+            # it FAILED on the very next tick -- recreating the same false
+            # failure, this time inside viva-api itself.
+            assert [
+                c.database_id
+                for c in await database_service.list_active_chain_campaigns()
+                if c.ref_id == simulation.database_id
+            ] == []
+
+            # Release the chokepoint and let the campaign finish submitting.
+            staging_released.set()
+            campaign_job_id = await service._local._tasks[job_id.value]
+
+        # 5. The real campaign row now supersedes the placeholder for every later
+        # read (get_hpcrun_by_ref is ORDER BY id DESC) and IS in the scheduler's
+        # poll set -- so analysis auto-fire stays wired exactly as before.
+        assert campaign_job_id == JobId.ray("parca-1")
+        assert mock_batch.submit_job.call_count == 7
+        campaign = await database_service.get_hpcrun_by_ref(ref_id=simulation.database_id, job_type=JobType.SIMULATION)
+        assert campaign is not None
+        assert campaign.database_id != placeholder.database_id
+        assert campaign.job_id == JobId.ray("parca-1")
+        assert campaign.chain_n_generations == 3
+        assert campaign.chain_final_job_ids == ["s0g2", "s1g2"]
+        assert [
+            c.database_id
+            for c in await database_service.list_active_chain_campaigns()
+            if c.ref_id == simulation.database_id
+        ] == [campaign.database_id]
+
+        # The completed background task reports COMPLETED, so the plain status
+        # path stops saying RUNNING once submission is genuinely done.
+        done = await service.get_job_status(job_id)
+        assert done is not None
+        assert done.status == JobStatus.COMPLETED
 
     async def test_composite_comparison_ensemble_with_multiple_generations_stays_on_mnp(
         self,

--- a/uv.lock
+++ b/uv.lock
@@ -2058,7 +2058,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -3655,7 +3655,7 @@ wheels = [
 
 [[package]]
 name = "viva-api"
-version = "0.9.42"
+version = "0.9.43"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },

--- a/viva_api/simulation/simulation_service_ray.py
+++ b/viva_api/simulation/simulation_service_ray.py
@@ -952,6 +952,18 @@ bash docker/build-and-push-ecr.sh -i {commit} -r {settings.ray_ecr_repository} -
         code (their only caller was the array branch this replaced; confirmed
         via a fresh repo-wide grep before deleting them, not assumed).
 
+        That delegation runs in the BACKGROUND (via
+        ``_submit_chain_dispatch_background``), so this method returns in
+        seconds no matter how large the campaign is, and the returned id is a
+        ``JobId.local(...)`` rather than the ParCa job's ``JobId.ray(...)``.
+        Submitting a campaign's N*G jobs takes minutes of real wall time
+        (~15 for the canonical 1000x10 shape) and used to happen inline, inside
+        the ``POST /api/v1/simulations`` request — see that method's docstring
+        for the real production failure that caused. Progress stays trackable
+        through the unchanged ``GET /api/v1/simulations/{id}/status``.
+        ``submit_chain_dispatch_job`` itself is untouched and still runs
+        synchronously to completion for its direct callers.
+
         Every OTHER shape still reaches the MNP path below exactly as before:
         the composite-driven two-engine comparison ensemble (genuinely fans out
         via Ray actors, at ANY generation count — chain-dispatch is v2ecoli-only
@@ -966,7 +978,7 @@ bash docker/build-and-push-ecr.sh -i {commit} -r {settings.ray_ecr_repository} -
         # the comparison knobs read further below -- read directly, not via getattr.
         n_generations = int(config.generations or 1)
         if composite is None and n_generations > 1:
-            return await self.submit_chain_dispatch_job(
+            return await self._submit_chain_dispatch_background(
                 ecoli_simulation, database_service, correlation_id=correlation_id
             )
 
@@ -1097,6 +1109,114 @@ bash docker/build-and-push-ecr.sh -i {commit} -r {settings.ray_ecr_repository} -
             "Team": getattr(settings, "cost_team_tag", None) or "covertlab",
         }
 
+    async def _submit_chain_dispatch_background(
+        self,
+        ecoli_simulation: Simulation,
+        database_service: DatabaseService,
+        *,
+        correlation_id: str,
+    ) -> JobId:
+        """Run ``submit_chain_dispatch_job`` as a background task; return a trackable id at once.
+
+        A chain-dispatch campaign issues ``n_seeds * n_generations`` individual
+        AWS Batch ``SubmitJob`` calls, paced below the account-wide TPS cap. For
+        the canonical 1000x10 shape that is 10,000 calls and roughly 15 minutes
+        of wall time — all of it inside the single ``POST /api/v1/simulations``
+        request while the submission loop runs inline. A real production
+        dispatch (2026-08-14) proved the consequence: the calling client's HTTP
+        timeout fired long before the loop finished, so the user was told the
+        dispatch had FAILED while viva-api went right on submitting the real,
+        AWS-billed campaign. The obvious reaction to that message — retry —
+        would have started a second, duplicate, paid campaign on top of the
+        first.
+
+        The fix reuses the pattern this service already uses for the other
+        multi-minute operation it owns, the DooD image build
+        (``submit_build_image_job``): hand the slow coroutine to
+        ``LocalTaskService``, return its ``JobId.local(...)`` immediately, let
+        the caller poll. No new machinery is involved — because every backend
+        service shares ONE process-wide ``LocalTaskService`` (see
+        ``viva_api.dependencies._init_simulation_service``), ``get_job_status``
+        — and therefore ``GET /api/v1/simulations/{id}/status`` — already
+        resolves such an id, reporting RUNNING while the submission loop is
+        still going and FAILED if it crashes outright. ``cancel_job`` already
+        routes LOCAL ids to ``LocalTaskService.cancel``, so cancelling a
+        still-submitting campaign comes along for free.
+
+        ``submit_chain_dispatch_job`` itself is UNCHANGED and still runs
+        synchronously to completion for its direct callers (its own unit tests
+        and the real-AWS integration test); only this one call site is
+        asynchronous.
+
+        THE PLACEHOLDER ROW, and why its chain fields must stay ``None``: the
+        campaign's REAL ``HpcRun`` row is inserted by
+        ``submit_chain_dispatch_job`` itself, as its very last action — minutes
+        from now. Until then a status lookup would find nothing at all, so this
+        method records a placeholder row carrying the LOCAL task id. It
+        deliberately leaves BOTH ``chain_n_generations`` and
+        ``chain_final_job_ids`` unset:
+
+          - ``DatabaseService.list_active_chain_campaigns`` (the scheduler's
+            poll set) discriminates on ``chain_n_generations IS NOT NULL``
+            ALONE. Setting it here would enroll the placeholder in that poll set
+            before a single per-seed job exists.
+          - ``get_chain_campaign_result([])`` returns ``terminal=True`` with
+            zero successes by definition, so ``JobScheduler._advance_chain_campaign``
+            would then immediately mark the campaign FAILED — recreating, inside
+            viva-api this time, the very false-failure this method exists to
+            eliminate.
+
+        With both left ``None``, ``get_simulation_status`` takes its ordinary
+        non-campaign branch and reports the LOCAL task's own status, which is
+        the honest answer while submission is in flight. Once the background
+        task finishes, the campaign row it inserts (a SECOND real row, under the
+        same ``correlation_id``) supersedes this placeholder for every later
+        read: ``get_hpcrun_by_ref`` resolves the highest ``id``. The handler's
+        own idempotent-insert guard (``viva_api.common.handlers.simulations``,
+        keyed on ``correlation_id``) sees this placeholder and correctly skips
+        adding a third, generic row.
+        """
+        # Gate the background task on the placeholder being committed. Without
+        # the gate, `create_task` followed by `await insert_hpcrun(...)` lets the
+        # campaign coroutine run during that await, and the two inserts can land
+        # in either order. The wrong order is NOT benign: `get_hpcrun_by_ref`
+        # resolves the highest id, so a placeholder written AFTER the real
+        # campaign row would shadow it permanently, and the plain status path
+        # would report the whole campaign COMPLETED the moment the submission
+        # loop finished — while every one of its N*G real jobs was still queued
+        # or running. An asyncio.Event makes the ordering a guarantee instead of
+        # a race the mocked-out test environment happens to usually win.
+        placeholder_recorded = asyncio.Event()
+
+        async def _run() -> JobId:
+            await placeholder_recorded.wait()
+            return await self.submit_chain_dispatch_job(
+                ecoli_simulation, database_service, correlation_id=correlation_id
+            )
+
+        task_job_id = self._local.submit(_run(), name=f"chain-dispatch-{ecoli_simulation.config.experiment_id}")
+        try:
+            await database_service.insert_hpcrun(
+                job_id=task_job_id,
+                job_type=JobType.SIMULATION,
+                ref_id=ecoli_simulation.database_id,
+                correlation_id=correlation_id,
+            )
+        except Exception:
+            # Nothing was recorded, so nothing may run: releasing the gate here
+            # would dispatch a real, billed campaign for a request whose caller
+            # is about to be handed an error.
+            self._local.cancel(task_job_id.value)
+            raise
+        placeholder_recorded.set()
+        logger.info(
+            "Chain dispatch %s: submitting the campaign in the background as local task %s "
+            "(request returns now; poll GET /simulations/{id}/status for progress)",
+            ecoli_simulation.config.experiment_id,
+            task_job_id.value,
+        )
+        return task_job_id
+
     async def submit_chain_dispatch_job(
         self,
         ecoli_simulation: Simulation,
@@ -1111,6 +1231,15 @@ bash docker/build-and-push-ecr.sh -i {commit} -r {settings.ray_ecr_repository} -
         per-seed Nextflow execution (Alex's explicit decision, 2026-08-08) —
         seed 5 can be on generation 8 while seed 800 is still on generation 1,
         throttled only by available compute, never by a cross-seed barrier.
+
+        This method is SYNCHRONOUS: it returns only once every one of the N*G
+        submissions has been issued, which for a real canonical campaign is
+        minutes of wall time. That contract is unchanged and its direct callers
+        (this repo's unit tests and the real-AWS integration test) still rely on
+        it. The real request entrypoint no longer awaits it inline, though —
+        ``submit_ecoli_simulation_job`` reaches it through
+        ``_submit_chain_dispatch_background``, which runs it as a background
+        task so the HTTP request returns in seconds; see that method for why.
 
         ``correlation_id``: this method (unlike a single-shot dispatch) always
         records its OWN ``HpcRun`` row internally — see the ``insert_hpcrun``

--- a/viva_api/version.py
+++ b/viva_api/version.py
@@ -322,4 +322,43 @@
 #          (that floor was AWS Batch's own array-size minimum, moot once nothing is
 #          an array job). RayLayout.wave_state_uri/wave_state_prefix ->
 #          daughter_state_uri/daughter_state_prefix (pure rename, same S3 layout).
-__version__ = "0.9.42"
+# 0.9.43 — POST /api/v1/simulations returns in seconds for a chain-dispatch
+#          campaign of ANY size. submit_chain_dispatch_job issues n_seeds *
+#          n_generations individual AWS Batch SubmitJob calls, TPS-paced --
+#          ~10,000 calls and ~15 minutes of wall time for the canonical 1000x10
+#          shape -- and submit_ecoli_simulation_job awaited all of it INLINE,
+#          inside the single HTTP request. Found during a real production
+#          dispatch on the smscdk GovCloud deployment (2026-08-14): the calling
+#          client (vivarium-workbench, 30s HTTP timeout) gave up long before the
+#          loop finished and reported a FAILED dispatch to the user, while
+#          viva-api went right on submitting the real, AWS-billed campaign. The
+#          obvious response to being told it failed -- retry -- would have
+#          started a second, duplicate, paid campaign on top of the first. Only
+#          caught by reading kubectl logs on the live pod.
+#          The one call site now goes through _submit_chain_dispatch_background,
+#          which hands the UNCHANGED submit_chain_dispatch_job coroutine to the
+#          LocalTaskService the service already uses for the other multi-minute
+#          operation it owns (submit_build_image_job's DooD image build) and
+#          returns its JobId.local(...) immediately. No new machinery: every
+#          backend service shares ONE process-wide LocalTaskService, so
+#          get_job_status -- and therefore GET /simulations/{id}/status --
+#          already resolves that id (RUNNING while submitting, FAILED if the
+#          submission loop crashes), and cancel_job already routes LOCAL ids to
+#          LocalTaskService.cancel, making a still-submitting campaign
+#          cancellable for free. submit_chain_dispatch_job itself is untouched
+#          and still synchronous for its direct callers (unit tests, the
+#          real-AWS integration test).
+#          A placeholder HpcRun row is committed synchronously before returning
+#          so an immediate status poll has something real to read. It leaves
+#          BOTH chain_n_generations and chain_final_job_ids None on purpose:
+#          list_active_chain_campaigns discriminates on chain_n_generations IS
+#          NOT NULL alone, and get_chain_campaign_result([]) is terminal with
+#          zero successes by definition -- so setting either would have
+#          _advance_chain_campaign mark the campaign FAILED on the next poll
+#          tick, recreating the very false-failure this release removes, this
+#          time inside viva-api. The background task is gated on that row being
+#          committed, so the real campaign row it inserts at the end always
+#          outranks the placeholder in get_hpcrun_by_ref's ORDER BY id DESC
+#          lookup; the reverse order would report a whole campaign COMPLETED the
+#          moment submission finished, with every real job still queued.
+__version__ = "0.9.43"


### PR DESCRIPTION
## The bug

`POST /api/v1/simulations` could take ~15 minutes to return for a canonical chain-dispatch campaign, causing the calling client to time out and report a **false failure** for a dispatch that was actually running.

`SimulationServiceRay.submit_chain_dispatch_job` issues `n_seeds * n_generations` individual AWS Batch `SubmitJob` calls in a plain nested loop, paced by `_SubmitJobPacer` to stay under the account-wide 50 TPS cap. `submit_ecoli_simulation_job` awaited all of it **inline**, inside the single HTTP request:

```python
if composite is None and n_generations > 1:
    return await self.submit_chain_dispatch_job(...)   # ~10,000 SubmitJob calls
```

Found during a real production 1000x10 dispatch on the smscdk GovCloud deployment (2026-08-14). 10,000 paced submissions took roughly 15 minutes; vivarium-workbench's 30s HTTP timeout fired long before that, so the user was told the dispatch **failed** while viva-api went right on submitting the real, AWS-billed campaign. The obvious response to a failure message — retry — would have fired a **second, duplicate, paid campaign** on top of the first. It was caught only by reading `kubectl logs` on the live pod.

(This is one half of a two-repo fix; the vivarium-workbench-side error handling is separate and not in this PR.)

## The fix

Only the **one call site** changes. It now goes through a new `_submit_chain_dispatch_background`, which hands the **unchanged** `submit_chain_dispatch_job` coroutine to `LocalTaskService` and returns its `JobId.local(...)` immediately.

This is the same pattern this service already uses for the other multi-minute operation it owns — `submit_build_image_job`'s DooD image build — so **no new machinery is introduced**:

- Every backend service shares one process-wide `LocalTaskService` (`dependencies._init_simulation_service`), so `get_job_status`, and therefore the **unchanged** `GET /api/v1/simulations/{id}/status`, already resolves a LOCAL id: RUNNING while the submission loop runs, FAILED if it crashes outright.
- `cancel_job` already routes LOCAL ids to `LocalTaskService.cancel`, so cancelling a still-submitting campaign comes along for free.
- `get_simulation_status`, `list_active_chain_campaigns` and `job_scheduler.py` are **not touched** — they already do the right thing.

`submit_chain_dispatch_job` itself is untouched and still runs synchronously to completion for its direct callers (its own unit tests and the real-AWS integration test).

### The placeholder row, and why both chain fields must stay `None`

The campaign's real `HpcRun` row is inserted by `submit_chain_dispatch_job` as its very last action — minutes from now — so a placeholder row carrying the LOCAL task id is committed synchronously before returning. It deliberately leaves **both** `chain_n_generations` and `chain_final_job_ids` unset:

- `list_active_chain_campaigns` (the scheduler's poll set) discriminates on `chain_n_generations IS NOT NULL` **alone**.
- `get_chain_campaign_result([])` returns `terminal=True` with zero successes by definition.

Set either one, and `JobScheduler._advance_chain_campaign` marks the campaign FAILED on the very next poll tick — recreating the exact false-failure this PR removes, this time inside viva-api. With both `None`, `get_simulation_status` takes its ordinary non-campaign branch and reports the LOCAL task's status, which is the honest answer while submission is in flight.

### One thing worth reviewer attention: insert ordering is a guarantee, not a race

The background task is gated on an `asyncio.Event` that is set only after the placeholder is committed. Without it, `create_task` followed by `await insert_hpcrun(...)` lets the campaign coroutine run *during* that await, and the two inserts can land in either order. The wrong order is not benign: `get_hpcrun_by_ref` resolves the highest `id`, so a placeholder written *after* the real campaign row would shadow it permanently and the plain status path would report the whole campaign COMPLETED the moment submission finished — with all N*G real jobs still queued. The gate makes the ordering structural rather than something the mocked test environment merely usually wins.

## Behaviour change to note

For a chain-dispatch request the POST response's `job_id` is now the LOCAL task id rather than the ParCa Batch job id. Status polling is by simulation id and is unaffected; once the background task finishes, the real campaign row (`job_id = ray:<parca job>`) supersedes the placeholder for every subsequent read.

## Test evidence

Real runs, not a summary:

| | result |
|---|---|
| `uv run pytest` on clean `origin/main` (baseline) | **564 passed, 64 skipped, 0 failed** |
| `uv run pytest` on this branch | **565 passed, 64 skipped, 0 failed** |

The delta is exactly the one new test. `uv lock --locked`, `ruff check`, `ruff format`, `mypy` (195 source files) and `deptry` are all clean.

**New test** — `test_canonical_chain_dispatch_returns_before_submitting_anything` asserts the property this PR creates, not just that the old behaviour survives re-timing:

1. `submit_job.call_count == 0` at return — zero, not "fewer".
2. The returned id has `backend == LOCAL` and `get_job_status` reports RUNNING.
3. A placeholder `HpcRun` row already exists with both chain fields `None`.
4. `list_active_chain_campaigns()` does **not** contain it.
5. After the task completes: the real row supersedes it, `list_active_chain_campaigns()` **does** contain it, and the task reports COMPLETED.

It holds the background task at a deterministic chokepoint (the `run_pbg.py` staging upload, which `submit_chain_dispatch_job` awaits after its DB reads and before every `submit_job`) so 1–4 are guarantees rather than a race, and wraps the entrypoint call in `asyncio.wait_for(..., timeout=10)` so the pre-fix inline behaviour fails in seconds instead of deadlocking the suite.

**Falsification checked, not assumed**: with the routing line temporarily reverted, this test fails with `TimeoutError` at the `wait_for`, and the three updated tests below also fail — fast — for the right reasons (`JobBackend.RAY != JobBackend.LOCAL`, and `'parca-1' in {}` for the task lookup).

**Updated existing tests** — these encoded the old synchronous contract. Each now awaits the spawned background task and then re-asserts the *exact same* downstream invariants. No assertion was weakened or dropped:

- `test_ray_backend.py::test_submit_routes_canonical_batch_baseline_to_chain_dispatch_when_multiseed` / `..._when_single_seed` — `submit_job` counts (7 / 4), full `dependsOn` chain shape, and the campaign row's `chain_final_job_ids` are all still asserted, just after the task completes. The campaign row is now resolved via `get_hpcrun_by_ref` (`ORDER BY id DESC`) rather than `get_hpcrun_id_by_correlation_id`, because two rows now share the correlation_id and that query is a bare `LIMIT 1` with no `ORDER BY`; correlation-id threading is still asserted separately.
- `test_k8s_workflow_mock.py::test_ray_canonical_batch_baseline_routes_through_real_entrypoint_to_chain_dispatch` — the real-entrypoint regression test. Its raw `HpcRun` row count goes 1 → 2, and it now pins what each row is. The invariant it was written to protect is unchanged and still checked: the handler's idempotent-insert guard must not add a **third**, generic row.

**Unaffected, confirmed by reading and by running:** `TestChainDispatchSubmission`'s tests and `tests/integration/test_aws_batch_e2e.py::test_chain_dispatch_multiseed_multigeneration_against_real_aws_batch` all call `submit_chain_dispatch_job` directly, which this PR does not modify. The real-AWS e2e test was read, not run — it costs real AWS spend.

## Release protocol

Version bumped to **0.9.43** in `viva_api/version.py` and `pyproject.toml` together, in this branch, per the repo's Release Protocol. Steps 3–5 (tag, GitHub Release, build/deploy, kustomize overlay bumps) are **not** done here and no cluster was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
